### PR TITLE
feat: add Subtitle, Category, Publisher, and default changes

### DIFF
--- a/BookTracker.Data/BookTrackerDbContext.cs
+++ b/BookTracker.Data/BookTrackerDbContext.cs
@@ -8,6 +8,7 @@ public class BookTrackerDbContext(DbContextOptions<BookTrackerDbContext> options
     public DbSet<Book> Books => Set<Book>();
     public DbSet<BookCopy> BookCopies => Set<BookCopy>();
     public DbSet<Genre> Genres => Set<Genre>();
+    public DbSet<Publisher> Publishers => Set<Publisher>();
     public DbSet<WishlistItem> WishlistItems => Set<WishlistItem>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
@@ -21,8 +22,18 @@ public class BookTrackerDbContext(DbContextOptions<BookTrackerDbContext> options
         modelBuilder.Entity<BookCopy>()
             .HasIndex(c => c.Isbn);
 
+        modelBuilder.Entity<BookCopy>()
+            .HasOne(c => c.Publisher)
+            .WithMany(p => p.Copies)
+            .HasForeignKey(c => c.PublisherId)
+            .OnDelete(DeleteBehavior.Restrict);
+
         modelBuilder.Entity<Genre>()
             .HasIndex(g => g.Name)
+            .IsUnique();
+
+        modelBuilder.Entity<Publisher>()
+            .HasIndex(p => p.Name)
             .IsUnique();
     }
 }

--- a/BookTracker.Data/Migrations/20260414071857_AddCategorySubtitleAndPublisher.Designer.cs
+++ b/BookTracker.Data/Migrations/20260414071857_AddCategorySubtitleAndPublisher.Designer.cs
@@ -4,6 +4,7 @@ using BookTracker.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BookTracker.Data.Migrations
 {
     [DbContext(typeof(BookTrackerDbContext))]
-    partial class BookTrackerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260414071857_AddCategorySubtitleAndPublisher")]
+    partial class AddCategorySubtitleAndPublisher
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BookTracker.Data/Migrations/20260414071857_AddCategorySubtitleAndPublisher.cs
+++ b/BookTracker.Data/Migrations/20260414071857_AddCategorySubtitleAndPublisher.cs
@@ -1,0 +1,93 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BookTracker.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCategorySubtitleAndPublisher : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "Category",
+                table: "Books",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Subtitle",
+                table: "Books",
+                type: "nvarchar(300)",
+                maxLength: 300,
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "PublisherId",
+                table: "BookCopies",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "Publishers",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Name = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Publishers", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_BookCopies_PublisherId",
+                table: "BookCopies",
+                column: "PublisherId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Publishers_Name",
+                table: "Publishers",
+                column: "Name",
+                unique: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_BookCopies_Publishers_PublisherId",
+                table: "BookCopies",
+                column: "PublisherId",
+                principalTable: "Publishers",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_BookCopies_Publishers_PublisherId",
+                table: "BookCopies");
+
+            migrationBuilder.DropTable(
+                name: "Publishers");
+
+            migrationBuilder.DropIndex(
+                name: "IX_BookCopies_PublisherId",
+                table: "BookCopies");
+
+            migrationBuilder.DropColumn(
+                name: "Category",
+                table: "Books");
+
+            migrationBuilder.DropColumn(
+                name: "Subtitle",
+                table: "Books");
+
+            migrationBuilder.DropColumn(
+                name: "PublisherId",
+                table: "BookCopies");
+        }
+    }
+}

--- a/BookTracker.Data/Models/Book.cs
+++ b/BookTracker.Data/Models/Book.cs
@@ -9,6 +9,12 @@ public enum BookStatus
     Read
 }
 
