### PR TITLE
feat(infra): optional custom domain with managed certificate

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -71,6 +71,19 @@ Assign users/groups to the enterprise app so they can sign in:
 
 Unassigned users attempting to sign in will see `AADSTS501051`.
 
+## Custom domain
+
+Bind a custom hostname (e.g. `books.silly.ninja`) to the production slot with a free App Service Managed Certificate:
+
+1. Run `./deploy.ps1 -TenantId … -SubscriptionId …` **without** `-CustomDomain`. The last block of output shows the `asuid.<subdomain>` TXT value and the CNAME target.
+2. At your DNS host (Gandi in our case), add:
+   - `TXT  asuid.books  <customDomainVerificationId>`
+   - `CNAME books  <app>.azurewebsites.net`
+3. Wait for DNS to propagate (a few minutes to an hour; `nslookup books.silly.ninja` should resolve).
+4. Re-run `./deploy.ps1 -TenantId … -SubscriptionId … -CustomDomain books.silly.ninja`. Bicep adds the hostname binding, issues the managed cert, and binds SSL. The script also registers the custom-domain redirect URI on the `Library-Patrons` app registration.
+
+Works for CNAME-pointed subdomains only. Apex domains (`silly.ninja`) need a different cert issuance path (A record + ALIAS or equivalent) — not covered here.
+
 ## TODOs
 
 - Move the Easy Auth client secret from an app setting to a Key Vault reference and schedule rotation.

--- a/infra/deploy.ps1
+++ b/infra/deploy.ps1
@@ -8,7 +8,10 @@ param(
     [Parameter(Mandatory)] [string] $SubscriptionId,
     [string] $Location = 'australiaeast',
     [string] $AppName = 'booktracker',
-    [string] $EnterpriseAppName = 'Library-Patrons'
+    [string] $EnterpriseAppName = 'Library-Patrons',
+    # Optional custom hostname (e.g. books.silly.ninja). DNS records must be in
+    # place first — the script prints them at the end of every run.
+    [string] $CustomDomain = ''
 )
 
 $ErrorActionPreference = 'Stop'
