### PR TITLE
feat: add book list page with filtering and pagination

### DIFF
--- a/BookTracker.Web/Components/Layout/MainLayout.razor
+++ b/BookTracker.Web/Components/Layout/MainLayout.razor
@@ -14,6 +14,9 @@
                         <NavLink class="nav-link text-dark" href="" Match="NavLinkMatch.All">Home</NavLink>
                     </li>
                     <li class="nav-item">
+                        <NavLink class="nav-link text-dark" href="books">Library</NavLink>
+                    </li>
+                    <li class="nav-item">
                         <NavLink class="nav-link text-dark" href="books/add">Add book</NavLink>
                     </li>
                     <li class="nav-item">

--- a/BookTracker.Web/Components/Pages/Books/List.razor
+++ b/BookTracker.Web/Components/Pages/Books/List.razor
@@ -1,0 +1,338 @@
+@page "/books"
+@inject IDbContextFactory<BookTrackerDbContext> DbFactory
+@inject NavigationManager Nav
+
+<PageTitle>Library - BookTracker</PageTitle>
+
+<h1 class="mb-3">Library</h1>
+
+<div class="card mb-4">
+    <div class="card-body">
+        <div class="row g-3 align-items-end">
+            <div class="col-md-3">
+                <label class="form-label small text-muted">Search</label>
+                <input type="text" class="form-control" placeholder="Title or author..." @bind="searchTerm" @bind:event="oninput" @onkeyup="HandleSearchKeyUp" />
+            </div>
+            <div class="col-md-2">
+                <label class="form-label small text-muted">Category</label>
+                <select class="form-select" @bind="selectedCategory" @bind:after="ApplyFiltersAsync">
+                    <option value="">All</option>
+                    <option value="Fiction">Fiction</option>
+                    <option value="NonFiction">Non-Fiction</option>
+                </select>
+            </div>
+            <div class="col-md-2">
+                <label class="form-label small text-muted">Genre</label>
+                <select class="form-select" @bind="selectedGenreId" @bind:after="ApplyFiltersAsync">
+                    <option value="0">All</option>
+                    @foreach (var g in allGenres)
+                    {
+                        var prefix = g.ParentGenreId.HasValue ? "\u00A0\u00A0\u00A0\u00A0" : "";
+                        <option value="@g.Id">@prefix@g.Name</option>
+                    }
+                </select>
+            </div>
+            <div class="col-md-2">
+                <label class="form-label small text-muted">Tag</label>
+                <select class="form-select" @bind="selectedTagId" @bind:after="ApplyFiltersAsync">
+                    <option value="0">All</option>
+                    @foreach (var t in allTags)
+                    {
+                        <option value="@t.Id">@t.Name</option>
+                    }
+                </select>
+            </div>
+            <div class="col-md-2">
+                <label class="form-label small text-muted">Author</label>
+                <input type="text" class="form-control" placeholder="Author..." list="author-filter-options" @bind="selectedAuthor" @bind:after="ApplyFiltersAsync" />
+                <datalist id="author-filter-options">
+                    @foreach (var a in allAuthors)
+                    {
+                        <option value="@a"></option>
+                    }
+                </datalist>
+            </div>
+            <div class="col-md-1">
+                <button type="button" class="btn btn-outline-secondary w-100" @onclick="ClearFiltersAsync" title="Clear filters">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
+@if (loading)
+{
+    <div class="text-center py-5">
+        <div class="spinner-border" role="status">
+            <span class="visually-hidden">Loading...</span>
+        </div>
+    </div>
+}
+else if (books.Count == 0)
+{
+    <div class="text-center py-5 text-muted">
+        <p class="mb-2">No books found.</p>
+        <a href="/books/add" class="btn btn-primary btn-sm">Add your first book</a>
+    </div>
+}
+else
+{
+    <div class="table-responsive">
+        <table class="table table-hover align-middle">
+            <thead class="table-light">
+                <tr>
+                    <th style="width: 60px;"></th>
+                    <th>Title</th>
+                    <th>Author</th>
+                    <th>Genres</th>
+                    <th>Tags</th>
+                    <th>Status</th>
+                    <th style="width: 110px;">Rating</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var book in books)
+                {
+                    <tr role="button" @onclick="() => NavigateToEdit(book.Id)" style="cursor: pointer;">
+                        <td>
+                            @if (!string.IsNullOrWhiteSpace(book.CoverUrl))
+                            {
+                                <img src="@book.CoverUrl" alt="" class="rounded" style="width: 40px; height: 56px; object-fit: cover;" />
+                            }
+                            else
+                            {
+                                <div class="rounded bg-light d-flex align-items-center justify-content-center" style="width: 40px; height: 56px;">
+                                    <span class="text-muted small">--</span>
+                                </div>
+                            }
+                        </td>
+                        <td>
+                            <div class="fw-semibold">@book.Title</div>
+                            @if (!string.IsNullOrWhiteSpace(book.Subtitle))
+                            {
+                                <div class="text-muted small">@book.Subtitle</div>
+                            }
+                        </td>
+                        <td>@book.Author</td>
+                        <td>
+                            @foreach (var genre in book.Genres)
+                            {
+                                <span class="badge bg-light text-dark border me-1 mb-1">@genre</span>
+                            }
+                        </td>
+                        <td>
+                            @foreach (var tag in book.Tags)
+                            {
+                                <span class="badge bg-info text-dark me-1 mb-1">@tag</span>
+                            }
+                        </td>
+                        <td>
+                            <span class="badge @StatusBadgeClass(book.Status)">@book.Status</span>
+                        </td>
+                        <td>
+                            @for (int i = 1; i <= 5; i++)
+                            {
+                                var filled = i <= book.Rating;
+                                <span class="@(filled ? "text-warning" : "text-muted" )" style="font-size: 0.85rem;">&#9733;</span>
+                            }
+                        </td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    </div>
+
+    @if (totalPages > 1)
+    {
+        <nav aria-label="Book list pagination">
+            <ul class="pagination justify-content-center">
+                <li class="page-item @(currentPage <= 1 ? "disabled" : "")">
+                    <button class="page-link" @onclick="() => GoToPageAsync(currentPage - 1)" disabled="@(currentPage <= 1)">Previous</button>
+                </li>
+                @for (int p = 1; p <= totalPages; p++)
+                {
+                    var page = p;
+                    <li class="page-item @(page == currentPage ? "active" : "")">
+                        <button class="page-link" @onclick="() => GoToPageAsync(page)">@(page)</button>
+                    </li>
+                }
+                <li class="page-item @(currentPage >= totalPages ? "disabled" : "")">
+                    <button class="page-link" @onclick="() => GoToPageAsync(currentPage + 1)" disabled="@(currentPage >= totalPages)">Next</button>
+                </li>
+            </ul>
+        </nav>
+    }
+
+    <div class="text-center text-muted small mb-3">
+        Showing @((currentPage - 1) * PageSize + 1)–@Math.Min(currentPage * PageSize, totalCount) of @totalCount books
+    </div>
+}
+
+@code {
+    private const int PageSize = 20;
+
+    private bool loading = true;
+    private List<BookListItem> books = [];
+    private int totalCount;
+    private int currentPage = 1;
+    private int totalPages;
+
+    private string searchTerm = "";
+    private string selectedCategory = "";
+    private int selectedGenreId;
+    private int selectedTagId;
+    private string selectedAuthor = "";
+
+    private List<GenreOption> allGenres = [];
+    private List<TagOption> allTags = [];
+    private List<string> allAuthors = [];
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadFilterOptionsAsync();
+        await LoadBooksAsync();
+    }
+
+    private async Task LoadFilterOptionsAsync()
+    {
+        await using var db = await DbFactory.CreateDbContextAsync();
+
+        var genres = await db.Genres
+            .OrderBy(g => g.Name)
+            .Select(g => new GenreOption(g.Id, g.Name, g.ParentGenreId))
+            .ToListAsync();
+
+        // Build hierarchical list: parent then children
+        var topLevel = genres.Where(g => g.ParentGenreId is null).OrderBy(g => g.Name).ToList();
+        allGenres = [];
+        foreach (var parent in topLevel)
+        {
+            allGenres.Add(parent);
+            var children = genres.Where(g => g.ParentGenreId == parent.Id).OrderBy(g => g.Name);
+            allGenres.AddRange(children);
+        }
+
+        allTags = await db.Tags
+            .OrderBy(t => t.Name)
+            .Select(t => new TagOption(t.Id, t.Name))
+            .ToListAsync();
+
+        allAuthors = await db.Books
+            .Select(b => b.Author)
+            .Distinct()
+            .OrderBy(a => a)
+            .ToListAsync();
+    }
+
+    private async Task LoadBooksAsync()
+    {
+        loading = true;
+        StateHasChanged();
+
+        await using var db = await DbFactory.CreateDbContextAsync();
+
+        IQueryable<Book> query = db.Books
+            .Include(b => b.Genres)
+            .Include(b => b.Tags);
+
+        if (!string.IsNullOrWhiteSpace(searchTerm))
+        {
+            var term = searchTerm.Trim();
+            query = query.Where(b => b.Title.Contains(term) || b.Author.Contains(term));
+        }
+
+        if (!string.IsNullOrEmpty(selectedCategory) && Enum.TryParse<BookCategory>(selectedCategory, out var cat))
+        {
+            query = query.Where(b => b.Category == cat);
+        }
+
+        if (selectedGenreId > 0)
+        {
+            query = query.Where(b => b.Genres.Any(g => g.Id == selectedGenreId));
+        }
+
+        if (selectedTagId > 0)
+        {
+            query = query.Where(b => b.Tags.Any(t => t.Id == selectedTagId));
+        }
+
+        if (!string.IsNullOrWhiteSpace(selectedAuthor))
+        {
+            var author = selectedAuthor.Trim();
+            query = query.Where(b => b.Author == author);
+        }
+
+        totalCount = await query.CountAsync();
+        totalPages = Math.Max(1, (int)Math.Ceiling(totalCount / (double)PageSize));
+        if (currentPage > totalPages) currentPage = totalPages;
+
+        books = await query
+            .OrderByDescending(b => b.DateAdded)
+            .Skip((currentPage - 1) * PageSize)
+            .Take(PageSize)
+            .Select(b => new BookListItem(
+                b.Id,
+                b.Title,
+                b.Subtitle,
+                b.Author,
+                b.DefaultCoverArtUrl,
+                b.Status,
+                b.Rating,
+                b.Genres.Select(g => g.Name).ToList(),
+                b.Tags.Select(t => t.Name).ToList()
+            ))
+            .ToListAsync();
+
+        loading = false;
+    }
+
+    private async Task ApplyFiltersAsync()
+    {
+        currentPage = 1;
+        await LoadBooksAsync();
+    }
+
+    private async Task HandleSearchKeyUp(KeyboardEventArgs e)
+    {
+        if (e.Key == "Enter")
+        {
+            await ApplyFiltersAsync();
+        }
+    }
+
+    private async Task ClearFiltersAsync()
+    {
+        searchTerm = "";
+        selectedCategory = "";
+        selectedGenreId = 0;
+        selectedTagId = 0;
+        selectedAuthor = "";
+        currentPage = 1;
+        await LoadBooksAsync();
+    }
+
+    private async Task GoToPageAsync(int page)
+    {
+        if (page < 1 || page > totalPages) return;
+        currentPage = page;
+        await LoadBooksAsync();
+    }
+
+    private void NavigateToEdit(int bookId) => Nav.NavigateTo($"/books/{bookId}/edit");
+
+    private static string StatusBadgeClass(BookStatus status) => status switch
+    {
+        BookStatus.Reading => "bg-primary",
+        BookStatus.Read => "bg-success",
+        BookStatus.Unread => "bg-secondary",
+        _ => "bg-secondary"
+    };
+
+    private record BookListItem(
+        int Id, string Title, string? Subtitle, string Author, string? CoverUrl,
+        BookStatus Status, int Rating, List<string> Genres, List<string> Tags);
+
+    private record GenreOption(int Id, string Name, int? ParentGenreId);
+    private record TagOption(int Id, string Name);
+}


### PR DESCRIPTION
New /books page showing all books in a table with cover thumbnails, genre/tag chips, status badges, and star ratings. Filter by search term, category, genre, tag, or author. Paginated at 20 per page. Rows link to /books/{id}/edit (edit page coming in a later PR). Adds "Library" nav link.