+public enum BookCategory
+{
+    Fiction,
+    NonFiction
+}
+
 public class Book
 {
     public int Id { get; set; }
@@ -16,12 +22,17 @@ public class Book
     [Required, MaxLength(300)]
     public string Title { get; set; } = string.Empty;
 
+    [MaxLength(300)]
+    public string? Subtitle { get; set; }
+
     [Required, MaxLength(200)]
     public string Author { get; set; } = string.Empty;
 
     public List<Genre> Genres { get; set; } = [];
 
-    public BookStatus Status { get; set; } = BookStatus.Unread;
+    public BookCategory Category { get; set; } = BookCategory.Fiction;
+
+    public BookStatus Status { get; set; } = BookStatus.Read;
 
     [Range(0, 5)]
     public int Rating { get; set; }

--- a/BookTracker.Data/Models/BookCopy.cs
+++ b/BookTracker.Data/Models/BookCopy.cs
@@ -29,7 +29,7 @@ public class BookCopy
     [Required, MaxLength(20)]
     public string Isbn { get; set; } = string.Empty;
 
-    public BookFormat Format { get; set; }
+    public BookFormat Format { get; set; } = BookFormat.Softcopy;
 
     public DateOnly? DatePrinted { get; set; }
 
@@ -37,4 +37,7 @@ public class BookCopy
 
     [MaxLength(500)]
     public string? CustomCoverArtUrl { get; set; }
+
+    public int? PublisherId { get; set; }
+    public Publisher? Publisher { get; set; }
 }

--- a/BookTracker.Data/Models/Publisher.cs
+++ b/BookTracker.Data/Models/Publisher.cs
@@ -1,0 +1,16 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace BookTracker.Data.Models;
+
+// TODO: add a "Manage publishers" feature — UI to rename/merge duplicates,
+// delete unused publishers, and see which copies each publisher covers.
+// Right now Publishers are only created via find-or-create on the Add page.
+public class Publisher
+{
+    public int Id { get; set; }
+
+    [Required, MaxLength(200)]
+    public string Name { get; set; } = string.Empty;
+
+    public List<BookCopy> Copies { get; set; } = [];
+}

--- a/BookTracker.Web/Components/Pages/Books/Add.razor
+++ b/BookTracker.Web/Components/Pages/Books/Add.razor
@@ -53,7 +53,20 @@
                             <InputText @bind-Value="Input.Author" class="form-control" />
                             <ValidationMessage For="() => Input.Author" class="text-danger small" />
                         </div>
-                        <div class="col-md-4">
+                        <div class="col-12">
+                            <label class="form-label">Subtitle</label>
+                            <InputText @bind-Value="Input.Subtitle" class="form-control" />
+                        </div>
+                        <div class="col-md-3">
+                            <label class="form-label">Category</label>
+                            <InputSelect @bind-Value="Input.Category" class="form-select">
+                                @foreach (var c in Enum.GetValues<BookCategory>())
+                                {
+                                    <option value="@c">@FormatCategory(c)</option>
+                                }
+                            </InputSelect>
+                        </div>
+                        <div class="col-md-3">
                             <label class="form-label">Status</label>
                             <InputSelect @bind-Value="Input.Status" class="form-select">
                                 @foreach (var s in Enum.GetValues<BookStatus>())
@@ -62,12 +75,12 @@
                                 }
                             </InputSelect>
                         </div>
-                        <div class="col-md-4">
+                        <div class="col-md-3">
                             <label class="form-label">Rating (0–5)</label>
                             <InputNumber @bind-Value="Input.Rating" min="0" max="5" class="form-control" />
                             <ValidationMessage For="() => Input.Rating" class="text-danger small" />
                         </div>
-                        <div class="col-md-4">
+                        <div class="col-md-3">
                             <label class="form-label">Default cover URL</label>
                             <InputText @bind-Value="Input.DefaultCoverArtUrl" class="form-control" placeholder="https://..." />
                         </div>
@@ -160,6 +173,16 @@
                                 }
                             </InputSelect>
                         </div>
+                        <div class="col-md-6">
+                            <label class="form-label">Publisher</label>
+                            <InputText @bind-Value="Input.Publisher" class="form-control" list="publisher-options" placeholder="Penguin Books" />
+                            <datalist id="publisher-options">
+                                @foreach (var p in existingPublishers)
+                                {
+                                    <option value="@p.Name"></option>
+                                }
+                            </datalist>
+                        </div>
                         <div class="col-12">
                             <label class="form-label">Custom cover for this copy (optional)</label>
                             <InputText @bind-Value="Input.CustomCoverArtUrl" class="form-control" placeholder="Overrides the book's default cover" />
@@ -190,15 +213,18 @@
     bool saving;
 
     List<GenreOption> existingGenres = [];
+    List<PublisherOption> existingPublishers = [];
 
