### PR TITLE
feat: GitHub Actions CI/CD with deploy + swap workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+      - run: dotnet restore BookTracker.slnx
+      - run: dotnet build BookTracker.slnx --configuration Release --no-restore

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,52 @@
+name: Deploy to staging slot
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-staging
+  cancel-in-progress: false
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Restore
+        run: dotnet restore BookTracker.slnx
+
+      - name: Build
+        run: dotnet build BookTracker.slnx --configuration Release --no-restore
+
+      - name: Publish
+        run: dotnet publish BookTracker.Web/BookTracker.Web.csproj --configuration Release --no-build -o ./publish
+
+      - name: Zip publish output
+        run: |
+          cd publish
+          zip -r ../app.zip .
+
+      - name: Azure login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Deploy to staging slot
+        uses: azure/webapps-deploy@v3
+        with:
+          app-name: ${{ vars.AZURE_APP_NAME }}
+          slot-name: ${{ vars.AZURE_SLOT_NAME }}
+          package: ./app.zip

--- a/.github/workflows/swap.yml
+++ b/.github/workflows/swap.yml
@@ -1,0 +1,30 @@
+name: Swap staging to production
+
+# TODO: configure a GitHub Environment named "production" (Settings -> Environments)
+# with required reviewers, then add `environment: production` to the job below so
+# the swap requires human approval before it runs.
+on:
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  swap:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Azure login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Swap staging into production
+        run: |
+          az webapp deployment slot swap \
+            --resource-group "${{ vars.AZURE_RG }}" \
+            --name "${{ vars.AZURE_APP_NAME }}" \
+            --slot "${{ vars.AZURE_SLOT_NAME }}" \
+            --target-slot production

