### PR TITLE
feat: add remove row from bulk grid and delete book/copy with confirm…

### DIFF
--- a/BookTracker.Web/Components/Pages/Books/BulkAdd.razor
+++ b/BookTracker.Web/Components/Pages/Books/BulkAdd.razor
@@ -159,42 +159,47 @@
                                     }
                                 </td>
                                 <td>
-                                    @if (row.Action == RowAction.Pending)
-                                    {
-                                        @if (row.Status == RowStatus.Found)
+                                    <div class="d-flex gap-1 align-items-center">
+                                        @if (row.Action == RowAction.Pending)
                                         {
-                                            <div class="btn-group btn-group-sm">
-                                                @if (row.IsDuplicate)
-                                                {
-                                                    <button type="button" class="btn btn-outline-success" @onclick="() => AcceptRowAsync(row)" title="Add another copy">
-                                                        Add copy
+                                            @if (row.Status == RowStatus.Found)
+                                            {
+                                                <div class="btn-group btn-group-sm">
+                                                    @if (row.IsDuplicate)
+                                                    {
+                                                        <button type="button" class="btn btn-outline-success" @onclick="() => AcceptRowAsync(row)" title="Add another copy">
+                                                            Add copy
+                                                        </button>
+                                                        <button type="button" class="btn btn-outline-secondary" @onclick="() => row.Action = RowAction.Duplicate" title="Skip duplicate">
+                                                            Skip
+                                                        </button>
+                                                    }
+                                                    else
+                                                    {
+                                                        <button type="button" class="btn btn-outline-success" @onclick="() => AcceptRowAsync(row)">
+                                                            Accept
+                                                        </button>
+                                                    }
+                                                    <button type="button" class="btn btn-outline-warning" @onclick="() => FollowUpRowAsync(row)">
+                                                        Follow-up
                                                     </button>
-                                                    <button type="button" class="btn btn-outline-secondary" @onclick="() => row.Action = RowAction.Duplicate" title="Skip duplicate">
-                                                        Skip
-                                                    </button>
-                                                }
-                                                else
-                                                {
-                                                    <button type="button" class="btn btn-outline-success" @onclick="() => AcceptRowAsync(row)">
-                                                        Accept
-                                                    </button>
-                                                }
-                                                <button type="button" class="btn btn-outline-warning" @onclick="() => FollowUpRowAsync(row)">
-                                                    Follow-up
+                                                </div>
+                                            }
+                                            else if (row.Status == RowStatus.NotFound)
+                                            {
+                                                <button type="button" class="btn btn-outline-warning btn-sm" @onclick="() => FollowUpNotFoundAsync(row)">
+                                                    Add as follow-up
                                                 </button>
-                                            </div>
+                                            }
                                         }
-                                        else if (row.Status == RowStatus.NotFound)
+                                        else
                                         {
-                                            <button type="button" class="btn btn-outline-warning btn-sm" @onclick="() => FollowUpNotFoundAsync(row)">
-                                                Add as follow-up
-                                            </button>
+                                            <span class="text-muted small">Done</span>
                                         }
-                                    }
-                                    else
-                                    {
-                                        <span class="text-muted small">Done</span>
-                                    }
+                                        <button type="button" class="btn btn-outline-danger btn-sm ms-1" @onclick="() => RemoveRow(row)" title="Remove from grid">
+                                            &times;
+                                        </button>
+                                    </div>
                                 </td>
                             </tr>
                         }
@@ -284,6 +289,8 @@
         }
         dotNetRef?.Dispose();
     }
+
+    private void RemoveRow(DiscoveryRow row) => rows.Remove(row);
 
     private async Task AddIsbnAsync()
     {

--- a/BookTracker.Web/Components/Pages/Books/Edit.razor
+++ b/BookTracker.Web/Components/Pages/Books/Edit.razor
@@ -147,10 +147,21 @@ else
                                                     <td>@(copy.PublisherName ?? "—")</td>
                                                     <td>@(copy.DatePrinted?.ToString("yyyy-MM-dd") ?? "—")</td>
                                                     <td>
-                                                        <div class="btn-group btn-group-sm">
-                                                            <button type="button" class="btn btn-outline-primary" @onclick="() => StartEditCopy(copy)">Edit</button>
-                                                            <button type="button" class="btn btn-outline-danger" @onclick="() => DeleteCopyAsync(copy)">Delete</button>
-                                                        </div>
+                                                        @if (confirmingDeleteCopyId == copy.Id)
+                                                        {
+                                                            <div class="d-flex align-items-center gap-1">
+                                                                <span class="text-danger small">Delete?</span>
+                                                                <button type="button" class="btn btn-danger btn-sm" @onclick="() => DeleteCopyAsync(copy)">Yes</button>
+                                                                <button type="button" class="btn btn-outline-secondary btn-sm" @onclick="() => confirmingDeleteCopyId = null">No</button>
+                                                            </div>
+                                                        }
+                                                        else
+                                                        {
+                                                            <div class="btn-group btn-group-sm">
+                                                                <button type="button" class="btn btn-outline-primary" @onclick="() => StartEditCopy(copy)">Edit</button>
+                                                                <button type="button" class="btn btn-outline-danger" @onclick="() => confirmingDeleteCopyId = copy.Id">Delete</button>
+                                                            </div>
+                                                        }
                                                     </td>
                                                 </tr>
                                             }
@@ -183,6 +194,24 @@ else
                     Save changes
                 </button>
                 <a class="btn btn-outline-secondary" href="/books">Back to library</a>
+                <div class="ms-auto">
+                    @if (confirmingDeleteBook)
+                    {
+                        <span class="me-2 text-danger fw-semibold">Delete this book and all its copies?</span>
+                        <button type="button" class="btn btn-danger btn-sm" @onclick="DeleteBookAsync" disabled="@deleting">
+                            @if (deleting)
+                            {
+                                <span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>
+                            }
+                            Yes, delete
+                        </button>
+                        <button type="button" class="btn btn-outline-secondary btn-sm" @onclick="() => confirmingDeleteBook = false">Cancel</button>
+                    }
+                    else
+                    {
+                        <button type="button" class="btn btn-outline-danger" @onclick="() => confirmingDeleteBook = true">Delete book</button>
+                    }
+                </div>
             </div>
         </div>
     </EditForm>
@@ -212,6 +241,11 @@ else
     // Inline copy editing
     private int? editingCopyId;
     private CopyEditInput editCopyInput = new();
+    private int? confirmingDeleteCopyId;
+
+    // Book deletion
+    private bool confirmingDeleteBook;
+    private bool deleting;
 
     protected override async Task OnInitializedAsync()
     {
@@ -401,6 +435,27 @@ else
             await db.SaveChangesAsync();
         }
         copies.RemoveAll(c => c.Id == copy.Id);
+        confirmingDeleteCopyId = null;
+    }
+
+    private async Task DeleteBookAsync()
+    {
+        deleting = true;
+        try
+        {
+            await using var db = await DbFactory.CreateDbContextAsync();
+            var book = await db.Books.FindAsync(BookId);
+            if (book is not null)
+            {
+                db.Books.Remove(book);
+                await db.SaveChangesAsync();
+            }
+            Nav.NavigateTo("/books");
+        }
+        finally
+        {
+            deleting = false;
+        }
     }
 
     // Save book metadata


### PR DESCRIPTION
…ation

Bulk Add: each row in the discovery grid now has an X button to remove it (miss-scans, duplicates, or already-processed rows).

Edit page: "Delete book" button with inline confirmation prompt deletes the book and all copies (cascade), then redirects to the library. Copy delete also now has inline Yes/No confirmation instead of deleting immediately on click.