-    protected override async Task OnInitializedAsync() => await LoadExistingGenresAsync();
-
-    private async Task LoadExistingGenresAsync()
+    protected override async Task OnInitializedAsync()
     {
         await using var db = await DbFactory.CreateDbContextAsync();
         existingGenres = await db.Genres
             .OrderBy(g => g.Name)
             .Select(g => new GenreOption(g.Id, g.Name))
+            .ToListAsync();
+        existingPublishers = await db.Publishers
+            .OrderBy(p => p.Name)
+            .Select(p => new PublisherOption(p.Id, p.Name))
             .ToListAsync();
     }
 
@@ -234,7 +260,9 @@
             }
 
             if (string.IsNullOrWhiteSpace(Input.Title)) Input.Title = result.Title ?? "";
+            if (string.IsNullOrWhiteSpace(Input.Subtitle)) Input.Subtitle = result.Subtitle;
             if (string.IsNullOrWhiteSpace(Input.Author)) Input.Author = result.Author ?? "";
+            if (string.IsNullOrWhiteSpace(Input.Publisher)) Input.Publisher = result.Publisher;
             if (string.IsNullOrWhiteSpace(Input.DefaultCoverArtUrl)) Input.DefaultCoverArtUrl = result.CoverUrl;
             if (string.IsNullOrWhiteSpace(Input.Isbn)) Input.Isbn = result.Isbn;
             Input.DatePrinted ??= result.DatePrinted;
@@ -300,11 +328,25 @@
                 }
             }
 
+            Publisher? publisher = null;
+            var publisherName = Input.Publisher?.Trim();
+            if (!string.IsNullOrEmpty(publisherName))
+            {
+                publisher = await db.Publishers.FirstOrDefaultAsync(p => p.Name == publisherName);
+                if (publisher is null)
+                {
+                    publisher = new Publisher { Name = publisherName };
+                    db.Publishers.Add(publisher);
+                }
+            }
+
             var book = new Book
             {
                 Title = Input.Title!.Trim(),
+                Subtitle = string.IsNullOrWhiteSpace(Input.Subtitle) ? null : Input.Subtitle.Trim(),
                 Author = Input.Author!.Trim(),
                 Notes = string.IsNullOrWhiteSpace(Input.Notes) ? null : Input.Notes.Trim(),
+                Category = Input.Category,
                 Status = Input.Status,
                 Rating = Input.Rating,
                 DefaultCoverArtUrl = string.IsNullOrWhiteSpace(Input.DefaultCoverArtUrl) ? null : Input.DefaultCoverArtUrl.Trim(),
@@ -317,6 +359,7 @@
                         Format = Input.Format,
                         DatePrinted = Input.DatePrinted,
                         Condition = Input.Condition,
+                        Publisher = publisher,
                         CustomCoverArtUrl = string.IsNullOrWhiteSpace(Input.CustomCoverArtUrl) ? null : Input.CustomCoverArtUrl.Trim()
                     }
                 ]
@@ -340,17 +383,29 @@
         _ => c.ToString()
     };
 
+    private static string FormatCategory(BookCategory c) => c switch
+    {
+        BookCategory.NonFiction => "Non-Fiction",
+        _ => c.ToString()
+    };
+
     public record GenreOption(int Id, string Name);
