### PR TITLE
feat: hierarchical preset genre taxonomy

### DIFF
--- a/BookTracker.Data/BookTrackerDbContext.cs
+++ b/BookTracker.Data/BookTrackerDbContext.cs
@@ -32,6 +32,12 @@ public class BookTrackerDbContext(DbContextOptions<BookTrackerDbContext> options
             .HasIndex(g => g.Name)
             .IsUnique();
 
+        modelBuilder.Entity<Genre>()
+            .HasOne(g => g.ParentGenre)
+            .WithMany(g => g.Children)
+            .HasForeignKey(g => g.ParentGenreId)
+            .OnDelete(DeleteBehavior.Restrict);
+
         modelBuilder.Entity<Publisher>()
             .HasIndex(p => p.Name)
             .IsUnique();

--- a/BookTracker.Data/Migrations/20260414111237_AddGenreHierarchyAndSeed.Designer.cs
+++ b/BookTracker.Data/Migrations/20260414111237_AddGenreHierarchyAndSeed.Designer.cs
@@ -4,6 +4,7 @@ using BookTracker.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BookTracker.Data.Migrations
 {
     [DbContext(typeof(BookTrackerDbContext))]
-    partial class BookTrackerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260414111237_AddGenreHierarchyAndSeed")]
+    partial class AddGenreHierarchyAndSeed
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BookTracker.Data/Migrations/20260414111237_AddGenreHierarchyAndSeed.cs
+++ b/BookTracker.Data/Migrations/20260414111237_AddGenreHierarchyAndSeed.cs
@@ -1,0 +1,106 @@
+using System.Linq;
+using System.Text;
+using BookTracker.Data.Models;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BookTracker.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddGenreHierarchyAndSeed : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "ParentGenreId",
+                table: "Genres",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Genres_ParentGenreId",
+                table: "Genres",
+                column: "ParentGenreId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Genres_Genres_ParentGenreId",
+                table: "Genres",
+                column: "ParentGenreId",
+                principalTable: "Genres",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.Sql(BuildSeedAndCleanupSql());
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // Best-effort revert: clear the parent FK column, drop the FK + index +
+            // column. We don't try to restore deleted free-text genres — they're
+            // unrecoverable by design (this migration is the cutover point).
+            migrationBuilder.Sql("UPDATE [Genres] SET [ParentGenreId] = NULL;");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Genres_Genres_ParentGenreId",
+                table: "Genres");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Genres_ParentGenreId",
+                table: "Genres");
+
+            migrationBuilder.DropColumn(
+                name: "ParentGenreId",
+                table: "Genres");
+        }
+
+        private static string BuildSeedAndCleanupSql()
+        {
+            var sb = new StringBuilder();
+
+            // Insert top-level genres if missing (parent NULL).
+            foreach (var entry in GenreSeed.All.Where(e => e.ParentName is null))
+            {
+                sb.AppendLine($@"
+IF NOT EXISTS (SELECT 1 FROM [Genres] WHERE [Name] = N'{Escape(entry.Name)}' AND [ParentGenreId] IS NULL)
+    INSERT INTO [Genres] ([Name], [ParentGenreId]) VALUES (N'{Escape(entry.Name)}', NULL);");
+            }
+
+            // Insert sub-genres if missing, parent looked up by name.
+            foreach (var entry in GenreSeed.All.Where(e => e.ParentName is not null))
+            {
+                sb.AppendLine($@"
+IF NOT EXISTS (SELECT 1 FROM [Genres] WHERE [Name] = N'{Escape(entry.Name)}')
+    INSERT INTO [Genres] ([Name], [ParentGenreId])
+    VALUES (N'{Escape(entry.Name)}',
+            (SELECT TOP 1 [Id] FROM [Genres] WHERE [Name] = N'{Escape(entry.ParentName!)}' AND [ParentGenreId] IS NULL));");
+            }
+
+            // For pre-existing rows whose names match a sub-genre but lack parent,
+            // attach the parent. Idempotent.
+            foreach (var entry in GenreSeed.All.Where(e => e.ParentName is not null))
+            {
+                sb.AppendLine($@"
+UPDATE [Genres]
+SET [ParentGenreId] = (SELECT TOP 1 [Id] FROM [Genres] WHERE [Name] = N'{Escape(entry.ParentName!)}' AND [ParentGenreId] IS NULL)
+WHERE [Name] = N'{Escape(entry.Name)}' AND [ParentGenreId] IS NULL;");
+            }
+
+            // Cleanup: drop book-genre links for genres not in the preset list,
+            // then drop the orphan genre rows themselves.
+            var nameList = string.Join(", ", GenreSeed.All.Select(e => $"N'{Escape(e.Name)}'"));
+            sb.AppendLine($@"
+DELETE bg FROM [BookGenre] bg
+INNER JOIN [Genres] g ON bg.[GenresId] = g.[Id]
+WHERE g.[Name] NOT IN ({nameList});
+
+DELETE FROM [Genres] WHERE [Name] NOT IN ({nameList});");
+
+            return sb.ToString();
+        }
+
+        private static string Escape(string s) => s.Replace("'", "''");
+    }
+}

--- a/BookTracker.Data/Models/Genre.cs
+++ b/BookTracker.Data/Models/Genre.cs
@@ -9,5 +9,9 @@ public class Genre
     [Required, MaxLength(100)]
     public string Name { get; set; } = string.Empty;
 
+    public int? ParentGenreId { get; set; }
+    public Genre? ParentGenre { get; set; }
+    public List<Genre> Children { get; set; } = [];
+
     public List<Book> Books { get; set; } = [];
 }

--- a/BookTracker.Data/Models/GenreSeed.cs
+++ b/BookTracker.Data/Models/GenreSeed.cs
@@ -1,0 +1,69 @@
+namespace BookTracker.Data.Models;
+
+// Source-of-truth taxonomy for the curated genre list. The migration uses this
+// to seed/clean the Genres table; the Add page uses it implicitly via what's
+// loaded from the DB. To extend the list, add an entry here and either ship a
+// new migration or wait for the next migration to pick it up.
+//
+// Reference: https://fictionary.co/journal/book-genres/
+public static class GenreSeed
+{
+    public record Entry(string Name, string? ParentName);
+
+    public static readonly IReadOnlyList<Entry> All = new Entry[]
+    {
+        new("Fantasy", null),
+        new("High (Epic) Fantasy", "Fantasy"),
+        new("Urban (Contemporary) Fantasy", "Fantasy"),
+        new("Dark Fantasy", "Fantasy"),
+        new("Grimdark", "Fantasy"),
+        new("Sword and Sorcery", "Fantasy"),
+        new("Portal Fantasy", "Fantasy"),
+        new("Fairy-Tale Retelling", "Fantasy"),
+        new("Mythic Fantasy", "Fantasy"),
+        new("Steampunk Fantasy", "Fantasy"),
+        new("Paranormal Fantasy", "Fantasy"),
+        new("Historical Fantasy", "Fantasy"),
+        new("Young Adult Fantasy", "Fantasy"),
+
+        new("Romance", null),
+        new("Contemporary Romance", "Romance"),
+        new("Historical Romance", "Romance"),
+        new("Paranormal Romance", "Romance"),
+        new("Romantic Suspense", "Romance"),
+        new("Regency Romance", "Romance"),
+        new("Dark Romance", "Romance"),
+        new("Last Chance Romance", "Romance"),
+        new("Enemies to Lovers", "Romance"),
+        new("Fake Dating", "Romance"),
+        new("Young Adult Romance", "Romance"),
+        new("Romantasy", "Romance"),
+
+        new("Mystery", null),
+        new("Cozy Mystery", "Mystery"),
+        new("Hard-Boiled / Detective", "Mystery"),
+        new("Police Procedural", "Mystery"),
+        new("Noir", "Mystery"),
+        new("Historical Mystery", "Mystery"),
+        new("Heist Mystery", "Mystery"),
+        new("Whodunit", "Mystery"),
+        new("Legal Thriller", "Mystery"),
+        new("Private Detective", "Mystery"),
+
+        new("Science Fiction", null),
+        new("Historical Fiction", null),
+        new("Horror", null),
+        new("Thriller", null),
+        new("Adventure", null),
+        new("Literary Fiction", null),
+        new("Coming-of-Age", null),
+        new("Satire", null),
+        new("Dystopian", null),
+        new("Utopian", null),
+        new("Magical Realism", null),
+        new("Biographical Fiction", null),
+        new("Western", null),
+        new("Graphic Novels", null),
+        new("Short Story Collections", null),
+    };
+}

--- a/BookTracker.Web/Components/Pages/Books/Add.razor
+++ b/BookTracker.Web/Components/Pages/Books/Add.razor
@@ -113,30 +113,38 @@
             <div class="card">
                 <div class="card-header bg-white"><h2 class="h5 mb-0">Genres</h2></div>
                 <div class="card-body">
-                    @if (existingGenres.Count == 0)
-                    {
-                        <p class="text-muted small mb-3">No genres yet — add some below.</p>
-                    }
-                    else
-                    {
-                        <div class="row row-cols-2 row-cols-md-3 row-cols-lg-4 g-2 mb-3">
-                            @foreach (var g in existingGenres)
-                            {
-                                var id = $"genre-{g.Id}";
-                                <div class="col">
-                                    <div class="form-check">
-                                        <input class="form-check-input" type="checkbox" id="@id"
-                                               checked="@Input.SelectedGenreIds.Contains(g.Id)"
-                                               @onchange="e => ToggleGenre(g.Id, (bool)e.Value!)" />
-                                        <label class="form-check-label" for="@id">@g.Name</label>
-                                    </div>
+                    <div class="row g-3">
+                        @foreach (var top in topLevelGenres)
+                        {
+                            <div class="col-md-6 col-lg-4">
+                                <div class="form-check">
+                                    <input class="form-check-input" type="checkbox" id="@($"genre-{top.Id}")"
+                                           checked="@Input.SelectedGenreIds.Contains(top.Id)"
+                                           @onchange="e => ToggleGenre(top.Id, (bool)e.Value!)" />
+                                    <label class="form-check-label fw-semibold" for="@($"genre-{top.Id}")">@top.Name</label>
                                 </div>
+                                @foreach (var child in top.Children.OrderBy(c => c.Name))
+                                {
+                                    <div class="form-check ms-4">
+                                        <input class="form-check-input" type="checkbox" id="@($"genre-{child.Id}")"
+                                               checked="@Input.SelectedGenreIds.Contains(child.Id)"
+                                               @onchange="e => ToggleGenre(child.Id, (bool)e.Value!)" />
+                                        <label class="form-check-label" for="@($"genre-{child.Id}")">@child.Name</label>
+                                    </div>
+                                }
+                            </div>
+                        }
+                    </div>
+                    @if (lookupCandidates.Count > 0)
+                    {
+                        <div class="mt-3 pt-3 border-top">
+                            <small class="text-muted d-block mb-1">Lookup returned (fuzzy-matched against the list above):</small>
+                            @foreach (var c in lookupCandidates)
+                            {
+                                <span class="badge bg-light text-dark border me-1 mb-1">@c</span>
                             }
                         </div>
                     }
-                    <label class="form-label">Additional genres (comma-separated)</label>
-                    <InputText @bind-Value="Input.NewGenres" class="form-control" placeholder="Science Fiction, Satire" />
-                    <div class="form-text">Any new names will be added to the shared genre list.</div>
                 </div>
             </div>
         </div>
@@ -212,16 +220,28 @@
     bool lookingUp;
     bool saving;
 
-    List<GenreOption> existingGenres = [];
+    List<GenreNode> topLevelGenres = [];
+    Dictionary<int, GenreNode> genreById = [];
     List<PublisherOption> existingPublishers = [];
+    List<string> lookupCandidates = [];
 
     protected override async Task OnInitializedAsync()
     {
         await using var db = await DbFactory.CreateDbContextAsync();
-        existingGenres = await db.Genres
+        var all = await db.Genres
             .OrderBy(g => g.Name)
-            .Select(g => new GenreOption(g.Id, g.Name))
+            .Select(g => new GenreNode(g.Id, g.Name, g.ParentGenreId))
             .ToListAsync();
+        genreById = all.ToDictionary(g => g.Id);
+        foreach (var g in all.Where(g => g.ParentGenreId.HasValue))
+        {
+            if (genreById.TryGetValue(g.ParentGenreId!.Value, out var parent))
+            {
+                parent.Children.Add(g);
+            }
+        }
+        topLevelGenres = all.Where(g => g.ParentGenreId is null).OrderBy(g => g.Name).ToList();
+
         existingPublishers = await db.Publishers
             .OrderBy(p => p.Name)
             .Select(p => new PublisherOption(p.Id, p.Name))
@@ -233,10 +253,17 @@
         if (isChecked)
         {
             if (!Input.SelectedGenreIds.Contains(id)) Input.SelectedGenreIds.Add(id);
+            // Auto-select the parent so a sub-genre tick implies its top-level genre.
+            if (genreById.TryGetValue(id, out var node) && node.ParentGenreId is int parentId
+                && !Input.SelectedGenreIds.Contains(parentId))
+            {
+                Input.SelectedGenreIds.Add(parentId);
+            }
         }
         else
         {
             Input.SelectedGenreIds.Remove(id);
+            // Un-checking a parent leaves children alone — they're independent picks.
         }
     }
 
@@ -267,24 +294,15 @@
             if (string.IsNullOrWhiteSpace(Input.Isbn)) Input.Isbn = result.Isbn;
             Input.DatePrinted ??= result.DatePrinted;
 
-            var extras = new List<string>();
-            foreach (var candidate in result.GenreCandidates)
+            lookupCandidates = result.GenreCandidates.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+            foreach (var candidate in lookupCandidates)
             {
-                var match = existingGenres.FirstOrDefault(g => string.Equals(g.Name, candidate, StringComparison.OrdinalIgnoreCase));
+                var match = genreById.Values.FirstOrDefault(g => FuzzyGenreMatch(candidate, g.Name));
                 if (match is not null)
                 {
-                    if (!Input.SelectedGenreIds.Contains(match.Id)) Input.SelectedGenreIds.Add(match.Id);
-                }
-                else
-                {
-                    extras.Add(candidate);
+                    ToggleGenre(match.Id, true);
                 }
             }
-            var merged = (Input.NewGenres ?? "")
-                .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-                .Concat(extras)
-                .Distinct(StringComparer.OrdinalIgnoreCase);
-            Input.NewGenres = string.Join(", ", merged);
 
             lookupMessage = $"Prefilled from {result.Source}. Edit anything before saving.";
         }
@@ -304,29 +322,6 @@
             var selectedGenres = await db.Genres
                 .Where(g => Input.SelectedGenreIds.Contains(g.Id))
                 .ToListAsync();
-
-            var newGenreNames = (Input.NewGenres ?? "")
-                .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .ToList();
-
-            foreach (var name in newGenreNames)
-            {
-                var existing = await db.Genres.FirstOrDefaultAsync(g => g.Name == name);
-                if (existing is not null)
-                {
-                    if (!selectedGenres.Any(g => g.Id == existing.Id))
-                    {
-                        selectedGenres.Add(existing);
-                    }
-                }
-                else
-                {
-                    var created = new Genre { Name = name };
-                    db.Genres.Add(created);
-                    selectedGenres.Add(created);
-                }
-            }
 
             Publisher? publisher = null;
             var publisherName = Input.Publisher?.Trim();
@@ -389,7 +384,28 @@
         _ => c.ToString()
     };
 
-    public record GenreOption(int Id, string Name);
+    // Match looser-than-exact: normalize (lowercase, alphanumeric only) and
+    // accept either-side substring containment. Lets "Fantasy fiction",
+    // "Epic fantasy", "Fantasy — High" etc. all match the relevant preset.
+    private static bool FuzzyGenreMatch(string candidate, string preset)
+    {
+        var nc = Normalize(candidate);
+        var np = Normalize(preset);
+        if (nc.Length == 0 || np.Length == 0) return false;
+        return nc == np || nc.Contains(np) || np.Contains(nc);
+    }
+
+    private static string Normalize(string s) =>
+        new string(s.Where(char.IsLetterOrDigit).ToArray()).ToLowerInvariant();
+
+    public class GenreNode(int id, string name, int? parentGenreId)
+    {
+        public int Id { get; } = id;
+        public string Name { get; } = name;
+        public int? ParentGenreId { get; } = parentGenreId;
+        public List<GenreNode> Children { get; } = [];
+    }
+
     public record PublisherOption(int Id, string Name);
 
     public class AddBookInput
@@ -416,8 +432,6 @@
         public string? DefaultCoverArtUrl { get; set; }
 
         public List<int> SelectedGenreIds { get; set; } = [];
-
-        public string? NewGenres { get; set; }
 
         [Required, StringLength(20)]
         [RegularExpression(@"^(97(8|9))?\d{9}(\d|X|x)$", ErrorMessage = "Enter a valid 10- or 13-digit ISBN.")]


### PR DESCRIPTION
Genre becomes self-referential (ParentGenreId, ParentGenre, Children navs) with Restrict on delete. The Genres table is no longer free-text: GenreSeed.cs holds the canonical Fictionary list (parents + children), and the AddGenreHierarchyAndSeed migration:
  - adds the parent FK column + index
  - inserts any missing preset genres (parents first, sub-genres with parent lookup by name)
  - attaches a parent to any pre-existing rows whose names match a sub-genre
  - deletes BookGenre links for non-preset genres
  - deletes the orphan non-preset Genres rows

Add page: replaces the flat checkbox grid + 'additional genres' text input with a tree-style picker (top-level checkboxes with indented sub-genres). Ticking a sub-genre auto-ticks its parent.

Lookup flow: GenreCandidates from Open Library / Google Books are fuzzy-matched (normalize to alphanumerics + lowercase, then either-side substring containment) against the preset list. Matches are auto-ticked; the raw candidate list is shown as badges below the picker so the user can see what came back even when nothing matched.

Removed AddBookInput.NewGenres and the corresponding find-or-create loop on save — the taxonomy is now closed.