--- a/BookTracker.Web/Program.cs
+++ b/BookTracker.Web/Program.cs
@@ -25,6 +25,17 @@ builder.Services.AddHttpClient<IBookLookupService, BookLookupService>(client =>
 
 var app = builder.Build();
 
+// TODO: replace migrate-on-startup with a dedicated deploy-time migration step
+// (e.g. `dotnet ef migrations bundle` run from the GitHub Actions workflow)
+// once the app goes multi-instance or needs zero-downtime deploys. For now,
+// the single-instance App Service makes this simple and safe.
+using (var scope = app.Services.CreateScope())
+{
+    var dbFactory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<BookTrackerDbContext>>();
+    await using var db = await dbFactory.CreateDbContextAsync();
+    await db.Database.MigrateAsync();
+}
+
 // TODO: replace the default /Error page and exception handler with proper error
 // handling — structured logging, user-friendly messages by category, correlation
 // ids surfaced to the user, and separate 404 handling.

--- a/infra/README.md
+++ b/infra/README.md
@@ -45,6 +45,24 @@ What the script does:
 5. Registers the App Service's Easy Auth callback URL on the app registration.
 6. Connects to the new SQL DB with AAD auth and grants the App Service managed identity `db_datareader/writer/ddladmin`.
 
+## GitHub Actions CI/CD
+
+After the first `deploy.ps1` run, set up the GitHub → Azure OIDC link:
+
+```powershell
+./setup-github-oidc.ps1 -TenantId '<tenant>' -SubscriptionId '<sub>' `
+    -GitHubOrg 'N3rdage' -GitHubRepo 'the-library'
+```
+
+The script creates a `booktracker-ci` app registration with federated identity credentials (one for pushes to `main`, one for pull requests), assigns it Contributor on `rg-booktracker-prod`, and prints six GitHub repository variables for you to configure at `Settings → Secrets and variables → Actions → Variables`.
+
+Workflows under `.github/workflows/`:
+- `ci.yml` — build on PRs.
+- `deploy.yml` — on push to `main`: build, publish, deploy to the **staging** slot.
+- `swap.yml` — manual: `az webapp deployment slot swap staging -> production`. TODO in the file to wire up a GitHub Environment with required reviewers.
+
+Schema migrations currently run on app startup via `db.Database.MigrateAsync()`. Fine for a single-instance app; there's a TODO in `Program.cs` to switch to a deploy-time migration bundle once the app scales out.
+
 ## Post-deploy
 
 Assign users/groups to the enterprise app so they can sign in:

--- a/infra/deploy.ps1
+++ b/infra/deploy.ps1
@@ -120,17 +120,23 @@ $appServiceName = $deployment.Outputs.appServiceName.Value
 $sqlFqdn = $deployment.Outputs.sqlServerFqdn.Value
 $sqlDb = $deployment.Outputs.sqlDatabaseName.Value
 $appHost = ([Uri]$appUrl).Host
+$stagingHost = $deployment.Outputs.stagingHostName.Value
+$stagingSlotSqlUserName = "$appServiceName/slots/staging"
 
 Write-Host ""
 Write-Host "Infrastructure deployed."
 Write-Host "  App Service: $appUrl"
 Write-Host "  SQL Server:  $sqlFqdn / $sqlDb"
 
-# ---- Ensure the Easy Auth redirect URI is registered -------------------------
-$expectedRedirect = "https://$appHost/.auth/login/aad/callback"
+# ---- Ensure the Easy Auth redirect URIs are registered (prod + staging) -----
+$redirects = @(
+    "https://$appHost/.auth/login/aad/callback"
+    "https://$stagingHost/.auth/login/aad/callback"
+)
 $currentUris = @($app.Web.RedirectUris)
-if ($currentUris -notcontains $expectedRedirect) {
-    $newUris = @($currentUris + $expectedRedirect | Where-Object { $_ } | Select-Object -Unique)
+$missing = $redirects | Where-Object { $currentUris -notcontains $_ }
+if ($missing) {
+    $newUris = @(($currentUris + $redirects) | Where-Object { $_ } | Select-Object -Unique)
     Update-MgApplication -ApplicationId $app.Id -Web @{
         RedirectUris = $newUris
         ImplicitGrantSettings = @{
@@ -138,7 +144,7 @@ if ($currentUris -notcontains $expectedRedirect) {
             EnableAccessTokenIssuance = $false
         }
     }
-    Write-Host "  Added redirect URI: $expectedRedirect"
+    foreach ($r in $missing) { Write-Host "  Added redirect URI: $r" }
 }
 
 # ---- Grant the App Service managed identity access to the SQL DB -------------
@@ -162,6 +168,8 @@ New-AzSqlServerFirewallRule `
 Start-Sleep -Seconds 10
 
 try {
+    # Both slots get their own system-assigned managed identity. The SQL user
+    # name for a slot is "<app-service-name>/slots/<slot-name>".
     $sqlScript = @"
 IF NOT EXISTS (SELECT 1 FROM sys.database_principals WHERE name = '$appServiceName')
 BEGIN
@@ -169,6 +177,14 @@ BEGIN
     ALTER ROLE db_datareader ADD MEMBER [$appServiceName];
     ALTER ROLE db_datawriter ADD MEMBER [$appServiceName];
     ALTER ROLE db_ddladmin  ADD MEMBER [$appServiceName];
+END
+
+IF NOT EXISTS (SELECT 1 FROM sys.database_principals WHERE name = '$stagingSlotSqlUserName')
+BEGIN
+    CREATE USER [$stagingSlotSqlUserName] FROM EXTERNAL PROVIDER;
+    ALTER ROLE db_datareader ADD MEMBER [$stagingSlotSqlUserName];
+    ALTER ROLE db_datawriter ADD MEMBER [$stagingSlotSqlUserName];
+    ALTER ROLE db_ddladmin  ADD MEMBER [$stagingSlotSqlUserName];
 END
 "@
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -56,5 +56,7 @@ output resourceGroupName string = rg.name
 output appServiceUrl string = resources.outputs.appServiceUrl
 output appServiceName string = resources.outputs.appServiceName
 output appServicePrincipalId string = resources.outputs.appServicePrincipalId
+output stagingHostName string = resources.outputs.stagingHostName
+output stagingPrincipalId string = resources.outputs.stagingPrincipalId
 output sqlServerFqdn string = resources.outputs.sqlServerFqdn
 output sqlDatabaseName string = resources.outputs.sqlDatabaseName

--- a/infra/modules/appservice.bicep
+++ b/infra/modules/appservice.bicep
@@ -117,6 +117,96 @@ resource authConfig 'Microsoft.Web/sites/config@2023-12-01' = {
   ]
 }
 
+// Staging deployment slot — GitHub Actions deploys here; swap.yml promotes to prod.
+// Each slot gets its own system-assigned managed identity, so both need to be
+// granted on the SQL DB (deploy.ps1 handles both).
+resource stagingSlot 'Microsoft.Web/sites/slots@2023-12-01' = {
+  parent: app
+  name: 'staging'
+  location: location
+  tags: tags
+  kind: 'app,linux'
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    serverFarmId: plan.id
+    httpsOnly: true
+    clientAffinityEnabled: true
+    siteConfig: {
+      linuxFxVersion: 'DOTNETCORE|10.0'
+      alwaysOn: true
+      http20Enabled: true
+      webSocketsEnabled: true
+      ftpsState: 'Disabled'
+      minTlsVersion: '1.2'
+    }
+  }
+}
+
+resource stagingAppSettings 'Microsoft.Web/sites/slots/config@2023-12-01' = {
+  parent: stagingSlot
+  name: 'appsettings'
+  properties: {
+    ASPNETCORE_ENVIRONMENT: 'Production'
+    APPLICATIONINSIGHTS_CONNECTION_STRING: appInsightsConnectionString
+    MICROSOFT_PROVIDER_AUTHENTICATION_SECRET: authClientSecret
+  }
+}
+
+resource stagingConnStrings 'Microsoft.Web/sites/slots/config@2023-12-01' = {
+  parent: stagingSlot
+  name: 'connectionstrings'
+  properties: {
+    DefaultConnection: {
+      value: 'Server=tcp:${sqlServerFqdn},1433;Database=${sqlDatabaseName};Authentication=Active Directory Default;Encrypt=True;TrustServerCertificate=False;'
+      type: 'SQLAzure'
+    }
+  }
+}
+
+resource stagingAuthConfig 'Microsoft.Web/sites/slots/config@2023-12-01' = {
+  parent: stagingSlot
+  name: 'authsettingsV2'
+  properties: {
+    platform: {
+      enabled: true
+      runtimeVersion: '~2'
+    }
+    globalValidation: {
+      requireAuthentication: true
+      unauthenticatedClientAction: 'RedirectToLoginPage'
+      redirectToProvider: 'azureactivedirectory'
+    }
+    identityProviders: {
+      azureActiveDirectory: {
+        enabled: true
+        registration: {
+          openIdIssuer: 'https://sts.windows.net/${tenantId}/v2.0'
+          clientId: authClientId
+          clientSecretSettingName: 'MICROSOFT_PROVIDER_AUTHENTICATION_SECRET'
+        }
+        validation: {
+          allowedAudiences: [
+            'api://${authClientId}'
+            authClientId
+          ]
+        }
+      }
+    }
+    login: {
+      tokenStore: {
+        enabled: true
+      }
+    }
+  }
+  dependsOn: [
+    stagingAppSettings
+  ]
+}
+
 output appServiceUrl string = 'https://${app.properties.defaultHostName}'
 output appServiceName string = app.name
 output principalId string = app.identity.principalId