+    public record PublisherOption(int Id, string Name);
 
     public class AddBookInput
     {
         [Required, StringLength(300)]
         public string? Title { get; set; }
 
+        [StringLength(300)]
+        public string? Subtitle { get; set; }
+
         [Required, StringLength(200)]
         public string? Author { get; set; }
 
-        public BookStatus Status { get; set; } = BookStatus.Unread;
+        public BookCategory Category { get; set; } = BookCategory.Fiction;
+
+        public BookStatus Status { get; set; } = BookStatus.Read;
 
         [Range(0, 5)]
         public int Rating { get; set; }
@@ -368,11 +423,14 @@
         [RegularExpression(@"^(97(8|9))?\d{9}(\d|X|x)$", ErrorMessage = "Enter a valid 10- or 13-digit ISBN.")]
         public string? Isbn { get; set; }
 
-        public BookFormat Format { get; set; } = BookFormat.Hardcopy;
+        public BookFormat Format { get; set; } = BookFormat.Softcopy;
 
         public DateOnly? DatePrinted { get; set; }
 
         public BookCondition Condition { get; set; } = BookCondition.Good;
+
+        [StringLength(200)]
+        public string? Publisher { get; set; }
 
         [StringLength(500)]
         public string? CustomCoverArtUrl { get; set; }

--- a/BookTracker.Web/Services/BookLookupResult.cs
+++ b/BookTracker.Web/Services/BookLookupResult.cs
@@ -3,7 +3,9 @@ namespace BookTracker.Web.Services;
 public record BookLookupResult(
     string Isbn,
     string? Title,
+    string? Subtitle,
     string? Author,
+    string? Publisher,
     IReadOnlyList<string> GenreCandidates,
     DateOnly? DatePrinted,
     string? CoverUrl,

--- a/BookTracker.Web/Services/BookLookupService.cs
+++ b/BookTracker.Web/Services/BookLookupService.cs
@@ -42,7 +42,9 @@ public class BookLookupService(HttpClient http, ILogger<BookLookupService> logge
             return new BookLookupResult(
                 Isbn: isbn,
                 Title: book.Title,
+                Subtitle: book.Subtitle,
                 Author: book.Authors?.FirstOrDefault()?.Name,
+                Publisher: book.Publishers?.FirstOrDefault()?.Name,
                 GenreCandidates: genres,
                 DatePrinted: ParseLooseDate(book.PublishDate),
                 CoverUrl: book.Cover?.Large ?? book.Cover?.Medium ?? $"https://covers.openlibrary.org/b/isbn/{isbn}-L.jpg",
@@ -82,7 +84,9 @@ public class BookLookupService(HttpClient http, ILogger<BookLookupService> logge
             return new BookLookupResult(
                 Isbn: isbn,
                 Title: item.Title,
+                Subtitle: item.Subtitle,
                 Author: item.Authors?.FirstOrDefault(),
+                Publisher: item.Publisher,
                 GenreCandidates: genres,
                 DatePrinted: ParseLooseDate(item.PublishedDate),
                 CoverUrl: cover,
@@ -125,12 +129,15 @@ public class BookLookupService(HttpClient http, ILogger<BookLookupService> logge
     private sealed class OpenLibraryBook
     {
         [JsonPropertyName("title")] public string? Title { get; set; }
+        [JsonPropertyName("subtitle")] public string? Subtitle { get; set; }
         [JsonPropertyName("authors")] public List<OpenLibraryAuthor>? Authors { get; set; }
+        [JsonPropertyName("publishers")] public List<OpenLibraryPublisher>? Publishers { get; set; }
         [JsonPropertyName("subjects")] public List<OpenLibrarySubject>? Subjects { get; set; }
         [JsonPropertyName("publish_date")] public string? PublishDate { get; set; }
         [JsonPropertyName("cover")] public OpenLibraryCover? Cover { get; set; }
     }
     private sealed class OpenLibraryAuthor { [JsonPropertyName("name")] public string? Name { get; set; } }
+    private sealed class OpenLibraryPublisher { [JsonPropertyName("name")] public string? Name { get; set; } }
     private sealed class OpenLibrarySubject { [JsonPropertyName("name")] public string Name { get; set; } = ""; }
     private sealed class OpenLibraryCover
     {
@@ -144,7 +151,9 @@ public class BookLookupService(HttpClient http, ILogger<BookLookupService> logge
     private sealed class GoogleVolumeInfo
     {
         [JsonPropertyName("title")] public string? Title { get; set; }
+        [JsonPropertyName("subtitle")] public string? Subtitle { get; set; }
         [JsonPropertyName("authors")] public List<string>? Authors { get; set; }
+        [JsonPropertyName("publisher")] public string? Publisher { get; set; }
         [JsonPropertyName("categories")] public List<string>? Categories { get; set; }
         [JsonPropertyName("publishedDate")] public string? PublishedDate { get; set; }
         [JsonPropertyName("imageLinks")] public GoogleImageLinks? ImageLinks { get; set; }


### PR DESCRIPTION
Entity changes:
- Book gains Subtitle (nullable) and Category (Fiction / NonFiction, default Fiction).
- Book.Status default flips Unread -> Read.
- BookCopy.Format default flips Hardcopy -> Softcopy.
- New Publisher entity (unique Name); BookCopy gains optional PublisherId / Publisher nav. Restrict on delete so books can be removed without stranding publisher rows.

Lookup service now extracts subtitle and publisher from both Open Library and Google Books responses.

Add page: new Subtitle field, Category select, Publisher input with a datalist of existing publishers. Lookup prefills Subtitle and Publisher when blank. Save does find-or-create on publisher name, matching the existing Genre pattern.

Added TODO on Publisher for a future 'manage publishers' feature.