### PR TITLE
docs: add branching workflow and contribution guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,18 @@ Entity model: `Book` (Title, Author, Genre, `BookStatus` enum Unread/Reading/Rea
 
 Config convention: connection string name is **`DefaultConnection`**. Dev value lives in `appsettings.Development.json` and points at the Docker SQL container. Prod value comes from Azure App Service configuration. `appsettings*.json` is **gitignored**; committed templates live alongside them as `appsettings.Example.json` and `appsettings.Development.Example.json` — on a fresh clone, copy each `.Example.json` to the real filename and fill in secrets.
 
+## Branching
+
+**Never commit or push to `main`.** All changes go through a feature branch + PR. Branch-name prefixes: `feat/`, `fix/`, `chore/`, `docs/`, `refactor/`. Large features may use sub-branches (`feat/parent/sub-branch`) that PR into the parent feature branch before the parent PRs into `main`. Squash-merge into `main`. See `CONTRIBUTING.md` for full details.
+
+Before starting new work:
+
+```powershell
+git checkout main
+git pull
+git checkout -b feat/<short-name>
+```
+
 ## Commands (PowerShell)
 
 Run from the repo root. Quote the path because it contains a space.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+# Contributing
+
+## Branching
+
+`main` is protected and always deployable. **No direct commits or pushes to `main`** — every change lands via a pull request from a feature branch.
+
+### Branch naming
+
+- `feat/<short-name>` — new features (e.g. `feat/wishlist-import`)
+- `fix/<short-name>` — bug fixes (e.g. `fix/rating-range-validation`)
+- `chore/<short-name>` — tooling, build, dependency bumps
+- `docs/<short-name>` — documentation-only changes
+- `refactor/<short-name>` — non-behavioral code changes
+
+### Sub-branches
+
+Large features can be staged. Branch off the parent feature branch, keep the same prefix, and add a second segment:
+
+```
+feat/wishlist-import              (parent feature)
+feat/wishlist-import/csv-parser   (sub-branch, PR targets the parent)
+feat/wishlist-import/ui           (sub-branch, PR targets the parent)
+```
+
+Merge sub-branch PRs into the parent feature branch; merge the parent into `main` when the whole feature is ready.
+
+### Workflow
+
+```powershell
+git checkout main
+git pull
+git checkout -b feat/<short-name>
+# ...commit work...
+git push -u origin feat/<short-name>
+# open a PR on GitHub targeting main
+```
+
+Delete the branch after the PR is merged.
+
+## Pull requests
+
+- Keep PRs focused — one concern per PR.
+- Squash-merge into `main` to keep history linear.
+- A PR cannot be merged without an approving review and passing required status checks (enforced by branch protection).


### PR DESCRIPTION
main is now the protected trunk. All changes land via feature branches (feat/ fix/ chore/ docs/ refactor/) and pull requests, with sub-branches allowed under large features.