### PR TITLE
chore: ignore .claude/settings.local.json

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,7 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(dotnet build:*)"
-    ]
-  }
-}

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ x86/
 .idea/
 *.swp
 
+# Claude Code — per-machine local settings (shared .claude/settings.json may be tracked)
+.claude/settings.local.json
+
 # .NET
 project.lock.json
 project.fragment.lock.json


### PR DESCRIPTION
Per-machine Claude Code settings should not be committed. Shared .claude/settings.json remains trackable if added later.