### PR TITLE
feat: split Book into title + copies with ISBN, format, condition

### DIFF
--- a/BookTracker.Data/BookTrackerDbContext.cs
+++ b/BookTracker.Data/BookTrackerDbContext.cs
@@ -6,5 +6,18 @@ namespace BookTracker.Data;
 public class BookTrackerDbContext(DbContextOptions<BookTrackerDbContext> options) : DbContext(options)
 {
     public DbSet<Book> Books => Set<Book>();
+    public DbSet<BookCopy> BookCopies => Set<BookCopy>();
     public DbSet<WishlistItem> WishlistItems => Set<WishlistItem>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<BookCopy>()
+            .HasOne(c => c.Book)
+            .WithMany(b => b.Copies)
+            .HasForeignKey(c => c.BookId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        modelBuilder.Entity<BookCopy>()
+            .HasIndex(c => c.Isbn);
+    }
 }

--- a/BookTracker.Data/Migrations/20260414061012_AddBookCopies.Designer.cs
+++ b/BookTracker.Data/Migrations/20260414061012_AddBookCopies.Designer.cs
@@ -4,6 +4,7 @@ using BookTracker.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BookTracker.Data.Migrations
 {
     [DbContext(typeof(BookTrackerDbContext))]
-    partial class BookTrackerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260414061012_AddBookCopies")]
+    partial class AddBookCopies
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BookTracker.Data/Migrations/20260414061012_AddBookCopies.cs
+++ b/BookTracker.Data/Migrations/20260414061012_AddBookCopies.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BookTracker.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddBookCopies : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "DefaultCoverArtUrl",
+                table: "Books",
+                type: "nvarchar(500)",
+                maxLength: 500,
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "BookCopies",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    BookId = table.Column<int>(type: "int", nullable: false),
+                    Isbn = table.Column<string>(type: "nvarchar(20)", maxLength: 20, nullable: false),
+                    Format = table.Column<int>(type: "int", nullable: false),
+                    DatePrinted = table.Column<DateOnly>(type: "date", nullable: true),
+                    Condition = table.Column<int>(type: "int", nullable: false),
+                    CustomCoverArtUrl = table.Column<string>(type: "nvarchar(500)", maxLength: 500, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_BookCopies", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_BookCopies_Books_BookId",
+                        column: x => x.BookId,
+                        principalTable: "Books",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_BookCopies_BookId",
+                table: "BookCopies",
+                column: "BookId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_BookCopies_Isbn",
+                table: "BookCopies",
+                column: "Isbn");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "BookCopies");
+
+            migrationBuilder.DropColumn(
+                name: "DefaultCoverArtUrl",
+                table: "Books");
+        }
+    }
+}

--- a/BookTracker.Data/Models/Book.cs
+++ b/BookTracker.Data/Models/Book.cs
@@ -30,4 +30,9 @@ public class Book
     public string? Notes { get; set; }
 
     public DateTime DateAdded { get; set; } = DateTime.UtcNow;
+
+    [MaxLength(500)]
+    public string? DefaultCoverArtUrl { get; set; }
+
+    public List<BookCopy> Copies { get; set; } = [];
 }

--- a/BookTracker.Data/Models/BookCopy.cs
+++ b/BookTracker.Data/Models/BookCopy.cs
@@ -1,0 +1,40 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace BookTracker.Data.Models;
+
+public enum BookFormat
+{
+    Hardcopy,
+    Softcopy
+}
+
+// Standard used-book grading scale, best → worst.
+public enum BookCondition
+{
+    AsNew,
+    Fine,
+    VeryGood,
+    Good,
+    Fair,
+    Poor
+}
+
+public class BookCopy
+{
+    public int Id { get; set; }
+
+    public int BookId { get; set; }
+    public Book Book { get; set; } = null!;
+
+    [Required, MaxLength(20)]
+    public string Isbn { get; set; } = string.Empty;
+
+    public BookFormat Format { get; set; }
+
+    public DateOnly? DatePrinted { get; set; }
+
+    public BookCondition Condition { get; set; } = BookCondition.Good;
+
+    [MaxLength(500)]
+    public string? CustomCoverArtUrl { get; set; }
+}


### PR DESCRIPTION
A Book holds the shared work-level data (title, author, genre, notes, default cover art). Each physical/digital instance is a BookCopy with its own ISBN, format (Hardcopy/Softcopy), date printed, condition (AsNew -> Poor, default Good), and optional custom cover art that overrides the book's default.

Status, Rating, and DateAdded remain on Book as work-level fields.