+output stagingHostName string = stagingSlot.properties.defaultHostName
+output stagingPrincipalId string = stagingSlot.identity.principalId

--- a/infra/modules/resources.bicep
+++ b/infra/modules/resources.bicep
@@ -61,5 +61,7 @@ module app './appservice.bicep' = {
 output appServiceUrl string = app.outputs.appServiceUrl
 output appServiceName string = app.outputs.appServiceName
 output appServicePrincipalId string = app.outputs.principalId
+output stagingHostName string = app.outputs.stagingHostName
+output stagingPrincipalId string = app.outputs.stagingPrincipalId
 output sqlServerFqdn string = sql.outputs.sqlServerFqdn
 output sqlDatabaseName string = sqlDatabaseName

--- a/infra/setup-github-oidc.ps1
+++ b/infra/setup-github-oidc.ps1
@@ -1,0 +1,111 @@
+# One-time setup for GitHub Actions → Azure OIDC.
+# Creates an Entra app registration + service principal scoped to this repo,
+# adds federated identity credentials (no secrets needed), assigns
+# Contributor on the resource group, and prints the GitHub repository
+# variables you need to configure.
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)] [string] $TenantId,
+    [Parameter(Mandatory)] [string] $SubscriptionId,
+    [Parameter(Mandatory)] [string] $GitHubOrg,
+    [Parameter(Mandatory)] [string] $GitHubRepo,
+    [string] $MainBranch = 'main',
+    [string] $CiAppName = 'booktracker-ci',
+    [string] $ResourceGroupName = 'rg-booktracker-prod',
+    [string] $SlotName = 'staging'
+)
+
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+
+$required = @('Az.Accounts','Az.Resources','Microsoft.Graph.Applications')
+foreach ($m in $required) {
+    if (-not (Get-Module -ListAvailable -Name $m)) {
+        Write-Host "Installing $m..."
+        Install-Module $m -Scope CurrentUser -Force -AllowClobber -Repository PSGallery
+    }
+    Import-Module $m -ErrorAction Stop
+}
+
+Connect-AzAccount -Tenant $TenantId -Subscription $SubscriptionId | Out-Null
+Set-AzContext -Tenant $TenantId -Subscription $SubscriptionId | Out-Null
+Connect-MgGraph -TenantId $TenantId -Scopes 'Application.ReadWrite.All','Directory.Read.All' -NoWelcome
+
+# ---- Ensure the CI app registration + service principal ---------------------
+Write-Host "Ensuring App Registration '$CiAppName'..."
+$app = Get-MgApplication -Filter "displayName eq '$CiAppName'" -ConsistencyLevel eventual -CountVariable c | Select-Object -First 1
+if (-not $app) {
+    $app = New-MgApplication -DisplayName $CiAppName -SignInAudience 'AzureADMyOrg'
+    Write-Host "  Created App Registration, AppId=$($app.AppId)"
+    Start-Sleep -Seconds 15  # replication before SP creation
+} else {
+    Write-Host "  Found existing, AppId=$($app.AppId)"
+}
+
+$sp = Get-MgServicePrincipal -Filter "appId eq '$($app.AppId)'" -ErrorAction SilentlyContinue | Select-Object -First 1
+if (-not $sp) {
+    $sp = New-MgServicePrincipal -AppId $app.AppId
+    Write-Host "  Created Service Principal $($sp.Id)"
+    Start-Sleep -Seconds 10
+}
+
+# ---- Federated identity credentials -----------------------------------------
+# A FIC binds a GitHub workflow run (subject) to this app registration.
+# Adding both the branch FIC (for push-to-main deploys) and the pull-request
+# FIC (so future PR workflows can validate against Azure if needed).
+$existingFics = Get-MgApplicationFederatedIdentityCredential -ApplicationId $app.Id
+$desiredFics = @(
+    @{
+        Name = 'github-main-branch'
+        Subject = "repo:${GitHubOrg}/${GitHubRepo}:ref:refs/heads/${MainBranch}"
+        Description = "$GitHubOrg/$GitHubRepo @ refs/heads/$MainBranch"
+    },
+    @{
+        Name = 'github-pull-request'
+        Subject = "repo:${GitHubOrg}/${GitHubRepo}:pull_request"
+        Description = "$GitHubOrg/$GitHubRepo pull_request"
+    }
+)
+foreach ($f in $desiredFics) {
+    if ($existingFics | Where-Object { $_.Name -eq $f.Name }) {
+        Write-Host "  FIC '$($f.Name)' already exists"
+        continue
+    }
+    New-MgApplicationFederatedIdentityCredential -ApplicationId $app.Id -BodyParameter @{
+        name = $f.Name
+        issuer = 'https://token.actions.githubusercontent.com'
+        subject = $f.Subject
+        audiences = @('api://AzureADTokenExchange')
+        description = $f.Description
+    } | Out-Null
+    Write-Host "  Added FIC '$($f.Name)' for $($f.Subject)"
+}
+
+# ---- Role assignment --------------------------------------------------------
+$scope = "/subscriptions/$SubscriptionId/resourceGroups/$ResourceGroupName"
+$existingRole = Get-AzRoleAssignment -ObjectId $sp.Id -Scope $scope -RoleDefinitionName 'Contributor' -ErrorAction SilentlyContinue
+if (-not $existingRole) {
+    New-AzRoleAssignment -ObjectId $sp.Id -RoleDefinitionName 'Contributor' -Scope $scope | Out-Null
+    Write-Host "  Assigned Contributor on $ResourceGroupName"
+} else {
+    Write-Host "  Contributor already assigned on $ResourceGroupName"
+}
+
+# ---- Discover the App Service name in the RG --------------------------------
+$appService = Get-AzResource -ResourceGroupName $ResourceGroupName -ResourceType 'Microsoft.Web/sites' -ErrorAction SilentlyContinue | Select-Object -First 1
+$appServiceName = if ($appService) { $appService.Name } else { '<run infra/deploy.ps1 first>' }
+
+Write-Host ""
+Write-Host "=========================================================="
+Write-Host "GitHub repository variables (Settings -> Secrets and variables -> Actions -> Variables):"
+Write-Host ""
+Write-Host "  AZURE_CLIENT_ID       = $($app.AppId)"
+Write-Host "  AZURE_TENANT_ID       = $TenantId"
+Write-Host "  AZURE_SUBSCRIPTION_ID = $SubscriptionId"
+Write-Host "  AZURE_RG              = $ResourceGroupName"
+Write-Host "  AZURE_APP_NAME        = $appServiceName"
+Write-Host "  AZURE_SLOT_NAME       = $SlotName"
+Write-Host ""
+Write-Host "These are *variables*, not secrets. OIDC means no client secret is stored anywhere."
+Write-Host "=========================================================="


### PR DESCRIPTION
Adds .github/workflows/{ci,deploy,swap}.yml:
- ci.yml: build on PRs
- deploy.yml: on push to main, build + publish + OIDC login + deploy to the 'staging' slot
- swap.yml: manual workflow_dispatch swap staging -> production, with a TODO to wire up a GitHub Environment with required reviewers

Infra:
- appservice.bicep: add a staging Microsoft.Web/sites/slots resource mirroring the production slot's runtime, app settings, connection string, and Easy Auth config. Each slot gets its own managed identity.
- deploy.ps1: register the staging slot's Easy Auth redirect URI on the Library-Patrons app registration, and grant the staging slot's managed identity the same db_datareader/writer/ddladmin roles as production on the SQL DB.
- setup-github-oidc.ps1 (new): creates a 'booktracker-ci' app registration with federated identity credentials scoped to this repo, assigns Contributor on the resource group, and prints the GitHub repo variables to set.

App:
- Program.cs runs db.Database.MigrateAsync() on startup. TODO to move to a deploy-time migration bundle when the app scales out.