@@ -103,6 +106,7 @@ $templateParams = @{
     authClientSecret    = $clientSecret
     sqlAadAdminObjectId = $me.Id
     sqlAadAdminLogin    = $me.UserPrincipalName
+    customDomain        = $CustomDomain
 }
 
 $deployment = New-AzSubscriptionDeployment `
@@ -133,6 +137,9 @@ $redirects = @(
     "https://$appHost/.auth/login/aad/callback"
     "https://$stagingHost/.auth/login/aad/callback"
 )
+if ($CustomDomain) {
+    $redirects += "https://$CustomDomain/.auth/login/aad/callback"
+}
 $currentUris = @($app.Web.RedirectUris)
 $missing = $redirects | Where-Object { $currentUris -notcontains $_ }
 if ($missing) {
@@ -203,7 +210,27 @@ finally {
 Write-Host ""
 Write-Host "Done."
 Write-Host "  App URL: $appUrl"
+if ($CustomDomain) {
+    Write-Host "  Custom URL: https://$CustomDomain"
+}
 Write-Host ""
 Write-Host "Next step — assign users/groups to the '$EnterpriseAppName' enterprise app:"
 Write-Host "  https://entra.microsoft.com -> Identity -> Applications -> Enterprise applications -> $EnterpriseAppName -> Users and groups"
 Write-Host "Only assigned principals will be able to sign in."
+
+# ---- DNS records required for a custom domain (print every run) -------------
+$defaultHost = $deployment.Outputs.defaultHostName.Value
+$verificationId = $deployment.Outputs.customDomainVerificationId.Value
+Write-Host ""
+Write-Host "----"
+Write-Host "To bind a custom domain (like books.silly.ninja), add these DNS records"
+Write-Host "at your registrar (Gandi, Cloudflare, etc.), wait for propagation, then re-run"
+Write-Host "this script with -CustomDomain <hostname>:"
+Write-Host ""
+Write-Host "  TXT   asuid.<subdomain>    $verificationId"
+Write-Host "  CNAME <subdomain>          $defaultHost"
+Write-Host ""
+Write-Host "e.g. for books.silly.ninja:"
+Write-Host "  TXT   asuid.books          $verificationId"
+Write-Host "  CNAME books                $defaultHost"
+Write-Host "----"

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -24,6 +24,9 @@ param sqlAadAdminObjectId string
 @description('Display name / UPN of the SQL Server AAD admin. Shown in the portal only.')
 param sqlAadAdminLogin string
 
+@description('Optional custom hostname to bind to the production slot (e.g. books.silly.ninja). Leave blank to skip.')
+param customDomain string = ''
+
 var tags = {
   Client: 'Drew'
   Environment: 'Production'
@@ -49,12 +52,15 @@ module resources './modules/resources.bicep' = {
     authClientSecret: authClientSecret
     sqlAadAdminObjectId: sqlAadAdminObjectId
     sqlAadAdminLogin: sqlAadAdminLogin
+    customDomain: customDomain
   }
 }
 
 output resourceGroupName string = rg.name
 output appServiceUrl string = resources.outputs.appServiceUrl
 output appServiceName string = resources.outputs.appServiceName
+output defaultHostName string = resources.outputs.defaultHostName
+output customDomainVerificationId string = resources.outputs.customDomainVerificationId
 output appServicePrincipalId string = resources.outputs.appServicePrincipalId
 output stagingHostName string = resources.outputs.stagingHostName
 output stagingPrincipalId string = resources.outputs.stagingPrincipalId

--- a/infra/modules/appservice.bicep
+++ b/infra/modules/appservice.bicep
@@ -207,6 +207,8 @@ resource stagingAuthConfig 'Microsoft.Web/sites/slots/config@2023-12-01' = {
 
 output appServiceUrl string = 'https://${app.properties.defaultHostName}'
 output appServiceName string = app.name
+output defaultHostName string = app.properties.defaultHostName
+output customDomainVerificationId string = app.properties.customDomainVerificationId
 output principalId string = app.identity.principalId
 output stagingHostName string = stagingSlot.properties.defaultHostName
 output stagingPrincipalId string = stagingSlot.identity.principalId

--- a/infra/modules/bindssl.bicep
+++ b/infra/modules/bindssl.bicep
@@ -1,0 +1,21 @@
+// Re-PUTs the hostname binding with SslState=SniEnabled and the issued
+// certificate thumbprint. Must be a separate module so Bicep lets us declare
+// the same ARM resource twice (once empty, once with SSL attached).
+param appServiceName string
+param customDomain string
+param thumbprint string
+
+resource app 'Microsoft.Web/sites@2023-12-01' existing = {
+  name: appServiceName
+}
+
+resource binding 'Microsoft.Web/sites/hostNameBindings@2023-12-01' = {
+  parent: app
+  name: customDomain
+  properties: {
+    siteName: appServiceName
+    hostNameType: 'Verified'
+    sslState: 'SniEnabled'
+    thumbprint: thumbprint
+  }
+}

--- a/infra/modules/customdomain.bicep
+++ b/infra/modules/customdomain.bicep
@@ -1,0 +1,56 @@
+// Adds a custom hostname + App Service Managed Certificate to the production
+// slot. Pattern:
+//   1. Create the hostname binding with SSL disabled (App Service validates
+//      DNS against the site's customDomainVerificationId + CNAME target).
+//   2. Create the Microsoft.Web/certificates resource (managed cert, auto-
+//      renewing). Azure issues it by re-validating DNS from the binding.
+//   3. Re-PUT the binding via a nested module, this time with
+//      sslState=SniEnabled + the freshly-issued cert thumbprint.
+// Step 3 lives in bindssl.bicep so the binding can be "re-declared" (ARM
+// treats it as an update; Bicep can't have two declarations of the same
+// resource in a single module).
+param appServiceName string
+param customDomain string
+param location string
+param tags object
+
+resource app 'Microsoft.Web/sites@2023-12-01' existing = {
+  name: appServiceName
+}
+
+resource binding 'Microsoft.Web/sites/hostNameBindings@2023-12-01' = {
+  parent: app
+  name: customDomain
+  properties: {
+    siteName: appServiceName
+    hostNameType: 'Verified'
+    sslState: 'Disabled'
+    customHostNameDnsRecordType: 'CName'
+  }
+}
+
+// App Service Managed Certificate — free, auto-renewing. CNAME-pointed
+// subdomains only (books.silly.ninja qualifies; apex domains do not).
+resource cert 'Microsoft.Web/certificates@2023-12-01' = {
+  name: replace(customDomain, '.', '-')
+  location: location
+  tags: tags
+  properties: {
+    canonicalName: customDomain
+    serverFarmId: app.properties.serverFarmId
+  }
+  dependsOn: [
+    binding
+  ]
+}
+
+module bindSsl './bindssl.bicep' = {
+  name: 'bindSsl-${uniqueString(customDomain)}'
+  params: {
+    appServiceName: appServiceName
+    customDomain: customDomain
+    thumbprint: cert.properties.thumbprint
+  }
+}
+
+output certThumbprint string = cert.properties.thumbprint

--- a/infra/modules/resources.bicep
+++ b/infra/modules/resources.bicep
@@ -9,6 +9,9 @@ param authClientSecret string
 param sqlAadAdminObjectId string
 param sqlAadAdminLogin string
 
+@description('Optional custom hostname to bind to the production slot (e.g. books.silly.ninja). Leave blank to skip.')
+param customDomain string = ''
+
 // Short suffix to keep globally-unique names (App Service hostname, SQL server
 // name) stable across re-deploys while still being unique per-subscription.
 var uniqueSuffix = substring(uniqueString(resourceGroup().id), 0, 6)
@@ -58,8 +61,20 @@ module app './appservice.bicep' = {
   }
 }
 
+module customdomain './customdomain.bicep' = if (!empty(customDomain)) {
+  name: 'customdomain'
+  params: {
+    appServiceName: app.outputs.appServiceName
+    customDomain: customDomain
+    location: location
+    tags: tags
+  }
+}
+
 output appServiceUrl string = app.outputs.appServiceUrl
 output appServiceName string = app.outputs.appServiceName
+output defaultHostName string = app.outputs.defaultHostName
+output customDomainVerificationId string = app.outputs.customDomainVerificationId
 output appServicePrincipalId string = app.outputs.principalId
 output stagingHostName string = app.outputs.stagingHostName
 output stagingPrincipalId string = app.outputs.stagingPrincipalId


### PR DESCRIPTION
New customdomain.bicep + bindssl.bicep modules handle the three-step App Service Managed Certificate flow: create hostname binding with SSL disabled, create Microsoft.Web/certificates (Azure issues the free managed cert by validating DNS via the binding), then re-PUT the binding with SniEnabled + thumbprint via a nested module.

main.bicep and resources.bicep take an optional customDomain param and invoke the module only when set.

deploy.ps1:
- New -CustomDomain parameter, passed through to Bicep.
- Easy Auth redirect URI for the custom domain added to the Library-Patrons app registration when -CustomDomain is set.
- On every run, prints the TXT (asuid.*) verification record and CNAME target so you know exactly what DNS to create before binding.

README has a Custom domain section documenting the two-run flow: first without -CustomDomain to get the DNS values, set DNS at the registrar (Gandi), then re-run with -CustomDomain to bind.