### PR TITLE
chore: add Dependabot for NuGet and JS dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+
+updates:
+  # NuGet packages (C#)
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "nuget"
+    open-pull-requests-limit: 10
+
+  # npm packages (vendored JS libraries like html5-qrcode)
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "javascript"
+    open-pull-requests-limit: 5

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "private": true,
+  "description": "Dependency manifest for Dependabot — not used for builds. Vendored JS libraries are tracked here so Dependabot can flag updates and security patches.",
+  "dependencies": {
+    "html5-qrcode": "2.3.8"
+  }
+}


### PR DESCRIPTION
Configures weekly Dependabot checks for both NuGet packages and vendored JS libraries. Adds a minimal package.json (private, not used for builds) so Dependabot can track html5-qrcode and any future static JS deps for version updates and security advisories.