### PR TITLE
refactor: extract ViewModels from Razor components (MVVM)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,3 +15,4 @@ jobs:
           dotnet-version: '10.0.x'
       - run: dotnet restore BookTracker.slnx
       - run: dotnet build BookTracker.slnx --configuration Release --no-restore
+      - run: dotnet test BookTracker.slnx --configuration Release --no-build --verbosity normal

--- a/BookTracker.Tests/BookTracker.Tests.csproj
+++ b/BookTracker.Tests/BookTracker.Tests.csproj
@@ -1,0 +1,28 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.6" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\BookTracker.Web\BookTracker.Web.csproj" />
+    <ProjectReference Include="..\BookTracker.Data\BookTracker.Data.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/BookTracker.Tests/TestDbContextFactory.cs
+++ b/BookTracker.Tests/TestDbContextFactory.cs
@@ -1,0 +1,26 @@
+using BookTracker.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookTracker.Tests;
+
+/// <summary>
+/// Creates in-memory DbContext instances for unit testing.
+/// Each factory instance uses a unique database name so tests don't interfere.
+/// </summary>
+public class TestDbContextFactory : IDbContextFactory<BookTrackerDbContext>
+{
+    private readonly DbContextOptions<BookTrackerDbContext> _options;
+
+    public TestDbContextFactory(string? databaseName = null)
+    {
+        databaseName ??= Guid.NewGuid().ToString();
+        _options = new DbContextOptionsBuilder<BookTrackerDbContext>()
+            .UseInMemoryDatabase(databaseName)
+            .Options;
+    }
+
+    public BookTrackerDbContext CreateDbContext()
+    {
+        return new BookTrackerDbContext(_options);
+    }
+}

--- a/BookTracker.Tests/ViewModels/BulkAddViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/BulkAddViewModelTests.cs
@@ -1,0 +1,188 @@
+using BookTracker.Data.Models;
+using BookTracker.Web.Services;
+using BookTracker.Web.ViewModels;
+using NSubstitute;
+
+namespace BookTracker.Tests.ViewModels;
+
+public class BulkAddViewModelTests
+{
+    private readonly TestDbContextFactory _factory = new();
+    private readonly IBookLookupService _lookup = Substitute.For<IBookLookupService>();
+
+    private BulkAddViewModel CreateVm() => new(_factory, _lookup);
+
+    [Fact]
+    public async Task AddIsbnAsync_AddsRowToGrid()
+    {
+        var vm = CreateVm();
+        vm.IsbnInput = "9780345391803";
+        vm.OnStateChanged = () => Task.CompletedTask;
+
+        await vm.AddIsbnAsync();
+
+        Assert.Single(vm.Rows);
+        Assert.Equal("9780345391803", vm.Rows[0].Isbn);
+        Assert.Equal("", vm.IsbnInput); // input is cleared
+    }
+
+    [Fact]
+    public async Task AddIsbnAsync_IgnoresDuplicateIsbnInGrid()
+    {
+        var vm = CreateVm();
+        vm.OnStateChanged = () => Task.CompletedTask;
+
+        vm.IsbnInput = "9780345391803";
+        await vm.AddIsbnAsync();
+        vm.IsbnInput = "9780345391803";
+        await vm.AddIsbnAsync();
+
+        Assert.Single(vm.Rows);
+    }
+
+    [Fact]
+    public async Task AddIsbnAsync_IgnoresEmptyInput()
+    {
+        var vm = CreateVm();
+        vm.IsbnInput = "  ";
+
+        await vm.AddIsbnAsync();
+
+        Assert.Empty(vm.Rows);
+    }
+
+    [Fact]
+    public async Task AddIsbnAsync_DetectsDuplicateInDatabase()
+    {
+        using (var db = _factory.CreateDbContext())
+        {
+            db.Books.Add(new Book
+            {
+                Title = "Existing",
+                Author = "Author",
+                Copies = [new BookCopy { Isbn = "9780345391803" }]
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var vm = CreateVm();
+        vm.OnStateChanged = () => Task.CompletedTask;
+        vm.IsbnInput = "9780345391803";
+
+        await vm.AddIsbnAsync();
+
+        Assert.True(vm.Rows[0].IsDuplicate);
+    }
+
+    [Fact]
+    public void RemoveRow_RemovesFromGrid()
+    {
+        var vm = CreateVm();
+        var row = new BulkAddViewModel.DiscoveryRow { Isbn = "123" };
+        vm.Rows.Add(row);
+
+        vm.RemoveRow(row);
+
+        Assert.Empty(vm.Rows);
+    }
+
+    [Fact]
+    public async Task AcceptRowAsync_CreatesBookAndCopy()
+    {
+        var vm = CreateVm();
+        var row = new BulkAddViewModel.DiscoveryRow
+        {
+            Isbn = "9780345391803",
+            Title = "The Hobbit",
+            Author = "J.R.R. Tolkien",
+            Status = BulkAddViewModel.RowStatus.Found
+        };
+
+        await vm.AcceptRowAsync(row);
+
+        Assert.Equal(BulkAddViewModel.RowAction.Accepted, row.Action);
+
+        using var db = _factory.CreateDbContext();
+        var book = db.Books.FirstOrDefault(b => b.Title == "The Hobbit");
+        Assert.NotNull(book);
+        Assert.Equal("J.R.R. Tolkien", book.Author);
+    }
+
+    [Fact]
+    public async Task FollowUpRowAsync_CreatesBookWithFollowUpTag()
+    {
+        // Seed the follow-up tag (like the real migration does)
+        using (var db = _factory.CreateDbContext())
+        {
+            db.Tags.Add(new Tag { Name = "follow-up" });
+            await db.SaveChangesAsync();
+        }
+
+        var vm = CreateVm();
+        var row = new BulkAddViewModel.DiscoveryRow
+        {
+            Isbn = "9780345391803",
+            Title = "The Hobbit",
+            Author = "J.R.R. Tolkien",
+            Status = BulkAddViewModel.RowStatus.Found
+        };
+
+        await vm.FollowUpRowAsync(row);
+
+        Assert.Equal(BulkAddViewModel.RowAction.FollowUp, row.Action);
+
+        using var db2 = _factory.CreateDbContext();
+        var book = db2.Books.FirstOrDefault(b => b.Title == "The Hobbit");
+        Assert.NotNull(book);
+    }
+
+    [Fact]
+    public async Task FollowUpNotFoundAsync_UsesDefaultTitle()
+    {
+        using (var db = _factory.CreateDbContext())
+        {
+            db.Tags.Add(new Tag { Name = "follow-up" });
+            await db.SaveChangesAsync();
+        }
+
+        var vm = CreateVm();
+        var row = new BulkAddViewModel.DiscoveryRow
+        {
+            Isbn = "1234567890",
+            Status = BulkAddViewModel.RowStatus.NotFound
+        };
+
+        await vm.FollowUpNotFoundAsync(row);
+
+        Assert.Equal(BulkAddViewModel.RowAction.FollowUp, row.Action);
+        Assert.StartsWith("Unknown book", row.Title);
+    }
+
+    [Fact]
+    public async Task AcceptAllFoundAsync_AcceptsOnlyFoundNonDuplicates()
+    {
+        var vm = CreateVm();
+        var found = new BulkAddViewModel.DiscoveryRow { Isbn = "111", Title = "A", Author = "A", Status = BulkAddViewModel.RowStatus.Found };
+        var duplicate = new BulkAddViewModel.DiscoveryRow { Isbn = "222", Title = "B", Author = "B", Status = BulkAddViewModel.RowStatus.Found, IsDuplicate = true };
+        var notFound = new BulkAddViewModel.DiscoveryRow { Isbn = "333", Status = BulkAddViewModel.RowStatus.NotFound };
+
+        vm.Rows.AddRange([found, duplicate, notFound]);
+
+        await vm.AcceptAllFoundAsync();
+
+        Assert.Equal(BulkAddViewModel.RowAction.Accepted, found.Action);
+        Assert.Equal(BulkAddViewModel.RowAction.Pending, duplicate.Action); // skipped
+        Assert.Equal(BulkAddViewModel.RowAction.Pending, notFound.Action); // skipped
+    }
+
+    [Theory]
+    [InlineData(BulkAddViewModel.RowAction.Accepted, "table-success")]
+    [InlineData(BulkAddViewModel.RowAction.FollowUp, "table-warning")]
+    [InlineData(BulkAddViewModel.RowAction.Duplicate, "table-secondary")]
+    [InlineData(BulkAddViewModel.RowAction.Pending, "")]
+    public void RowCssClass_ReturnsCorrectClass(BulkAddViewModel.RowAction action, string expected)
+    {
+        var row = new BulkAddViewModel.DiscoveryRow { Action = action };
+        Assert.Equal(expected, BulkAddViewModel.RowCssClass(row));
+    }
+}

--- a/BookTracker.Tests/ViewModels/GenrePickerViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/GenrePickerViewModelTests.cs
@@ -1,0 +1,81 @@
+using BookTracker.Data.Models;
+using BookTracker.Web.ViewModels;
+
+namespace BookTracker.Tests.ViewModels;
+
+public class GenrePickerViewModelTests
+{
+    [Fact]
+    public async Task InitializeAsync_LoadsHierarchicalGenres()
+    {
+        var factory = new TestDbContextFactory();
+        using (var db = factory.CreateDbContext())
+        {
+            var fantasy = new Genre { Id = 1, Name = "Fantasy" };
+            db.Genres.Add(fantasy);
+            db.Genres.Add(new Genre { Id = 2, Name = "High Fantasy", ParentGenreId = 1 });
+            db.Genres.Add(new Genre { Id = 3, Name = "Urban Fantasy", ParentGenreId = 1 });
+            db.Genres.Add(new Genre { Id = 4, Name = "Science Fiction" });
+            await db.SaveChangesAsync();
+        }
+
+        var vm = new GenrePickerViewModel(factory);
+        await vm.InitializeAsync();
+
+        Assert.Equal(2, vm.TopLevelGenres.Count);
+        var fantasyNode = vm.TopLevelGenres.First(g => g.Name == "Fantasy");
+        Assert.Equal(2, fantasyNode.Children.Count);
+    }
+
+    [Fact]
+    public async Task ToggleGenre_SelectingChild_AutoSelectsParent()
+    {
+        var factory = new TestDbContextFactory();
+        using (var db = factory.CreateDbContext())
+        {
+            db.Genres.Add(new Genre { Id = 1, Name = "Fantasy" });
+            db.Genres.Add(new Genre { Id = 2, Name = "High Fantasy", ParentGenreId = 1 });
+            await db.SaveChangesAsync();
+        }
+
+        var vm = new GenrePickerViewModel(factory);
+        await vm.InitializeAsync();
+
+        vm.ToggleGenre(2, true);
+
+        Assert.Contains(2, vm.SelectedGenreIds);
+        Assert.Contains(1, vm.SelectedGenreIds); // parent auto-selected
+    }
+
+    [Fact]
+    public async Task ToggleGenre_UnselectingParent_LeavesChildrenAlone()
+    {
+        var factory = new TestDbContextFactory();
+        using (var db = factory.CreateDbContext())
+        {
+            db.Genres.Add(new Genre { Id = 1, Name = "Fantasy" });
+            db.Genres.Add(new Genre { Id = 2, Name = "High Fantasy", ParentGenreId = 1 });
+            await db.SaveChangesAsync();
+        }
+
+        var vm = new GenrePickerViewModel(factory);
+        await vm.InitializeAsync();
+        vm.ToggleGenre(2, true); // selects child + parent
+
+        vm.ToggleGenre(1, false); // unselect parent
+
+        Assert.DoesNotContain(1, vm.SelectedGenreIds);
+        Assert.Contains(2, vm.SelectedGenreIds); // child stays
+    }
+
+    [Theory]
+    [InlineData("Fantasy fiction", "Fantasy", true)]
+    [InlineData("Epic fantasy", "Fantasy", true)]
+    [InlineData("Science", "Science Fiction", true)]
+    [InlineData("Romance", "Fantasy", false)]
+    [InlineData("", "Fantasy", false)]
+    public void FuzzyGenreMatch_MatchesCorrectly(string candidate, string preset, bool expected)
+    {
+        Assert.Equal(expected, GenrePickerViewModel.FuzzyGenreMatch(candidate, preset));
+    }
+}

--- a/BookTracker.Tests/ViewModels/HomeViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/HomeViewModelTests.cs
@@ -1,0 +1,73 @@
+using BookTracker.Data.Models;
+using BookTracker.Web.ViewModels;
+
+namespace BookTracker.Tests.ViewModels;
+
+public class HomeViewModelTests
+{
+    [Fact]
+    public async Task InitializeAsync_EmptyDatabase_ReturnsZeroCounts()
+    {
+        var factory = new TestDbContextFactory();
+        var vm = new HomeViewModel(factory);
+
+        await vm.InitializeAsync();
+
+        Assert.Equal(0, vm.TotalBooks);
+        Assert.Equal(0, vm.TotalAuthors);
+        Assert.Empty(vm.TopAuthors);
+        Assert.Empty(vm.TopGenres);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_WithBooks_ReturnsCounts()
+    {
+        var factory = new TestDbContextFactory();
+
+        // Seed some books
+        using (var db = factory.CreateDbContext())
+        {
+            db.Books.AddRange(
+                new Book { Title = "Book A", Author = "Author 1" },
+                new Book { Title = "Book B", Author = "Author 1" },
+                new Book { Title = "Book C", Author = "Author 2" }
+            );
+            await db.SaveChangesAsync();
+        }
+
+        var vm = new HomeViewModel(factory);
+        await vm.InitializeAsync();
+
+        Assert.Equal(3, vm.TotalBooks);
+        Assert.Equal(2, vm.TotalAuthors);
+        Assert.Equal(2, vm.TopAuthors.Count);
+        Assert.Equal("Author 1", vm.TopAuthors[0].Author);
+        Assert.Equal(2, vm.TopAuthors[0].Count);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_WithGenres_ReturnsTopGenres()
+    {
+        var factory = new TestDbContextFactory();
+
+        using (var db = factory.CreateDbContext())
+        {
+            var fantasy = new Genre { Name = "Fantasy" };
+            var sciFi = new Genre { Name = "Science Fiction" };
+
+            db.Books.AddRange(
+                new Book { Title = "Book A", Author = "A", Genres = [fantasy] },
+                new Book { Title = "Book B", Author = "B", Genres = [fantasy, sciFi] },
+                new Book { Title = "Book C", Author = "C", Genres = [sciFi] }
+            );
+            await db.SaveChangesAsync();
+        }
+
+        var vm = new HomeViewModel(factory);
+        await vm.InitializeAsync();
+
+        Assert.Equal(2, vm.TopGenres.Count);
+        Assert.Contains(vm.TopGenres, g => g.Genre == "Fantasy" && g.Count == 2);
+        Assert.Contains(vm.TopGenres, g => g.Genre == "Science Fiction" && g.Count == 2);
+    }
+}

--- a/BookTracker.Web/Components/Pages/Books/Add.razor
+++ b/BookTracker.Web/Components/Pages/Books/Add.razor
@@ -1,6 +1,5 @@
 @page "/books/add"
-@inject IDbContextFactory<BookTrackerDbContext> DbFactory
-@inject IBookLookupService Lookup
+@inject BookAddViewModel VM
 @inject NavigationManager Nav
 
 <PageTitle>Add a book - BookTracker</PageTitle>
@@ -16,9 +15,9 @@
                 <div class="card-body">
                     <label class="form-label fw-semibold">Look up by ISBN</label>
                     <div class="input-group">
-                        <InputText @bind-Value="lookupIsbn" class="form-control" placeholder="9780345391803" />
-                        <button type="button" class="btn btn-outline-primary" @onclick="LookupAsync" disabled="@lookingUp">
-                            @if (lookingUp)
+                        <InputText @bind-Value="VM.LookupIsbn" class="form-control" placeholder="9780345391803" />
+                        <button type="button" class="btn btn-outline-primary" @onclick="LookupAsync" disabled="@VM.LookingUp">
+                            @if (VM.LookingUp)
                             {
                                 <span class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>
                             }
@@ -26,32 +25,32 @@
                         </button>
                     </div>
                     <div class="form-text">Searches Open Library, then Google Books. Prefills the fields below — you can edit anything before saving.</div>
-                    @if (!string.IsNullOrEmpty(lookupMessage))
+                    @if (!string.IsNullOrEmpty(VM.LookupMessage))
                     {
-                        <div class="alert alert-info mt-3 mb-0 py-2">@lookupMessage</div>
+                        <div class="alert alert-info mt-3 mb-0 py-2">@VM.LookupMessage</div>
                     }
                 </div>
             </div>
         </div>
 
         <div class="col-12">
-            <BookForm Input="bookInput" />
+            <BookForm Input="VM.BookInput" />
         </div>
 
         <div class="col-12">
             <GenrePicker @ref="genrePicker"
                          SelectedGenreIds="selectedGenreIds"
                          SelectedGenreIdsChanged="ids => selectedGenreIds = ids"
-                         LookupCandidates="lookupCandidates" />
+                         LookupCandidates="VM.LookupCandidates" />
         </div>
 
         <div class="col-12">
-            <CopyForm Input="copyInput" Title="First copy" />
+            <CopyForm Input="VM.CopyInput" Title="First copy" />
         </div>
 
         <div class="col-12 d-flex gap-2">
-            <button type="submit" class="btn btn-primary" disabled="@saving">
-                @if (saving)
+            <button type="submit" class="btn btn-primary" disabled="@VM.Saving">
+                @if (VM.Saving)
                 {
                     <span class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>
                 }
@@ -63,114 +62,22 @@
 </EditForm>
 
 @code {
-    private BookForm.BookFormInput bookInput = new();
-    private CopyForm.CopyFormInput copyInput = new();
     private List<int> selectedGenreIds = [];
-    private List<string> lookupCandidates = [];
     private GenrePicker? genrePicker;
-
-    private string? lookupIsbn;
-    private string? lookupMessage;
-    private bool lookingUp;
-    private bool saving;
 
     private async Task LookupAsync()
     {
-        lookupMessage = null;
-        if (string.IsNullOrWhiteSpace(lookupIsbn))
+        if (genrePicker is not null)
         {
-            lookupMessage = "Enter an ISBN to look up.";
-            return;
-        }
-
-        lookingUp = true;
-        try
-        {
-            var result = await Lookup.LookupByIsbnAsync(lookupIsbn, CancellationToken.None);
-            if (result is null)
-            {
-                lookupMessage = $"No match found for ISBN {lookupIsbn}.";
-                return;
-            }
-
-            if (string.IsNullOrWhiteSpace(bookInput.Title)) bookInput.Title = result.Title ?? "";
-            if (string.IsNullOrWhiteSpace(bookInput.Subtitle)) bookInput.Subtitle = result.Subtitle;
-            if (string.IsNullOrWhiteSpace(bookInput.Author)) bookInput.Author = result.Author ?? "";
-            if (string.IsNullOrWhiteSpace(bookInput.DefaultCoverArtUrl)) bookInput.DefaultCoverArtUrl = result.CoverUrl;
-            if (string.IsNullOrWhiteSpace(copyInput.Isbn)) copyInput.Isbn = result.Isbn;
-            if (string.IsNullOrWhiteSpace(copyInput.Publisher)) copyInput.Publisher = result.Publisher;
-            copyInput.DatePrinted ??= result.DatePrinted;
-
-            lookupCandidates = result.GenreCandidates.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
-            if (genrePicker is not null)
-            {
-                await genrePicker.ApplyLookupCandidatesAsync(lookupCandidates);
-            }
-
-            lookupMessage = $"Prefilled from {result.Source}. Edit anything before saving.";
-        }
-        finally
-        {
-            lookingUp = false;
+            await VM.LookupAsync(genrePicker.ViewModel);
         }
     }
 
     private async Task SaveAsync()
     {
-        saving = true;
-        try
+        if (await VM.SaveAsync(selectedGenreIds))
         {
-            await using var db = await DbFactory.CreateDbContextAsync();
-
-            var selectedGenres = await db.Genres
-                .Where(g => selectedGenreIds.Contains(g.Id))
-                .ToListAsync();
-
-            Publisher? publisher = null;
-            var publisherName = copyInput.Publisher?.Trim();
-            if (!string.IsNullOrEmpty(publisherName))
-            {
-                publisher = await db.Publishers.FirstOrDefaultAsync(p => p.Name == publisherName);
-                if (publisher is null)
-                {
-                    publisher = new Publisher { Name = publisherName };
-                    db.Publishers.Add(publisher);
-                }
-            }
-
-            var book = new Book
-            {
-                Title = bookInput.Title!.Trim(),
-                Subtitle = string.IsNullOrWhiteSpace(bookInput.Subtitle) ? null : bookInput.Subtitle.Trim(),
-                Author = bookInput.Author!.Trim(),
-                Notes = string.IsNullOrWhiteSpace(bookInput.Notes) ? null : bookInput.Notes.Trim(),
-                Category = bookInput.Category,
-                Status = bookInput.Status,
-                Rating = bookInput.Rating,
-                DefaultCoverArtUrl = string.IsNullOrWhiteSpace(bookInput.DefaultCoverArtUrl) ? null : bookInput.DefaultCoverArtUrl.Trim(),
-                Genres = selectedGenres,
-                Copies =
-                [
-                    new BookCopy
-                    {
-                        Isbn = copyInput.Isbn!.Trim(),
-                        Format = copyInput.Format,
-                        DatePrinted = copyInput.DatePrinted,
-                        Condition = copyInput.Condition,
-                        Publisher = publisher,
-                        CustomCoverArtUrl = string.IsNullOrWhiteSpace(copyInput.CustomCoverArtUrl) ? null : copyInput.CustomCoverArtUrl.Trim()
-                    }
-                ]
-            };
-
-            db.Books.Add(book);
-            await db.SaveChangesAsync();
-
             Nav.NavigateTo("/");
-        }
-        finally
-        {
-            saving = false;
         }
     }
 }

--- a/BookTracker.Web/Components/Pages/Books/BulkAdd.razor
+++ b/BookTracker.Web/Components/Pages/Books/BulkAdd.razor
@@ -1,7 +1,6 @@
 @page "/books/bulk-add"
 @implements IAsyncDisposable
-@inject IDbContextFactory<BookTrackerDbContext> DbFactory
-@inject IBookLookupService Lookup
+@inject BulkAddViewModel VM
 @inject NavigationManager Nav
 @inject IJSRuntime JS
 
@@ -13,9 +12,9 @@
     <div class="card-body">
         <label class="form-label fw-semibold">Add ISBN</label>
         <div class="input-group" style="max-width: 500px;">
-            <input type="text" class="form-control" placeholder="9780345391803" @bind="isbnInput"
+            <input type="text" class="form-control" placeholder="9780345391803" @bind="VM.IsbnInput"
                    @onkeyup="HandleIsbnKeyUp" />
-            <button type="button" class="btn btn-outline-primary" @onclick="AddIsbnAsync" disabled="@string.IsNullOrWhiteSpace(isbnInput)">
+            <button type="button" class="btn btn-outline-primary" @onclick="AddIsbnAsync" disabled="@string.IsNullOrWhiteSpace(VM.IsbnInput)">
                 Add
             </button>
         </div>
@@ -49,23 +48,23 @@
     </div>
 }
 
-@if (rows.Count > 0)
+@if (VM.Rows.Count > 0)
 {
     <div class="card mb-4">
         <div class="card-header bg-white d-flex justify-content-between align-items-center">
-            <h2 class="h5 mb-0">Discovered books (@rows.Count)</h2>
+            <h2 class="h5 mb-0">Discovered books (@VM.Rows.Count)</h2>
             <div class="d-flex gap-2">
-                @if (rows.Any(r => r.Status == RowStatus.Found && r.Action == RowAction.Pending))
+                @if (VM.Rows.Any(r => r.Status == BulkAddViewModel.RowStatus.Found && r.Action == BulkAddViewModel.RowAction.Pending))
                 {
-                    <button type="button" class="btn btn-success btn-sm" @onclick="AcceptAllFoundAsync">
+                    <button type="button" class="btn btn-success btn-sm" @onclick="VM.AcceptAllFoundAsync">
                         Accept all found
                     </button>
                 }
-                @if (rows.Any(r => r.Action == RowAction.Accepted || r.Action == RowAction.FollowUp))
+                @if (VM.Rows.Any(r => r.Action == BulkAddViewModel.RowAction.Accepted || r.Action == BulkAddViewModel.RowAction.FollowUp))
                 {
                     <span class="text-muted small align-self-center">
-                        @rows.Count(r => r.Action == RowAction.Accepted) accepted,
-                        @rows.Count(r => r.Action == RowAction.FollowUp) follow-up
+                        @VM.Rows.Count(r => r.Action == BulkAddViewModel.RowAction.Accepted) accepted,
+                        @VM.Rows.Count(r => r.Action == BulkAddViewModel.RowAction.FollowUp) follow-up
                     </span>
                 }
             </div>
@@ -85,9 +84,9 @@
                         </tr>
                     </thead>
                     <tbody>
-                        @foreach (var row in rows)
+                        @foreach (var row in VM.Rows)
                         {
-                            <tr class="@RowCssClass(row)">
+                            <tr class="@BulkAddViewModel.RowCssClass(row)">
                                 <td>
                                     @if (!string.IsNullOrWhiteSpace(row.CoverUrl))
                                     {
@@ -102,7 +101,7 @@
                                 </td>
                                 <td class="font-monospace small">@row.Isbn</td>
                                 <td>
-                                    @if (row.Status == RowStatus.NotFound && row.Action != RowAction.FollowUp)
+                                    @if (row.Status == BulkAddViewModel.RowStatus.NotFound && row.Action != BulkAddViewModel.RowAction.FollowUp)
                                     {
                                         <input type="text" class="form-control form-control-sm" placeholder="Book title..."
                                                @bind="row.Title" />
@@ -114,7 +113,7 @@
                                 </td>
                                 <td>@(row.Author ?? "—")</td>
                                 <td>
-                                    @if (row.Status == RowStatus.Searching)
+                                    @if (row.Status == BulkAddViewModel.RowStatus.Searching)
                                     {
                                         <span class="spinner-border spinner-border-sm" role="status"></span>
                                     }
@@ -126,13 +125,13 @@
                                 <td>
                                     @switch (row.Action)
                                     {
-                                        case RowAction.Accepted:
+                                        case BulkAddViewModel.RowAction.Accepted:
                                             <span class="badge bg-success">Accepted</span>
                                             break;
-                                        case RowAction.FollowUp:
+                                        case BulkAddViewModel.RowAction.FollowUp:
                                             <span class="badge bg-warning text-dark">Follow-up</span>
                                             break;
-                                        case RowAction.Duplicate:
+                                        case BulkAddViewModel.RowAction.Duplicate:
                                             <span class="badge bg-secondary">Duplicate</span>
                                             break;
                                         default:
@@ -144,13 +143,13 @@
                                             {
                                                 switch (row.Status)
                                                 {
-                                                    case RowStatus.Found:
+                                                    case BulkAddViewModel.RowStatus.Found:
                                                         <span class="badge bg-info text-dark">Found</span>
                                                         break;
-                                                    case RowStatus.NotFound:
+                                                    case BulkAddViewModel.RowStatus.NotFound:
                                                         <span class="badge bg-danger">Not found</span>
                                                         break;
-                                                    case RowStatus.Searching:
+                                                    case BulkAddViewModel.RowStatus.Searching:
                                                         <span class="badge bg-light text-dark">Searching...</span>
                                                         break;
                                                 }
@@ -160,34 +159,34 @@
                                 </td>
                                 <td>
                                     <div class="d-flex gap-1 align-items-center">
-                                        @if (row.Action == RowAction.Pending)
+                                        @if (row.Action == BulkAddViewModel.RowAction.Pending)
                                         {
-                                            @if (row.Status == RowStatus.Found)
+                                            @if (row.Status == BulkAddViewModel.RowStatus.Found)
                                             {
                                                 <div class="btn-group btn-group-sm">
                                                     @if (row.IsDuplicate)
                                                     {
-                                                        <button type="button" class="btn btn-outline-success" @onclick="() => AcceptRowAsync(row)" title="Add another copy">
+                                                        <button type="button" class="btn btn-outline-success" @onclick="() => VM.AcceptRowAsync(row)" title="Add another copy">
                                                             Add copy
                                                         </button>
-                                                        <button type="button" class="btn btn-outline-secondary" @onclick="() => row.Action = RowAction.Duplicate" title="Skip duplicate">
+                                                        <button type="button" class="btn btn-outline-secondary" @onclick="() => row.Action = BulkAddViewModel.RowAction.Duplicate" title="Skip duplicate">
                                                             Skip
                                                         </button>
                                                     }
                                                     else
                                                     {
-                                                        <button type="button" class="btn btn-outline-success" @onclick="() => AcceptRowAsync(row)">
+                                                        <button type="button" class="btn btn-outline-success" @onclick="() => VM.AcceptRowAsync(row)">
                                                             Accept
                                                         </button>
                                                     }
-                                                    <button type="button" class="btn btn-outline-warning" @onclick="() => FollowUpRowAsync(row)">
+                                                    <button type="button" class="btn btn-outline-warning" @onclick="() => VM.FollowUpRowAsync(row)">
                                                         Follow-up
                                                     </button>
                                                 </div>
                                             }
-                                            else if (row.Status == RowStatus.NotFound)
+                                            else if (row.Status == BulkAddViewModel.RowStatus.NotFound)
                                             {
-                                                <button type="button" class="btn btn-outline-warning btn-sm" @onclick="() => FollowUpNotFoundAsync(row)">
+                                                <button type="button" class="btn btn-outline-warning btn-sm" @onclick="() => VM.FollowUpNotFoundAsync(row)">
                                                     Add as follow-up
                                                 </button>
                                             }
@@ -196,7 +195,7 @@
                                         {
                                             <span class="text-muted small">Done</span>
                                         }
-                                        <button type="button" class="btn btn-outline-danger btn-sm ms-1" @onclick="() => RemoveRow(row)" title="Remove from grid">
+                                        <button type="button" class="btn btn-outline-danger btn-sm ms-1" @onclick="() => VM.RemoveRow(row)" title="Remove from grid">
                                             &times;
                                         </button>
                                     </div>
@@ -209,7 +208,7 @@
         </div>
     </div>
 
-    @if (rows.Any(r => r.Action == RowAction.Accepted || r.Action == RowAction.FollowUp))
+    @if (VM.Rows.Any(r => r.Action == BulkAddViewModel.RowAction.Accepted || r.Action == BulkAddViewModel.RowAction.FollowUp))
     {
         <div class="d-flex gap-2">
             <a href="/books" class="btn btn-primary">View library</a>
@@ -218,18 +217,25 @@
 }
 
 @code {
-    private string isbnInput = "";
-    private List<DiscoveryRow> rows = [];
     private bool scannerActive;
     private string? scannerError;
     private DotNetObjectReference<BulkAdd>? dotNetRef;
 
+    protected override void OnInitialized()
+    {
+        VM.OnStateChanged = () => InvokeAsync(StateHasChanged);
+    }
+
     private async Task HandleIsbnKeyUp(KeyboardEventArgs e)
     {
         if (e.Key == "Enter")
-        {
             await AddIsbnAsync();
-        }
+    }
+
+    private async Task AddIsbnAsync()
+    {
+        await VM.AddIsbnAsync();
+        StateHasChanged();
     }
 
     private async Task ToggleScannerAsync()
@@ -244,7 +250,6 @@
         {
             scannerActive = true;
             dotNetRef ??= DotNetObjectReference.Create(this);
-            // Wait for the DOM element to render before starting the scanner
             StateHasChanged();
             await Task.Delay(100);
             await JS.InvokeVoidAsync("BarcodeScanner.start", "barcode-reader", dotNetRef);
@@ -254,18 +259,16 @@
     [JSInvokable]
     public async Task OnBarcodeScanned(string decodedText)
     {
-        // EAN-13 barcodes for books start with 978 or 979
         var isbn = decodedText.Trim();
         if (string.IsNullOrWhiteSpace(isbn)) return;
 
-        // Avoid adding the same ISBN that's already in the grid
-        if (rows.Any(r => string.Equals(r.Isbn, isbn, StringComparison.OrdinalIgnoreCase)))
+        if (VM.Rows.Any(r => string.Equals(r.Isbn, isbn, StringComparison.OrdinalIgnoreCase)))
             return;
 
         await InvokeAsync(async () =>
         {
-            isbnInput = isbn;
-            await AddIsbnAsync();
+            VM.IsbnInput = isbn;
+            await VM.AddIsbnAsync();
             StateHasChanged();
         });
     }
@@ -289,247 +292,4 @@
         }
         dotNetRef?.Dispose();
     }
-
-    private void RemoveRow(DiscoveryRow row) => rows.Remove(row);
-
-    private async Task AddIsbnAsync()
-    {
-        var isbn = isbnInput.Trim();
-        if (string.IsNullOrWhiteSpace(isbn)) return;
-
-        // Don't add same ISBN twice to the grid
-        if (rows.Any(r => string.Equals(r.Isbn, isbn, StringComparison.OrdinalIgnoreCase)))
-        {
-            isbnInput = "";
-            return;
-        }
-
-        var row = new DiscoveryRow { Isbn = isbn, Status = RowStatus.Searching };
-        rows.Insert(0, row);
-        isbnInput = "";
-        StateHasChanged();
-
-        // Check for duplicates in the database
-        await CheckDuplicateAsync(row);
-
-        // Fire-and-forget the lookup — updates the row and re-renders
-        _ = LookupRowAsync(row);
-    }
-
-    private async Task CheckDuplicateAsync(DiscoveryRow row)
-    {
-        await using var db = await DbFactory.CreateDbContextAsync();
-        row.IsDuplicate = await db.BookCopies.AnyAsync(c => c.Isbn == row.Isbn);
-    }
-
-    private async Task LookupRowAsync(DiscoveryRow row)
-    {
-        try
-        {
-            var result = await Lookup.LookupByIsbnAsync(row.Isbn, CancellationToken.None);
-            if (result is not null)
-            {
-                row.Title = result.Title;
-                row.Author = result.Author;
-                row.CoverUrl = result.CoverUrl;
-                row.Source = result.Source;
-                row.Publisher = result.Publisher;
-                row.Subtitle = result.Subtitle;
-                row.DatePrinted = result.DatePrinted;
-                row.GenreCandidates = result.GenreCandidates.ToList();
-                row.Status = RowStatus.Found;
-            }
-            else
-            {
-                row.Title = $"Unknown book — {row.Isbn}";
-                row.Status = RowStatus.NotFound;
-            }
-        }
-        catch
-        {
-            row.Title = $"Unknown book — {row.Isbn}";
-            row.Status = RowStatus.NotFound;
-        }
-
-        await InvokeAsync(StateHasChanged);
-    }
-
-    private async Task AcceptRowAsync(DiscoveryRow row)
-    {
-        await SaveBookAsync(row, followUp: false);
-        row.Action = RowAction.Accepted;
-    }
-
-    private async Task FollowUpRowAsync(DiscoveryRow row)
-    {
-        await SaveBookAsync(row, followUp: true);
-        row.Action = RowAction.FollowUp;
-    }
-
-    private async Task FollowUpNotFoundAsync(DiscoveryRow row)
-    {
-        if (string.IsNullOrWhiteSpace(row.Title))
-        {
-            row.Title = $"Unknown book — {row.Isbn}";
-        }
-        await SaveBookAsync(row, followUp: true);
-        row.Action = RowAction.FollowUp;
-    }
-
-    private async Task AcceptAllFoundAsync()
-    {
-        var pending = rows.Where(r => r.Status == RowStatus.Found && r.Action == RowAction.Pending && !r.IsDuplicate).ToList();
-        foreach (var row in pending)
-        {
-            await AcceptRowAsync(row);
-        }
-    }
-
-    private async Task SaveBookAsync(DiscoveryRow row, bool followUp)
-    {
-        await using var db = await DbFactory.CreateDbContextAsync();
-
-        // If it's a duplicate, just add a new copy to the existing book
-        if (row.IsDuplicate)
-        {
-            var existingCopy = await db.BookCopies
-                .Include(c => c.Book)
-                .FirstOrDefaultAsync(c => c.Isbn == row.Isbn);
-
-            if (existingCopy is not null)
-            {
-                var newCopy = new BookCopy
-                {
-                    BookId = existingCopy.BookId,
-                    Isbn = row.Isbn,
-                    Format = BookFormat.Softcopy,
-                    Condition = BookCondition.Good
-                };
-                db.BookCopies.Add(newCopy);
-
-                if (followUp)
-                {
-                    var book = await db.Books.Include(b => b.Tags).FirstAsync(b => b.Id == existingCopy.BookId);
-                    await EnsureFollowUpTagAsync(db, book);
-                }
-
-                await db.SaveChangesAsync();
-                return;
-            }
-        }
-
-        // Create new book with a copy
-        Publisher? publisher = null;
-        var pubName = row.Publisher?.Trim();
-        if (!string.IsNullOrEmpty(pubName))
-        {
-            publisher = await db.Publishers.FirstOrDefaultAsync(p => p.Name == pubName);
-            if (publisher is null)
-            {
-                publisher = new Publisher { Name = pubName };
-                db.Publishers.Add(publisher);
-            }
-        }
-
-        var newBook = new Book
-        {
-            Title = (row.Title ?? $"Unknown book — {row.Isbn}").Trim(),
-            Subtitle = row.Subtitle,
-            Author = (row.Author ?? "Unknown").Trim(),
-            DefaultCoverArtUrl = row.CoverUrl,
-            Copies =
-            [
-                new BookCopy
-                {
-                    Isbn = row.Isbn,
-                    Format = BookFormat.Softcopy,
-                    Condition = BookCondition.Good,
-                    DatePrinted = row.DatePrinted,
-                    Publisher = publisher
-                }
-            ]
-        };
-
-        // Fuzzy-match genres from lookup candidates
-        if (row.GenreCandidates.Count > 0)
-        {
-            var allGenres = await db.Genres.ToListAsync();
-            var matched = new HashSet<int>();
-            foreach (var candidate in row.GenreCandidates)
-            {
-                var genre = allGenres.FirstOrDefault(g => FuzzyGenreMatch(candidate, g.Name));
-                if (genre is not null && matched.Add(genre.Id))
-                {
-                    newBook.Genres.Add(genre);
-                    // Auto-add parent
-                    if (genre.ParentGenreId is int parentId && matched.Add(parentId))
-                    {
-                        var parent = allGenres.FirstOrDefault(g => g.Id == parentId);
-                        if (parent is not null) newBook.Genres.Add(parent);
-                    }
-                }
-            }
-        }
-
-        db.Books.Add(newBook);
-        await db.SaveChangesAsync();
-
-        if (followUp)
-        {
-            await EnsureFollowUpTagAsync(db, newBook);
-            await db.SaveChangesAsync();
-        }
-    }
-
-    private static async Task EnsureFollowUpTagAsync(BookTrackerDbContext db, Book book)
-    {
-        var tag = await db.Tags.FirstOrDefaultAsync(t => t.Name == "follow-up");
-        if (tag is null)
-        {
-            tag = new Tag { Name = "follow-up" };
-            db.Tags.Add(tag);
-        }
-        if (!book.Tags.Any(t => t.Name == "follow-up"))
-        {
-            book.Tags.Add(tag);
-        }
-    }
-
-    private static bool FuzzyGenreMatch(string candidate, string preset)
-    {
-        var nc = Normalize(candidate);
-        var np = Normalize(preset);
-        if (nc.Length == 0 || np.Length == 0) return false;
-        return nc == np || nc.Contains(np) || np.Contains(nc);
-    }
-
-    private static string Normalize(string s) =>
-        new string(s.Where(char.IsLetterOrDigit).ToArray()).ToLowerInvariant();
-
-    private static string RowCssClass(DiscoveryRow row) => row.Action switch
-    {
-        RowAction.Accepted => "table-success",
-        RowAction.FollowUp => "table-warning",
-        RowAction.Duplicate => "table-secondary",
-        _ => ""
-    };
-
-    private class DiscoveryRow
-    {
-        public string Isbn { get; set; } = "";
-        public string? Title { get; set; }
-        public string? Subtitle { get; set; }
-        public string? Author { get; set; }
-        public string? CoverUrl { get; set; }
-        public string? Source { get; set; }
-        public string? Publisher { get; set; }
-        public DateOnly? DatePrinted { get; set; }
-        public List<string> GenreCandidates { get; set; } = [];
-        public RowStatus Status { get; set; }
-        public RowAction Action { get; set; } = RowAction.Pending;
-        public bool IsDuplicate { get; set; }
-    }
-
-    private enum RowStatus { Searching, Found, NotFound }
-    private enum RowAction { Pending, Accepted, FollowUp, Duplicate }
 }

--- a/BookTracker.Web/Components/Pages/Books/Edit.razor
+++ b/BookTracker.Web/Components/Pages/Books/Edit.razor
@@ -1,16 +1,16 @@
 @page "/books/{BookId:int}/edit"
-@inject IDbContextFactory<BookTrackerDbContext> DbFactory
+@inject BookEditViewModel VM
 @inject NavigationManager Nav
 
 <PageTitle>Edit book - BookTracker</PageTitle>
 
-@if (notFound)
+@if (VM.NotFound)
 {
     <h1 class="mb-3">Book not found</h1>
     <p>No book with ID @BookId exists.</p>
     <a href="/books" class="btn btn-outline-secondary">Back to library</a>
 }
-else if (bookInput is null)
+else if (VM.BookInput is null)
 {
     <div class="text-center py-5">
         <div class="spinner-border" role="status">
@@ -22,11 +22,11 @@ else
 {
     <h1 class="mb-3">Edit book</h1>
 
-    @if (!string.IsNullOrEmpty(successMessage))
+    @if (!string.IsNullOrEmpty(VM.SuccessMessage))
     {
         <div class="alert alert-success alert-dismissible fade show" role="alert">
-            @successMessage
-            <button type="button" class="btn-close" @onclick="() => successMessage = null" aria-label="Close"></button>
+            @VM.SuccessMessage
+            <button type="button" class="btn-close" @onclick="() => VM.SuccessMessage = null" aria-label="Close"></button>
         </div>
     }
 
@@ -35,13 +35,13 @@ else
 
         <div class="row g-4">
             <div class="col-12">
-                <BookForm Input="bookInput" />
+                <BookForm Input="VM.BookInput" />
             </div>
 
             <div class="col-12">
                 <GenrePicker @ref="genrePicker"
-                             SelectedGenreIds="selectedGenreIds"
-                             SelectedGenreIdsChanged="ids => selectedGenreIds = ids"
+                             SelectedGenreIds="VM.SelectedGenreIds"
+                             SelectedGenreIdsChanged="ids => VM.SelectedGenreIds = ids"
                              LookupCandidates="[]" />
             </div>
 
@@ -52,25 +52,25 @@ else
                     </div>
                     <div class="card-body">
                         <div class="d-flex flex-wrap gap-2 mb-3">
-                            @foreach (var tag in assignedTags)
+                            @foreach (var tag in VM.AssignedTags)
                             {
                                 <span class="badge bg-info text-dark d-flex align-items-center gap-1">
                                     @tag.Name
                                     <button type="button" class="btn-close btn-close-sm" style="font-size: 0.6rem;"
-                                            @onclick="() => RemoveTag(tag)" aria-label="Remove @tag.Name"></button>
+                                            @onclick="() => VM.RemoveTag(tag)" aria-label="Remove @tag.Name"></button>
                                 </span>
                             }
-                            @if (assignedTags.Count == 0)
+                            @if (VM.AssignedTags.Count == 0)
                             {
                                 <span class="text-muted small">No tags assigned.</span>
                             }
                         </div>
                         <div class="input-group" style="max-width: 400px;">
                             <input type="text" class="form-control form-control-sm" placeholder="Add tag..."
-                                   list="available-tags" @bind="newTagName" />
-                            <button type="button" class="btn btn-outline-secondary btn-sm" @onclick="AddTagAsync">Add</button>
+                                   list="available-tags" @bind="VM.NewTagName" />
+                            <button type="button" class="btn btn-outline-secondary btn-sm" @onclick="VM.AddTagAsync">Add</button>
                             <datalist id="available-tags">
-                                @foreach (var t in availableTags)
+                                @foreach (var t in VM.AvailableTags)
                                 {
                                     <option value="@t.Name"></option>
                                 }
@@ -83,11 +83,11 @@ else
             <div class="col-12">
                 <div class="card">
                     <div class="card-header bg-white d-flex justify-content-between align-items-center">
-                        <h2 class="h5 mb-0">Copies (@copies.Count)</h2>
-                        <button type="button" class="btn btn-outline-primary btn-sm" @onclick="ShowAddCopy">Add copy</button>
+                        <h2 class="h5 mb-0">Copies (@VM.Copies.Count)</h2>
+                        <button type="button" class="btn btn-outline-primary btn-sm" @onclick="VM.ShowAddCopy">Add copy</button>
                     </div>
                     <div class="card-body">
-                        @if (copies.Count == 0 && !showingNewCopy)
+                        @if (VM.Copies.Count == 0 && !VM.ShowingNewCopy)
                         {
                             <p class="text-muted mb-0">No copies recorded.</p>
                         }
@@ -106,14 +106,14 @@ else
                                         </tr>
                                     </thead>
                                     <tbody>
-                                        @foreach (var copy in copies)
+                                        @foreach (var copy in VM.Copies)
                                         {
-                                            @if (editingCopyId == copy.Id)
+                                            @if (VM.EditingCopyId == copy.Id)
                                             {
                                                 <tr>
-                                                    <td><input type="text" class="form-control form-control-sm" @bind="editCopyInput.Isbn" /></td>
+                                                    <td><input type="text" class="form-control form-control-sm" @bind="VM.EditCopyInput.Isbn" /></td>
                                                     <td>
-                                                        <select class="form-select form-select-sm" @bind="editCopyInput.Format">
+                                                        <select class="form-select form-select-sm" @bind="VM.EditCopyInput.Format">
                                                             @foreach (var f in Enum.GetValues<BookFormat>())
                                                             {
                                                                 <option value="@f">@f</option>
@@ -121,19 +121,19 @@ else
                                                         </select>
                                                     </td>
                                                     <td>
-                                                        <select class="form-select form-select-sm" @bind="editCopyInput.Condition">
+                                                        <select class="form-select form-select-sm" @bind="VM.EditCopyInput.Condition">
                                                             @foreach (var c in Enum.GetValues<BookCondition>())
                                                             {
-                                                                <option value="@c">@CopyForm.FormatCondition(c)</option>
+                                                                <option value="@c">@CopyFormViewModel.FormatCondition(c)</option>
                                                             }
                                                         </select>
                                                     </td>
-                                                    <td><input type="text" class="form-control form-control-sm" @bind="editCopyInput.Publisher" /></td>
-                                                    <td><input type="date" class="form-control form-control-sm" @bind="editCopyInput.DatePrinted" /></td>
+                                                    <td><input type="text" class="form-control form-control-sm" @bind="VM.EditCopyInput.Publisher" /></td>
+                                                    <td><input type="date" class="form-control form-control-sm" @bind="VM.EditCopyInput.DatePrinted" /></td>
                                                     <td>
                                                         <div class="btn-group btn-group-sm">
-                                                            <button type="button" class="btn btn-outline-success" @onclick="SaveCopyEditAsync">Save</button>
-                                                            <button type="button" class="btn btn-outline-secondary" @onclick="CancelCopyEdit">Cancel</button>
+                                                            <button type="button" class="btn btn-outline-success" @onclick="VM.SaveCopyEditAsync">Save</button>
+                                                            <button type="button" class="btn btn-outline-secondary" @onclick="VM.CancelCopyEdit">Cancel</button>
                                                         </div>
                                                     </td>
                                                 </tr>
@@ -143,23 +143,23 @@ else
                                                 <tr>
                                                     <td>@copy.Isbn</td>
                                                     <td>@copy.Format</td>
-                                                    <td>@CopyForm.FormatCondition(copy.Condition)</td>
+                                                    <td>@CopyFormViewModel.FormatCondition(copy.Condition)</td>
                                                     <td>@(copy.PublisherName ?? "—")</td>
                                                     <td>@(copy.DatePrinted?.ToString("yyyy-MM-dd") ?? "—")</td>
                                                     <td>
-                                                        @if (confirmingDeleteCopyId == copy.Id)
+                                                        @if (VM.ConfirmingDeleteCopyId == copy.Id)
                                                         {
                                                             <div class="d-flex align-items-center gap-1">
                                                                 <span class="text-danger small">Delete?</span>
-                                                                <button type="button" class="btn btn-danger btn-sm" @onclick="() => DeleteCopyAsync(copy)">Yes</button>
-                                                                <button type="button" class="btn btn-outline-secondary btn-sm" @onclick="() => confirmingDeleteCopyId = null">No</button>
+                                                                <button type="button" class="btn btn-danger btn-sm" @onclick="() => VM.DeleteCopyAsync(copy)">Yes</button>
+                                                                <button type="button" class="btn btn-outline-secondary btn-sm" @onclick="() => VM.ConfirmingDeleteCopyId = null">No</button>
                                                             </div>
                                                         }
                                                         else
                                                         {
                                                             <div class="btn-group btn-group-sm">
-                                                                <button type="button" class="btn btn-outline-primary" @onclick="() => StartEditCopy(copy)">Edit</button>
-                                                                <button type="button" class="btn btn-outline-danger" @onclick="() => confirmingDeleteCopyId = copy.Id">Delete</button>
+                                                                <button type="button" class="btn btn-outline-primary" @onclick="() => VM.StartEditCopy(copy)">Edit</button>
+                                                                <button type="button" class="btn btn-outline-danger" @onclick="() => VM.ConfirmingDeleteCopyId = copy.Id">Delete</button>
                                                             </div>
                                                         }
                                                     </td>
@@ -171,13 +171,13 @@ else
                             </div>
                         }
 
-                        @if (showingNewCopy)
+                        @if (VM.ShowingNewCopy)
                         {
                             <div class="mt-3 pt-3 border-top">
-                                <CopyForm Input="newCopyInput" Title="New copy" />
+                                <CopyForm Input="VM.NewCopyInput" Title="New copy" />
                                 <div class="mt-2 d-flex gap-2">
-                                    <button type="button" class="btn btn-outline-success btn-sm" @onclick="SaveNewCopyAsync">Save copy</button>
-                                    <button type="button" class="btn btn-outline-secondary btn-sm" @onclick="() => showingNewCopy = false">Cancel</button>
+                                    <button type="button" class="btn btn-outline-success btn-sm" @onclick="() => VM.SaveNewCopyAsync(BookId)">Save copy</button>
+                                    <button type="button" class="btn btn-outline-secondary btn-sm" @onclick="() => VM.ShowingNewCopy = false">Cancel</button>
                                 </div>
                             </div>
                         }
@@ -186,8 +186,8 @@ else
             </div>
 
             <div class="col-12 d-flex gap-2">
-                <button type="submit" class="btn btn-primary" disabled="@saving">
-                    @if (saving)
+                <button type="submit" class="btn btn-primary" disabled="@VM.Saving">
+                    @if (VM.Saving)
                     {
                         <span class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>
                     }
@@ -195,21 +195,21 @@ else
                 </button>
                 <a class="btn btn-outline-secondary" href="/books">Back to library</a>
                 <div class="ms-auto">
-                    @if (confirmingDeleteBook)
+                    @if (VM.ConfirmingDeleteBook)
                     {
                         <span class="me-2 text-danger fw-semibold">Delete this book and all its copies?</span>
-                        <button type="button" class="btn btn-danger btn-sm" @onclick="DeleteBookAsync" disabled="@deleting">
-                            @if (deleting)
+                        <button type="button" class="btn btn-danger btn-sm" @onclick="DeleteBookAsync" disabled="@VM.Deleting">
+                            @if (VM.Deleting)
                             {
                                 <span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>
                             }
                             Yes, delete
                         </button>
-                        <button type="button" class="btn btn-outline-secondary btn-sm" @onclick="() => confirmingDeleteBook = false">Cancel</button>
+                        <button type="button" class="btn btn-outline-secondary btn-sm" @onclick="() => VM.ConfirmingDeleteBook = false">Cancel</button>
                     }
                     else
                     {
-                        <button type="button" class="btn btn-outline-danger" @onclick="() => confirmingDeleteBook = true">Delete book</button>
+                        <button type="button" class="btn btn-outline-danger" @onclick="() => VM.ConfirmingDeleteBook = true">Delete book</button>
                     }
                 </div>
             </div>
@@ -221,297 +221,17 @@ else
     [Parameter]
     public int BookId { get; set; }
 
-    private BookForm.BookFormInput? bookInput;
-    private List<int> selectedGenreIds = [];
     private GenrePicker? genrePicker;
-    private bool notFound;
-    private bool saving;
-    private string? successMessage;
 
-    // Tags
-    private List<TagItem> assignedTags = [];
-    private List<TagItem> availableTags = [];
-    private string newTagName = "";
+    protected override async Task OnInitializedAsync() => await VM.InitializeAsync(BookId);
 
-    // Copies
-    private List<CopyRow> copies = [];
-    private bool showingNewCopy;
-    private CopyForm.CopyFormInput newCopyInput = new();
-
-    // Inline copy editing
-    private int? editingCopyId;
-    private CopyEditInput editCopyInput = new();
-    private int? confirmingDeleteCopyId;
-
-    // Book deletion
-    private bool confirmingDeleteBook;
-    private bool deleting;
-
-    protected override async Task OnInitializedAsync()
-    {
-        await using var db = await DbFactory.CreateDbContextAsync();
-
-        var book = await db.Books
-            .Include(b => b.Genres)
-            .Include(b => b.Tags)
-            .Include(b => b.Copies)
-                .ThenInclude(c => c.Publisher)
-            .FirstOrDefaultAsync(b => b.Id == BookId);
-
-        if (book is null)
-        {
-            notFound = true;
-            return;
-        }
-
-        bookInput = new BookForm.BookFormInput
-        {
-            Title = book.Title,
-            Subtitle = book.Subtitle,
-            Author = book.Author,
-            Category = book.Category,
-            Status = book.Status,
-            Rating = book.Rating,
-            Notes = book.Notes,
-            DefaultCoverArtUrl = book.DefaultCoverArtUrl
-        };
-
-        selectedGenreIds = book.Genres.Select(g => g.Id).ToList();
-        assignedTags = book.Tags.Select(t => new TagItem(t.Id, t.Name)).ToList();
-        copies = book.Copies.Select(c => new CopyRow(c.Id, c.Isbn, c.Format, c.Condition, c.Publisher?.Name, c.DatePrinted, c.CustomCoverArtUrl)).ToList();
-
-        await LoadAvailableTagsAsync();
-    }
-
-    private async Task LoadAvailableTagsAsync()
-    {
-        await using var db = await DbFactory.CreateDbContextAsync();
-        var assignedIds = assignedTags.Select(t => t.Id).ToHashSet();
-        availableTags = await db.Tags
-            .Where(t => !assignedIds.Contains(t.Id))
-            .OrderBy(t => t.Name)
-            .Select(t => new TagItem(t.Id, t.Name))
-            .ToListAsync();
-    }
-
-    private async Task AddTagAsync()
-    {
-        if (string.IsNullOrWhiteSpace(newTagName)) return;
-        var name = newTagName.Trim().ToLowerInvariant();
-
-        await using var db = await DbFactory.CreateDbContextAsync();
-        var tag = await db.Tags.FirstOrDefaultAsync(t => t.Name == name);
-        if (tag is null)
-        {
-            tag = new Tag { Name = name };
-            db.Tags.Add(tag);
-            await db.SaveChangesAsync();
-        }
-
-        if (assignedTags.All(t => t.Id != tag.Id))
-        {
-            assignedTags.Add(new TagItem(tag.Id, tag.Name));
-            await LoadAvailableTagsAsync();
-        }
-
-        newTagName = "";
-    }
-
-    private void RemoveTag(TagItem tag)
-    {
-        assignedTags.RemoveAll(t => t.Id == tag.Id);
-        if (availableTags.All(t => t.Id != tag.Id))
-        {
-            availableTags.Add(tag);
-            availableTags = availableTags.OrderBy(t => t.Name).ToList();
-        }
-    }
-
-    // Copy management
-    private void ShowAddCopy()
-    {
-        newCopyInput = new CopyForm.CopyFormInput();
-        showingNewCopy = true;
-    }
-
-    private async Task SaveNewCopyAsync()
-    {
-        if (string.IsNullOrWhiteSpace(newCopyInput.Isbn)) return;
-
-        await using var db = await DbFactory.CreateDbContextAsync();
-
-        Publisher? publisher = null;
-        var pubName = newCopyInput.Publisher?.Trim();
-        if (!string.IsNullOrEmpty(pubName))
-        {
-            publisher = await db.Publishers.FirstOrDefaultAsync(p => p.Name == pubName);
-            if (publisher is null)
-            {
-                publisher = new Publisher { Name = pubName };
-                db.Publishers.Add(publisher);
-            }
-        }
-
-        var copy = new BookCopy
-        {
-            BookId = BookId,
-            Isbn = newCopyInput.Isbn.Trim(),
-            Format = newCopyInput.Format,
-            DatePrinted = newCopyInput.DatePrinted,
-            Condition = newCopyInput.Condition,
-            Publisher = publisher,
-            CustomCoverArtUrl = string.IsNullOrWhiteSpace(newCopyInput.CustomCoverArtUrl) ? null : newCopyInput.CustomCoverArtUrl.Trim()
-        };
-
-        db.BookCopies.Add(copy);
-        await db.SaveChangesAsync();
-
-        copies.Add(new CopyRow(copy.Id, copy.Isbn, copy.Format, copy.Condition, publisher?.Name, copy.DatePrinted, copy.CustomCoverArtUrl));
-        showingNewCopy = false;
-    }
-
-    private void StartEditCopy(CopyRow copy)
-    {
-        editingCopyId = copy.Id;
-        editCopyInput = new CopyEditInput
-        {
-            Isbn = copy.Isbn,
-            Format = copy.Format,
-            Condition = copy.Condition,
-            Publisher = copy.PublisherName,
-            DatePrinted = copy.DatePrinted
-        };
-    }
-
-    private void CancelCopyEdit() => editingCopyId = null;
-
-    private async Task SaveCopyEditAsync()
-    {
-        if (editingCopyId is not int copyId) return;
-
-        await using var db = await DbFactory.CreateDbContextAsync();
-        var copy = await db.BookCopies.Include(c => c.Publisher).FirstOrDefaultAsync(c => c.Id == copyId);
-        if (copy is null) { editingCopyId = null; return; }
-
-        copy.Isbn = editCopyInput.Isbn?.Trim() ?? copy.Isbn;
-        copy.Format = editCopyInput.Format;
-        copy.Condition = editCopyInput.Condition;
-        copy.DatePrinted = editCopyInput.DatePrinted;
-
-        var pubName = editCopyInput.Publisher?.Trim();
-        if (!string.IsNullOrEmpty(pubName))
-        {
-            var publisher = await db.Publishers.FirstOrDefaultAsync(p => p.Name == pubName);
-            if (publisher is null)
-            {
-                publisher = new Publisher { Name = pubName };
-                db.Publishers.Add(publisher);
-            }
-            copy.Publisher = publisher;
-        }
-        else
-        {
-            copy.Publisher = null;
-            copy.PublisherId = null;
-        }
-
-        await db.SaveChangesAsync();
-
-        var idx = copies.FindIndex(c => c.Id == copyId);
-        if (idx >= 0)
-        {
-            copies[idx] = new CopyRow(copy.Id, copy.Isbn, copy.Format, copy.Condition, pubName, copy.DatePrinted, copy.CustomCoverArtUrl);
-        }
-        editingCopyId = null;
-    }
-
-    private async Task DeleteCopyAsync(CopyRow copy)
-    {
-        await using var db = await DbFactory.CreateDbContextAsync();
-        var entity = await db.BookCopies.FindAsync(copy.Id);
-        if (entity is not null)
-        {
-            db.BookCopies.Remove(entity);
-            await db.SaveChangesAsync();
-        }
-        copies.RemoveAll(c => c.Id == copy.Id);
-        confirmingDeleteCopyId = null;
-    }
+    private async Task SaveAsync() => await VM.SaveAsync(BookId);
 
     private async Task DeleteBookAsync()
     {
-        deleting = true;
-        try
+        if (await VM.DeleteBookAsync(BookId))
         {
-            await using var db = await DbFactory.CreateDbContextAsync();
-            var book = await db.Books.FindAsync(BookId);
-            if (book is not null)
-            {
-                db.Books.Remove(book);
-                await db.SaveChangesAsync();
-            }
             Nav.NavigateTo("/books");
         }
-        finally
-        {
-            deleting = false;
-        }
-    }
-
-    // Save book metadata
-    private async Task SaveAsync()
-    {
-        saving = true;
-        try
-        {
-            await using var db = await DbFactory.CreateDbContextAsync();
-
-            var book = await db.Books
-                .Include(b => b.Genres)
-                .Include(b => b.Tags)
-                .FirstOrDefaultAsync(b => b.Id == BookId);
-
-            if (book is null) { notFound = true; return; }
-
-            book.Title = bookInput!.Title!.Trim();
-            book.Subtitle = string.IsNullOrWhiteSpace(bookInput.Subtitle) ? null : bookInput.Subtitle.Trim();
-            book.Author = bookInput.Author!.Trim();
-            book.Category = bookInput.Category;
-            book.Status = bookInput.Status;
-            book.Rating = bookInput.Rating;
-            book.Notes = string.IsNullOrWhiteSpace(bookInput.Notes) ? null : bookInput.Notes.Trim();
-            book.DefaultCoverArtUrl = string.IsNullOrWhiteSpace(bookInput.DefaultCoverArtUrl) ? null : bookInput.DefaultCoverArtUrl.Trim();
-
-            var selectedGenres = await db.Genres
-                .Where(g => selectedGenreIds.Contains(g.Id))
-                .ToListAsync();
-            book.Genres.Clear();
-            book.Genres.AddRange(selectedGenres);
-
-            var selectedTags = await db.Tags
-                .Where(t => assignedTags.Select(at => at.Id).Contains(t.Id))
-                .ToListAsync();
-            book.Tags.Clear();
-            book.Tags.AddRange(selectedTags);
-
-            await db.SaveChangesAsync();
-            successMessage = "Book saved successfully.";
-        }
-        finally
-        {
-            saving = false;
-        }
-    }
-
-    private record TagItem(int Id, string Name);
-    private record CopyRow(int Id, string Isbn, BookFormat Format, BookCondition Condition, string? PublisherName, DateOnly? DatePrinted, string? CustomCoverArtUrl);
-
-    private class CopyEditInput
-    {
-        public string? Isbn { get; set; }
-        public BookFormat Format { get; set; }
-        public BookCondition Condition { get; set; }
-        public string? Publisher { get; set; }
-        public DateOnly? DatePrinted { get; set; }
     }
 }

--- a/BookTracker.Web/Components/Pages/Books/List.razor
+++ b/BookTracker.Web/Components/Pages/Books/List.razor
@@ -1,5 +1,5 @@
 @page "/books"
-@inject IDbContextFactory<BookTrackerDbContext> DbFactory
+@inject BookListViewModel VM
 @inject NavigationManager Nav
 
 <PageTitle>Library - BookTracker</PageTitle>
@@ -11,11 +11,11 @@
         <div class="row g-3 align-items-end">
             <div class="col-md-3">
                 <label class="form-label small text-muted">Search</label>
-                <input type="text" class="form-control" placeholder="Title or author..." @bind="searchTerm" @bind:event="oninput" @onkeyup="HandleSearchKeyUp" />
+                <input type="text" class="form-control" placeholder="Title or author..." @bind="VM.SearchTerm" @bind:event="oninput" @onkeyup="HandleSearchKeyUp" />
             </div>
             <div class="col-md-2">
                 <label class="form-label small text-muted">Category</label>
-                <select class="form-select" @bind="selectedCategory" @bind:after="ApplyFiltersAsync">
+                <select class="form-select" @bind="VM.SelectedCategory" @bind:after="() => VM.ApplyFiltersAsync()">
                     <option value="">All</option>
                     <option value="Fiction">Fiction</option>
                     <option value="NonFiction">Non-Fiction</option>
@@ -23,9 +23,9 @@
             </div>
             <div class="col-md-2">
                 <label class="form-label small text-muted">Genre</label>
-                <select class="form-select" @bind="selectedGenreId" @bind:after="ApplyFiltersAsync">
+                <select class="form-select" @bind="VM.SelectedGenreId" @bind:after="() => VM.ApplyFiltersAsync()">
                     <option value="0">All</option>
-                    @foreach (var g in allGenres)
+                    @foreach (var g in VM.AllGenres)
                     {
                         var prefix = g.ParentGenreId.HasValue ? "\u00A0\u00A0\u00A0\u00A0" : "";
                         <option value="@g.Id">@prefix@g.Name</option>
@@ -34,9 +34,9 @@
             </div>
             <div class="col-md-2">
                 <label class="form-label small text-muted">Tag</label>
-                <select class="form-select" @bind="selectedTagId" @bind:after="ApplyFiltersAsync">
+                <select class="form-select" @bind="VM.SelectedTagId" @bind:after="() => VM.ApplyFiltersAsync()">
                     <option value="0">All</option>
-                    @foreach (var t in allTags)
+                    @foreach (var t in VM.AllTags)
                     {
                         <option value="@t.Id">@t.Name</option>
                     }
@@ -44,16 +44,16 @@
             </div>
             <div class="col-md-2">
                 <label class="form-label small text-muted">Author</label>
-                <input type="text" class="form-control" placeholder="Author..." list="author-filter-options" @bind="selectedAuthor" @bind:after="ApplyFiltersAsync" />
+                <input type="text" class="form-control" placeholder="Author..." list="author-filter-options" @bind="VM.SelectedAuthor" @bind:after="() => VM.ApplyFiltersAsync()" />
                 <datalist id="author-filter-options">
-                    @foreach (var a in allAuthors)
+                    @foreach (var a in VM.AllAuthors)
                     {
                         <option value="@a"></option>
                     }
                 </datalist>
             </div>
             <div class="col-md-1">
-                <button type="button" class="btn btn-outline-secondary w-100" @onclick="ClearFiltersAsync" title="Clear filters">
+                <button type="button" class="btn btn-outline-secondary w-100" @onclick="VM.ClearFiltersAsync" title="Clear filters">
                     <span aria-hidden="true">&times;</span>
                 </button>
             </div>
@@ -61,7 +61,7 @@
     </div>
 </div>
 
-@if (loading)
+@if (VM.Loading)
 {
     <div class="text-center py-5">
         <div class="spinner-border" role="status">
@@ -69,7 +69,7 @@
         </div>
     </div>
 }
-else if (books.Count == 0)
+else if (VM.Books.Count == 0)
 {
     <div class="text-center py-5 text-muted">
         <p class="mb-2">No books found.</p>
@@ -92,7 +92,7 @@ else
                 </tr>
             </thead>
             <tbody>
-                @foreach (var book in books)
+                @foreach (var book in VM.Books)
                 {
                     <tr role="button" @onclick="() => NavigateToEdit(book.Id)" style="cursor: pointer;">
                         <td>
@@ -128,7 +128,7 @@ else
                             }
                         </td>
                         <td>
-                            <span class="badge @StatusBadgeClass(book.Status)">@book.Status</span>
+                            <span class="badge @BookListViewModel.StatusBadgeClass(book.Status)">@book.Status</span>
                         </td>
                         <td>
                             @for (int i = 1; i <= 5; i++)
@@ -143,196 +143,40 @@ else
         </table>
     </div>
 
-    @if (totalPages > 1)
+    @if (VM.TotalPages > 1)
     {
         <nav aria-label="Book list pagination">
             <ul class="pagination justify-content-center">
-                <li class="page-item @(currentPage <= 1 ? "disabled" : "")">
-                    <button class="page-link" @onclick="() => GoToPageAsync(currentPage - 1)" disabled="@(currentPage <= 1)">Previous</button>
+                <li class="page-item @(VM.CurrentPage <= 1 ? "disabled" : "")">
+                    <button class="page-link" @onclick="() => VM.GoToPageAsync(VM.CurrentPage - 1)" disabled="@(VM.CurrentPage <= 1)">Previous</button>
                 </li>
-                @for (int p = 1; p <= totalPages; p++)
+                @for (int p = 1; p <= VM.TotalPages; p++)
                 {
-                    var page = p;
-                    <li class="page-item @(page == currentPage ? "active" : "")">
-                        <button class="page-link" @onclick="() => GoToPageAsync(page)">@(page)</button>
+                    var pageNum = p;
+                    <li class="page-item @(pageNum == VM.CurrentPage ? "active" : "")">
+                        <button class="page-link" @onclick="() => VM.GoToPageAsync(pageNum)">@(pageNum)</button>
                     </li>
                 }
-                <li class="page-item @(currentPage >= totalPages ? "disabled" : "")">
-                    <button class="page-link" @onclick="() => GoToPageAsync(currentPage + 1)" disabled="@(currentPage >= totalPages)">Next</button>
+                <li class="page-item @(VM.CurrentPage >= VM.TotalPages ? "disabled" : "")">
+                    <button class="page-link" @onclick="() => VM.GoToPageAsync(VM.CurrentPage + 1)" disabled="@(VM.CurrentPage >= VM.TotalPages)">Next</button>
                 </li>
             </ul>
         </nav>
     }
 
     <div class="text-center text-muted small mb-3">
-        Showing @((currentPage - 1) * PageSize + 1)–@Math.Min(currentPage * PageSize, totalCount) of @totalCount books
+        Showing @((VM.CurrentPage - 1) * BookListViewModel.PageSize + 1)–@Math.Min(VM.CurrentPage * BookListViewModel.PageSize, VM.TotalCount) of @VM.TotalCount books
     </div>
 }
 
 @code {
-    private const int PageSize = 20;
-
-    private bool loading = true;
-    private List<BookListItem> books = [];
-    private int totalCount;
-    private int currentPage = 1;
-    private int totalPages;
-
-    private string searchTerm = "";
-    private string selectedCategory = "";
-    private int selectedGenreId;
-    private int selectedTagId;
-    private string selectedAuthor = "";
-
-    private List<GenreOption> allGenres = [];
-    private List<TagOption> allTags = [];
-    private List<string> allAuthors = [];
-
-    protected override async Task OnInitializedAsync()
-    {
-        await LoadFilterOptionsAsync();
-        await LoadBooksAsync();
-    }
-
-    private async Task LoadFilterOptionsAsync()
-    {
-        await using var db = await DbFactory.CreateDbContextAsync();
-
-        var genres = await db.Genres
-            .OrderBy(g => g.Name)
-            .Select(g => new GenreOption(g.Id, g.Name, g.ParentGenreId))
-            .ToListAsync();
-
-        // Build hierarchical list: parent then children
-        var topLevel = genres.Where(g => g.ParentGenreId is null).OrderBy(g => g.Name).ToList();
-        allGenres = [];
-        foreach (var parent in topLevel)
-        {
-            allGenres.Add(parent);
-            var children = genres.Where(g => g.ParentGenreId == parent.Id).OrderBy(g => g.Name);
-            allGenres.AddRange(children);
-        }
-
-        allTags = await db.Tags
-            .OrderBy(t => t.Name)
-            .Select(t => new TagOption(t.Id, t.Name))
-            .ToListAsync();
-
-        allAuthors = await db.Books
-            .Select(b => b.Author)
-            .Distinct()
-            .OrderBy(a => a)
-            .ToListAsync();
-    }
-
-    private async Task LoadBooksAsync()
-    {
-        loading = true;
-        StateHasChanged();
-
-        await using var db = await DbFactory.CreateDbContextAsync();
-
-        IQueryable<Book> query = db.Books
-            .Include(b => b.Genres)
-            .Include(b => b.Tags);
-
-        if (!string.IsNullOrWhiteSpace(searchTerm))
-        {
-            var term = searchTerm.Trim();
-            query = query.Where(b => b.Title.Contains(term) || b.Author.Contains(term));
-        }
-
-        if (!string.IsNullOrEmpty(selectedCategory) && Enum.TryParse<BookCategory>(selectedCategory, out var cat))
-        {
-            query = query.Where(b => b.Category == cat);
-        }
-
-        if (selectedGenreId > 0)
-        {
-            query = query.Where(b => b.Genres.Any(g => g.Id == selectedGenreId));
-        }
-
-        if (selectedTagId > 0)
-        {
-            query = query.Where(b => b.Tags.Any(t => t.Id == selectedTagId));
-        }
-
-        if (!string.IsNullOrWhiteSpace(selectedAuthor))
-        {
-            var author = selectedAuthor.Trim();
-            query = query.Where(b => b.Author == author);
-        }
-
-        totalCount = await query.CountAsync();
-        totalPages = Math.Max(1, (int)Math.Ceiling(totalCount / (double)PageSize));
-        if (currentPage > totalPages) currentPage = totalPages;
-
-        books = await query
-            .OrderByDescending(b => b.DateAdded)
-            .Skip((currentPage - 1) * PageSize)
-            .Take(PageSize)
-            .Select(b => new BookListItem(
-                b.Id,
-                b.Title,
-                b.Subtitle,
-                b.Author,
-                b.DefaultCoverArtUrl,
-                b.Status,
-                b.Rating,
-                b.Genres.Select(g => g.Name).ToList(),
-                b.Tags.Select(t => t.Name).ToList()
-            ))
-            .ToListAsync();
-
-        loading = false;
-    }
-
-    private async Task ApplyFiltersAsync()
-    {
-        currentPage = 1;
-        await LoadBooksAsync();
-    }
+    protected override async Task OnInitializedAsync() => await VM.InitializeAsync();
 
     private async Task HandleSearchKeyUp(KeyboardEventArgs e)
     {
         if (e.Key == "Enter")
-        {
-            await ApplyFiltersAsync();
-        }
-    }
-
-    private async Task ClearFiltersAsync()
-    {
-        searchTerm = "";
-        selectedCategory = "";
-        selectedGenreId = 0;
-        selectedTagId = 0;
-        selectedAuthor = "";
-        currentPage = 1;
-        await LoadBooksAsync();
-    }
-
-    private async Task GoToPageAsync(int page)
-    {
-        if (page < 1 || page > totalPages) return;
-        currentPage = page;
-        await LoadBooksAsync();
+            await VM.ApplyFiltersAsync();
     }
 
     private void NavigateToEdit(int bookId) => Nav.NavigateTo($"/books/{bookId}/edit");
-
-    private static string StatusBadgeClass(BookStatus status) => status switch
-    {
-        BookStatus.Reading => "bg-primary",
-        BookStatus.Read => "bg-success",
-        BookStatus.Unread => "bg-secondary",
-        _ => "bg-secondary"
-    };
-
-    private record BookListItem(
-        int Id, string Title, string? Subtitle, string Author, string? CoverUrl,
-        BookStatus Status, int Rating, List<string> Genres, List<string> Tags);
-
-    private record GenreOption(int Id, string Name, int? ParentGenreId);
-    private record TagOption(int Id, string Name);
 }

--- a/BookTracker.Web/Components/Pages/Home.razor
+++ b/BookTracker.Web/Components/Pages/Home.razor
@@ -1,5 +1,5 @@
 @page "/"
-@inject IDbContextFactory<BookTrackerDbContext> DbFactory
+@inject HomeViewModel VM
 
 <PageTitle>Home - BookTracker</PageTitle>
 
@@ -84,7 +84,7 @@
                 <div class="stat-icon me-3">📚</div>
                 <div>
                     <div class="text-muted small text-uppercase">Books in collection</div>
-                    <div class="display-6 fw-bold">@totalBooks</div>
+                    <div class="display-6 fw-bold">@VM.TotalBooks</div>
                 </div>
             </div>
         </div>
@@ -95,7 +95,7 @@
                 <div class="stat-icon me-3">✍️</div>
                 <div>
                     <div class="text-muted small text-uppercase">Unique authors</div>
-                    <div class="display-6 fw-bold">@totalAuthors</div>
+                    <div class="display-6 fw-bold">@VM.TotalAuthors</div>
                 </div>
             </div>
         </div>
@@ -107,16 +107,16 @@
         <div class="card h-100">
             <div class="card-header bg-white border-0 pt-3"><h2 class="h5 mb-0">Top 10 authors</h2></div>
             <div class="card-body">
-                @if (topAuthors.Count == 0)
+                @if (VM.TopAuthors.Count == 0)
                 {
                     <p class="text-muted mb-0">No books yet — add one to see your top authors.</p>
                 }
                 else
                 {
                     <ul class="list-unstyled mb-0">
-                        @foreach (var a in topAuthors)
+                        @foreach (var a in VM.TopAuthors)
                         {
-                            var pct = maxAuthor == 0 ? 0 : (int)Math.Round(a.Count * 100.0 / maxAuthor);
+                            var pct = VM.MaxAuthor == 0 ? 0 : (int)Math.Round(a.Count * 100.0 / VM.MaxAuthor);
                             <li class="mb-2">
                                 <div class="d-flex justify-content-between small">
                                     <span class="text-truncate pe-2">@a.Author</span>
@@ -136,16 +136,16 @@
         <div class="card h-100">
             <div class="card-header bg-white border-0 pt-3"><h2 class="h5 mb-0">Top 10 genres</h2></div>
             <div class="card-body">
-                @if (topGenres.Count == 0)
+                @if (VM.TopGenres.Count == 0)
                 {
                     <p class="text-muted mb-0">No genres recorded yet.</p>
                 }
                 else
                 {
                     <ul class="list-unstyled mb-0">
-                        @foreach (var g in topGenres)
+                        @foreach (var g in VM.TopGenres)
                         {
-                            var pct = maxGenre == 0 ? 0 : (int)Math.Round(g.Count * 100.0 / maxGenre);
+                            var pct = VM.MaxGenre == 0 ? 0 : (int)Math.Round(g.Count * 100.0 / VM.MaxGenre);
                             <li class="mb-2">
                                 <div class="d-flex justify-content-between small">
                                     <span class="text-truncate pe-2">@g.Genre</span>
@@ -164,46 +164,5 @@
 </div>
 
 @code {
-    int totalBooks;
-    int totalAuthors;
-    List<AuthorCount> topAuthors = [];
-    List<GenreCount> topGenres = [];
-    int maxAuthor;
-    int maxGenre;
-
-    protected override async Task OnInitializedAsync()
-    {
-        await using var db = await DbFactory.CreateDbContextAsync();
-
-        totalBooks = await db.Books.CountAsync();
-
-        totalAuthors = await db.Books
-            .Select(b => b.Author)
-            .Distinct()
-            .CountAsync();
-
-        var authors = await db.Books
-            .GroupBy(b => b.Author)
-            .Select(g => new { Author = g.Key, Count = g.Count() })
-            .OrderByDescending(x => x.Count)
-            .ThenBy(x => x.Author)
-            .Take(10)
-            .ToListAsync();
-        topAuthors = authors.Select(x => new AuthorCount(x.Author, x.Count)).ToList();
-
-        var genres = await db.Genres
-            .Select(g => new { Genre = g.Name, Count = g.Books.Count })
-            .Where(x => x.Count > 0)
-            .OrderByDescending(x => x.Count)
-            .ThenBy(x => x.Genre)
-            .Take(10)
-            .ToListAsync();
-        topGenres = genres.Select(x => new GenreCount(x.Genre, x.Count)).ToList();
-
-        maxAuthor = topAuthors.Count > 0 ? topAuthors.Max(a => a.Count) : 0;
-        maxGenre = topGenres.Count > 0 ? topGenres.Max(g => g.Count) : 0;
-    }
-
-    record AuthorCount(string Author, int Count);
-    record GenreCount(string Genre, int Count);
+    protected override async Task OnInitializedAsync() => await VM.InitializeAsync();
 }

--- a/BookTracker.Web/Components/Shared/BookForm.razor
+++ b/BookTracker.Web/Components/Shared/BookForm.razor
@@ -23,7 +23,7 @@
                         <InputSelect @bind-Value="Input.Category" class="form-select">
                             @foreach (var c in Enum.GetValues<BookCategory>())
                             {
-                                <option value="@c">@FormatCategory(c)</option>
+                                <option value="@c">@BookFormViewModel.FormatCategory(c)</option>
                             }
                         </InputSelect>
                     </div>
@@ -73,35 +73,5 @@
 
 @code {
     [Parameter, EditorRequired]
-    public BookFormInput Input { get; set; } = default!;
-
-    public static string FormatCategory(BookCategory c) => c switch
-    {
-        BookCategory.NonFiction => "Non-Fiction",
-        _ => c.ToString()
-    };
-
-    public class BookFormInput
-    {
-        [Required, StringLength(300)]
-        public string? Title { get; set; }
-
-        [StringLength(300)]
-        public string? Subtitle { get; set; }
-
-        [Required, StringLength(200)]
-        public string? Author { get; set; }
-
-        public BookCategory Category { get; set; } = BookCategory.Fiction;
-
-        public BookStatus Status { get; set; } = BookStatus.Read;
-
-        [Range(0, 5)]
-        public int Rating { get; set; }
-
-        public string? Notes { get; set; }
-
-        [StringLength(500)]
-        public string? DefaultCoverArtUrl { get; set; }
-    }
+    public BookFormViewModel.BookFormInput Input { get; set; } = default!;
 }

--- a/BookTracker.Web/Components/Shared/CopyForm.razor
+++ b/BookTracker.Web/Components/Shared/CopyForm.razor
@@ -1,4 +1,4 @@
-@inject IDbContextFactory<BookTrackerDbContext> DbFactory
+@inject CopyFormViewModel VM
 
 <div class="card">
     <div class="card-header bg-white"><h2 class="h5 mb-0">@Title</h2></div>
@@ -27,7 +27,7 @@
                 <InputSelect @bind-Value="Input.Condition" class="form-select">
                     @foreach (var c in Enum.GetValues<BookCondition>())
                     {
-                        <option value="@c">@FormatCondition(c)</option>
+                        <option value="@c">@CopyFormViewModel.FormatCondition(c)</option>
                     }
                 </InputSelect>
             </div>
@@ -35,7 +35,7 @@
                 <label class="form-label">Publisher</label>
                 <InputText @bind-Value="Input.Publisher" class="form-control" list="@publisherDatalistId" placeholder="Penguin Books" />
                 <datalist id="@publisherDatalistId">
-                    @foreach (var p in existingPublishers)
+                    @foreach (var p in VM.ExistingPublishers)
                     {
                         <option value="@p.Name"></option>
                     }
@@ -51,48 +51,15 @@
 
 @code {
     [Parameter, EditorRequired]
-    public CopyFormInput Input { get; set; } = default!;
+    public CopyFormViewModel.CopyFormInput Input { get; set; } = default!;
 
     [Parameter]
     public string Title { get; set; } = "Copy";
 
     private string publisherDatalistId = $"publisher-options-{Guid.NewGuid():N}";
-    private List<PublisherOption> existingPublishers = [];
 
     protected override async Task OnInitializedAsync()
     {
-        await using var db = await DbFactory.CreateDbContextAsync();
-        existingPublishers = await db.Publishers
-            .OrderBy(p => p.Name)
-            .Select(p => new PublisherOption(p.Id, p.Name))
-            .ToListAsync();
-    }
-
-    public static string FormatCondition(BookCondition c) => c switch
-    {
-        BookCondition.AsNew => "As New",
-        BookCondition.VeryGood => "Very Good",
-        _ => c.ToString()
-    };
-
-    public record PublisherOption(int Id, string Name);
-
-    public class CopyFormInput
-    {
-        [Required, StringLength(20)]
-        [RegularExpression(@"^(97(8|9))?\d{9}(\d|X|x)$", ErrorMessage = "Enter a valid 10- or 13-digit ISBN.")]
-        public string? Isbn { get; set; }
-
-        public BookFormat Format { get; set; } = BookFormat.Softcopy;
-
-        public DateOnly? DatePrinted { get; set; }
-
-        public BookCondition Condition { get; set; } = BookCondition.Good;
-
-        [StringLength(200)]
-        public string? Publisher { get; set; }
-
-        [StringLength(500)]
-        public string? CustomCoverArtUrl { get; set; }
+        await VM.InitializeAsync();
     }
 }

--- a/BookTracker.Web/Components/Shared/GenrePicker.razor
+++ b/BookTracker.Web/Components/Shared/GenrePicker.razor
@@ -1,33 +1,35 @@
+@inject GenrePickerViewModel VM
+
 <div class="card">
     <div class="card-header bg-white"><h2 class="h5 mb-0">Genres</h2></div>
     <div class="card-body">
         <div class="row g-3">
-            @foreach (var top in topLevelGenres)
+            @foreach (var top in VM.TopLevelGenres)
             {
                 <div class="col-md-6 col-lg-4">
                     <div class="form-check">
                         <input class="form-check-input" type="checkbox" id="@($"genre-{top.Id}")"
-                               checked="@SelectedGenreIds.Contains(top.Id)"
-                               @onchange="e => ToggleGenre(top.Id, (bool)e.Value!)" />
+                               checked="@VM.SelectedGenreIds.Contains(top.Id)"
+                               @onchange="e => OnToggle(top.Id, (bool)e.Value!)" />
                         <label class="form-check-label fw-semibold" for="@($"genre-{top.Id}")">@top.Name</label>
                     </div>
                     @foreach (var child in top.Children.OrderBy(c => c.Name))
                     {
                         <div class="form-check ms-4">
                             <input class="form-check-input" type="checkbox" id="@($"genre-{child.Id}")"
-                                   checked="@SelectedGenreIds.Contains(child.Id)"
-                                   @onchange="e => ToggleGenre(child.Id, (bool)e.Value!)" />
+                                   checked="@VM.SelectedGenreIds.Contains(child.Id)"
+                                   @onchange="e => OnToggle(child.Id, (bool)e.Value!)" />
                             <label class="form-check-label" for="@($"genre-{child.Id}")">@child.Name</label>
                         </div>
                     }
                 </div>
             }
         </div>
-        @if (LookupCandidates.Count > 0)
+        @if (VM.LookupCandidates.Count > 0)
         {
             <div class="mt-3 pt-3 border-top">
                 <small class="text-muted d-block mb-1">Lookup returned (fuzzy-matched against the list above):</small>
-                @foreach (var c in LookupCandidates)
+                @foreach (var c in VM.LookupCandidates)
                 {
                     <span class="badge bg-light text-dark border me-1 mb-1">@c</span>
                 }
@@ -46,80 +48,22 @@
     [Parameter]
     public List<string> LookupCandidates { get; set; } = [];
 
-    [Inject]
-    private IDbContextFactory<BookTrackerDbContext> DbFactory { get; set; } = default!;
-
-    private List<GenreNode> topLevelGenres = [];
-    private Dictionary<int, GenreNode> genreById = [];
+    /// <summary>
+    /// Exposes the underlying ViewModel so parent components can call
+    /// ApplyLookupCandidates and access genre data directly.
+    /// </summary>
+    public GenrePickerViewModel ViewModel => VM;
 
     protected override async Task OnInitializedAsync()
     {
-        await using var db = await DbFactory.CreateDbContextAsync();
-        var all = await db.Genres
-            .OrderBy(g => g.Name)
-            .Select(g => new GenreNode(g.Id, g.Name, g.ParentGenreId))
-            .ToListAsync();
-        genreById = all.ToDictionary(g => g.Id);
-        foreach (var g in all.Where(g => g.ParentGenreId.HasValue))
-        {
-            if (genreById.TryGetValue(g.ParentGenreId!.Value, out var parent))
-            {
-                parent.Children.Add(g);
-            }
-        }
-        topLevelGenres = all.Where(g => g.ParentGenreId is null).OrderBy(g => g.Name).ToList();
+        VM.SelectedGenreIds = SelectedGenreIds;
+        VM.LookupCandidates = LookupCandidates;
+        await VM.InitializeAsync();
     }
 
-    private async Task ToggleGenre(int id, bool isChecked)
+    private async Task OnToggle(int id, bool isChecked)
     {
-        if (isChecked)
-        {
-            if (!SelectedGenreIds.Contains(id)) SelectedGenreIds.Add(id);
-            if (genreById.TryGetValue(id, out var node) && node.ParentGenreId is int parentId
-                && !SelectedGenreIds.Contains(parentId))
-            {
-                SelectedGenreIds.Add(parentId);
-            }
-        }
-        else
-        {
-            SelectedGenreIds.Remove(id);
-        }
-        await SelectedGenreIdsChanged.InvokeAsync(SelectedGenreIds);
-    }
-
-    /// <summary>
-    /// Applies fuzzy genre matching from lookup candidates and auto-selects matching genres.
-    /// Call this after setting LookupCandidates.
-    /// </summary>
-    public async Task ApplyLookupCandidatesAsync(IReadOnlyList<string> candidates)
-    {
-        foreach (var candidate in candidates)
-        {
-            var match = genreById.Values.FirstOrDefault(g => FuzzyGenreMatch(candidate, g.Name));
-            if (match is not null)
-            {
-                await ToggleGenre(match.Id, true);
-            }
-        }
-    }
-
-    private static bool FuzzyGenreMatch(string candidate, string preset)
-    {
-        var nc = Normalize(candidate);
-        var np = Normalize(preset);
-        if (nc.Length == 0 || np.Length == 0) return false;
-        return nc == np || nc.Contains(np) || np.Contains(nc);
-    }
-
-    private static string Normalize(string s) =>
-        new string(s.Where(char.IsLetterOrDigit).ToArray()).ToLowerInvariant();
-
-    public class GenreNode(int id, string name, int? parentGenreId)
-    {
-        public int Id { get; } = id;
-        public string Name { get; } = name;
-        public int? ParentGenreId { get; } = parentGenreId;
-        public List<GenreNode> Children { get; } = [];
+        VM.ToggleGenre(id, isChecked);
+        await SelectedGenreIdsChanged.InvokeAsync(VM.SelectedGenreIds);
     }
 }

--- a/BookTracker.Web/Components/_Imports.razor
+++ b/BookTracker.Web/Components/_Imports.razor
@@ -12,3 +12,4 @@
 @using BookTracker.Web.Components
 @using BookTracker.Web.Components.Shared
 @using BookTracker.Web.Services
+@using BookTracker.Web.ViewModels

--- a/BookTracker.Web/Program.cs
+++ b/BookTracker.Web/Program.cs
@@ -1,6 +1,7 @@
 using BookTracker.Data;
 using BookTracker.Web.Components;
 using BookTracker.Web.Services;
+using BookTracker.Web.ViewModels;
 using Microsoft.EntityFrameworkCore;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -22,6 +23,16 @@ builder.Services.AddHttpClient<IBookLookupService, BookLookupService>(client =>
     client.Timeout = TimeSpan.FromSeconds(10);
     client.DefaultRequestHeaders.UserAgent.ParseAdd("BookTracker/0.1 (+github.com/N3rdage/the-library)");
 });
+
+// ViewModels — transient so each component instance gets its own VM.
+builder.Services.AddTransient<HomeViewModel>();
+builder.Services.AddTransient<BookFormViewModel>();
+builder.Services.AddTransient<CopyFormViewModel>();
+builder.Services.AddTransient<GenrePickerViewModel>();
+builder.Services.AddTransient<BookListViewModel>();
+builder.Services.AddTransient<BookAddViewModel>();
+builder.Services.AddTransient<BookEditViewModel>();
+builder.Services.AddTransient<BulkAddViewModel>();
 
 var app = builder.Build();
 

--- a/BookTracker.Web/ViewModels/BookAddViewModel.cs
+++ b/BookTracker.Web/ViewModels/BookAddViewModel.cs
@@ -1,0 +1,117 @@
+using BookTracker.Data;
+using BookTracker.Data.Models;
+using BookTracker.Web.Services;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookTracker.Web.ViewModels;
+
+public class BookAddViewModel(
+    IDbContextFactory<BookTrackerDbContext> dbFactory,
+    IBookLookupService lookup)
+{
+    public BookFormViewModel.BookFormInput BookInput { get; set; } = new();
+    public CopyFormViewModel.CopyFormInput CopyInput { get; set; } = new();
+    public List<string> LookupCandidates { get; private set; } = [];
+
+    public string? LookupIsbn { get; set; }
+    public string? LookupMessage { get; private set; }
+    public bool LookingUp { get; private set; }
+    public bool Saving { get; private set; }
+
+    public async Task LookupAsync(GenrePickerViewModel genrePicker)
+    {
+        LookupMessage = null;
+        if (string.IsNullOrWhiteSpace(LookupIsbn))
+        {
+            LookupMessage = "Enter an ISBN to look up.";
+            return;
+        }
+
+        LookingUp = true;
+        try
+        {
+            var result = await lookup.LookupByIsbnAsync(LookupIsbn, CancellationToken.None);
+            if (result is null)
+            {
+                LookupMessage = $"No match found for ISBN {LookupIsbn}.";
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(BookInput.Title)) BookInput.Title = result.Title ?? "";
+            if (string.IsNullOrWhiteSpace(BookInput.Subtitle)) BookInput.Subtitle = result.Subtitle;
+            if (string.IsNullOrWhiteSpace(BookInput.Author)) BookInput.Author = result.Author ?? "";
+            if (string.IsNullOrWhiteSpace(BookInput.DefaultCoverArtUrl)) BookInput.DefaultCoverArtUrl = result.CoverUrl;
+            if (string.IsNullOrWhiteSpace(CopyInput.Isbn)) CopyInput.Isbn = result.Isbn;
+            if (string.IsNullOrWhiteSpace(CopyInput.Publisher)) CopyInput.Publisher = result.Publisher;
+            CopyInput.DatePrinted ??= result.DatePrinted;
+
+            LookupCandidates = result.GenreCandidates.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+            genrePicker.LookupCandidates = LookupCandidates;
+            genrePicker.ApplyLookupCandidates(LookupCandidates);
+
+            LookupMessage = $"Prefilled from {result.Source}. Edit anything before saving.";
+        }
+        finally
+        {
+            LookingUp = false;
+        }
+    }
+
+    public async Task<bool> SaveAsync(List<int> selectedGenreIds)
+    {
+        Saving = true;
+        try
+        {
+            await using var db = await dbFactory.CreateDbContextAsync();
+
+            var selectedGenres = await db.Genres
+                .Where(g => selectedGenreIds.Contains(g.Id))
+                .ToListAsync();
+
+            Publisher? publisher = null;
+            var publisherName = CopyInput.Publisher?.Trim();
+            if (!string.IsNullOrEmpty(publisherName))
+            {
+                publisher = await db.Publishers.FirstOrDefaultAsync(p => p.Name == publisherName);
+                if (publisher is null)
+                {
+                    publisher = new Publisher { Name = publisherName };
+                    db.Publishers.Add(publisher);
+                }
+            }
+
+            var book = new Book
+            {
+                Title = BookInput.Title!.Trim(),
+                Subtitle = string.IsNullOrWhiteSpace(BookInput.Subtitle) ? null : BookInput.Subtitle.Trim(),
+                Author = BookInput.Author!.Trim(),
+                Notes = string.IsNullOrWhiteSpace(BookInput.Notes) ? null : BookInput.Notes.Trim(),
+                Category = BookInput.Category,
+                Status = BookInput.Status,
+                Rating = BookInput.Rating,
+                DefaultCoverArtUrl = string.IsNullOrWhiteSpace(BookInput.DefaultCoverArtUrl) ? null : BookInput.DefaultCoverArtUrl.Trim(),
+                Genres = selectedGenres,
+                Copies =
+                [
+                    new BookCopy
+                    {
+                        Isbn = CopyInput.Isbn!.Trim(),
+                        Format = CopyInput.Format,
+                        DatePrinted = CopyInput.DatePrinted,
+                        Condition = CopyInput.Condition,
+                        Publisher = publisher,
+                        CustomCoverArtUrl = string.IsNullOrWhiteSpace(CopyInput.CustomCoverArtUrl) ? null : CopyInput.CustomCoverArtUrl.Trim()
+                    }
+                ]
+            };
+
+            db.Books.Add(book);
+            await db.SaveChangesAsync();
+            return true;
+        }
+        finally
+        {
+            Saving = false;
+        }
+    }
+}

--- a/BookTracker.Web/ViewModels/BookEditViewModel.cs
+++ b/BookTracker.Web/ViewModels/BookEditViewModel.cs
@@ -1,0 +1,300 @@
+using BookTracker.Data;
+using BookTracker.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookTracker.Web.ViewModels;
+
+public class BookEditViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory)
+{
+    public BookFormViewModel.BookFormInput? BookInput { get; private set; }
+    public List<int> SelectedGenreIds { get; set; } = [];
+    public bool NotFound { get; private set; }
+    public bool Saving { get; private set; }
+    public string? SuccessMessage { get; set; }
+
+    // Tags
+    public List<TagItem> AssignedTags { get; private set; } = [];
+    public List<TagItem> AvailableTags { get; private set; } = [];
+    public string NewTagName { get; set; } = "";
+
+    // Copies
+    public List<CopyRow> Copies { get; private set; } = [];
+    public bool ShowingNewCopy { get; set; }
+    public CopyFormViewModel.CopyFormInput NewCopyInput { get; set; } = new();
+
+    // Inline copy editing
+    public int? EditingCopyId { get; set; }
+    public CopyEditInput EditCopyInput { get; set; } = new();
+    public int? ConfirmingDeleteCopyId { get; set; }
+
+    // Book deletion
+    public bool ConfirmingDeleteBook { get; set; }
+    public bool Deleting { get; private set; }
+
+    public async Task InitializeAsync(int bookId)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync();
+
+        var book = await db.Books
+            .Include(b => b.Genres)
+            .Include(b => b.Tags)
+            .Include(b => b.Copies)
+                .ThenInclude(c => c.Publisher)
+            .FirstOrDefaultAsync(b => b.Id == bookId);
+
+        if (book is null)
+        {
+            NotFound = true;
+            return;
+        }
+
+        BookInput = new BookFormViewModel.BookFormInput
+        {
+            Title = book.Title,
+            Subtitle = book.Subtitle,
+            Author = book.Author,
+            Category = book.Category,
+            Status = book.Status,
+            Rating = book.Rating,
+            Notes = book.Notes,
+            DefaultCoverArtUrl = book.DefaultCoverArtUrl
+        };
+
+        SelectedGenreIds = book.Genres.Select(g => g.Id).ToList();
+        AssignedTags = book.Tags.Select(t => new TagItem(t.Id, t.Name)).ToList();
+        Copies = book.Copies.Select(c => new CopyRow(c.Id, c.Isbn, c.Format, c.Condition, c.Publisher?.Name, c.DatePrinted, c.CustomCoverArtUrl)).ToList();
+
+        await LoadAvailableTagsAsync();
+    }
+
+    public async Task LoadAvailableTagsAsync()
+    {
+        await using var db = await dbFactory.CreateDbContextAsync();
+        var assignedIds = AssignedTags.Select(t => t.Id).ToHashSet();
+        AvailableTags = await db.Tags
+            .Where(t => !assignedIds.Contains(t.Id))
+            .OrderBy(t => t.Name)
+            .Select(t => new TagItem(t.Id, t.Name))
+            .ToListAsync();
+    }
+
+    public async Task AddTagAsync()
+    {
+        if (string.IsNullOrWhiteSpace(NewTagName)) return;
+        var name = NewTagName.Trim().ToLowerInvariant();
+
+        await using var db = await dbFactory.CreateDbContextAsync();
+        var tag = await db.Tags.FirstOrDefaultAsync(t => t.Name == name);
+        if (tag is null)
+        {
+            tag = new Tag { Name = name };
+            db.Tags.Add(tag);
+            await db.SaveChangesAsync();
+        }
+
+        if (AssignedTags.All(t => t.Id != tag.Id))
+        {
+            AssignedTags.Add(new TagItem(tag.Id, tag.Name));
+            await LoadAvailableTagsAsync();
+        }
+
+        NewTagName = "";
+    }
+
+    public void RemoveTag(TagItem tag)
+    {
+        AssignedTags.RemoveAll(t => t.Id == tag.Id);
+        if (AvailableTags.All(t => t.Id != tag.Id))
+        {
+            AvailableTags.Add(tag);
+            AvailableTags = AvailableTags.OrderBy(t => t.Name).ToList();
+        }
+    }
+
+    public void ShowAddCopy()
+    {
+        NewCopyInput = new CopyFormViewModel.CopyFormInput();
+        ShowingNewCopy = true;
+    }
+
+    public async Task SaveNewCopyAsync(int bookId)
+    {
+        if (string.IsNullOrWhiteSpace(NewCopyInput.Isbn)) return;
+
+        await using var db = await dbFactory.CreateDbContextAsync();
+
+        Publisher? publisher = null;
+        var pubName = NewCopyInput.Publisher?.Trim();
+        if (!string.IsNullOrEmpty(pubName))
+        {
+            publisher = await db.Publishers.FirstOrDefaultAsync(p => p.Name == pubName);
+            if (publisher is null)
+            {
+                publisher = new Publisher { Name = pubName };
+                db.Publishers.Add(publisher);
+            }
+        }
+
+        var copy = new BookCopy
+        {
+            BookId = bookId,
+            Isbn = NewCopyInput.Isbn.Trim(),
+            Format = NewCopyInput.Format,
+            DatePrinted = NewCopyInput.DatePrinted,
+            Condition = NewCopyInput.Condition,
+            Publisher = publisher,
+            CustomCoverArtUrl = string.IsNullOrWhiteSpace(NewCopyInput.CustomCoverArtUrl) ? null : NewCopyInput.CustomCoverArtUrl.Trim()
+        };
+
+        db.BookCopies.Add(copy);
+        await db.SaveChangesAsync();
+
+        Copies.Add(new CopyRow(copy.Id, copy.Isbn, copy.Format, copy.Condition, publisher?.Name, copy.DatePrinted, copy.CustomCoverArtUrl));
+        ShowingNewCopy = false;
+    }
+
+    public void StartEditCopy(CopyRow copy)
+    {
+        EditingCopyId = copy.Id;
+        EditCopyInput = new CopyEditInput
+        {
+            Isbn = copy.Isbn,
+            Format = copy.Format,
+            Condition = copy.Condition,
+            Publisher = copy.PublisherName,
+            DatePrinted = copy.DatePrinted
+        };
+    }
+
+    public void CancelCopyEdit() => EditingCopyId = null;
+
+    public async Task SaveCopyEditAsync()
+    {
+        if (EditingCopyId is not int copyId) return;
+
+        await using var db = await dbFactory.CreateDbContextAsync();
+        var copy = await db.BookCopies.Include(c => c.Publisher).FirstOrDefaultAsync(c => c.Id == copyId);
+        if (copy is null) { EditingCopyId = null; return; }
+
+        copy.Isbn = EditCopyInput.Isbn?.Trim() ?? copy.Isbn;
+        copy.Format = EditCopyInput.Format;
+        copy.Condition = EditCopyInput.Condition;
+        copy.DatePrinted = EditCopyInput.DatePrinted;
+
+        var pubName = EditCopyInput.Publisher?.Trim();
+        if (!string.IsNullOrEmpty(pubName))
+        {
+            var publisher = await db.Publishers.FirstOrDefaultAsync(p => p.Name == pubName);
+            if (publisher is null)
+            {
+                publisher = new Publisher { Name = pubName };
+                db.Publishers.Add(publisher);
+            }
+            copy.Publisher = publisher;
+        }
+        else
+        {
+            copy.Publisher = null;
+            copy.PublisherId = null;
+        }
+
+        await db.SaveChangesAsync();
+
+        var idx = Copies.FindIndex(c => c.Id == copyId);
+        if (idx >= 0)
+        {
+            Copies[idx] = new CopyRow(copy.Id, copy.Isbn, copy.Format, copy.Condition, pubName, copy.DatePrinted, copy.CustomCoverArtUrl);
+        }
+        EditingCopyId = null;
+    }
+
+    public async Task DeleteCopyAsync(CopyRow copy)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync();
+        var entity = await db.BookCopies.FindAsync(copy.Id);
+        if (entity is not null)
+        {
+            db.BookCopies.Remove(entity);
+            await db.SaveChangesAsync();
+        }
+        Copies.RemoveAll(c => c.Id == copy.Id);
+        ConfirmingDeleteCopyId = null;
+    }
+
+    /// <returns>true if the book was deleted (caller should navigate away)</returns>
+    public async Task<bool> DeleteBookAsync(int bookId)
+    {
+        Deleting = true;
+        try
+        {
+            await using var db = await dbFactory.CreateDbContextAsync();
+            var book = await db.Books.FindAsync(bookId);
+            if (book is not null)
+            {
+                db.Books.Remove(book);
+                await db.SaveChangesAsync();
+            }
+            return true;
+        }
+        finally
+        {
+            Deleting = false;
+        }
+    }
+
+    public async Task SaveAsync(int bookId)
+    {
+        Saving = true;
+        try
+        {
+            await using var db = await dbFactory.CreateDbContextAsync();
+
+            var book = await db.Books
+                .Include(b => b.Genres)
+                .Include(b => b.Tags)
+                .FirstOrDefaultAsync(b => b.Id == bookId);
+
+            if (book is null) { NotFound = true; return; }
+
+            book.Title = BookInput!.Title!.Trim();
+            book.Subtitle = string.IsNullOrWhiteSpace(BookInput.Subtitle) ? null : BookInput.Subtitle.Trim();
+            book.Author = BookInput.Author!.Trim();
+            book.Category = BookInput.Category;
+            book.Status = BookInput.Status;
+            book.Rating = BookInput.Rating;
+            book.Notes = string.IsNullOrWhiteSpace(BookInput.Notes) ? null : BookInput.Notes.Trim();
+            book.DefaultCoverArtUrl = string.IsNullOrWhiteSpace(BookInput.DefaultCoverArtUrl) ? null : BookInput.DefaultCoverArtUrl.Trim();
+
+            var selectedGenres = await db.Genres
+                .Where(g => SelectedGenreIds.Contains(g.Id))
+                .ToListAsync();
+            book.Genres.Clear();
+            book.Genres.AddRange(selectedGenres);
+
+            var selectedTags = await db.Tags
+                .Where(t => AssignedTags.Select(at => at.Id).Contains(t.Id))
+                .ToListAsync();
+            book.Tags.Clear();
+            book.Tags.AddRange(selectedTags);
+
+            await db.SaveChangesAsync();
+            SuccessMessage = "Book saved successfully.";
+        }
+        finally
+        {
+            Saving = false;
+        }
+    }
+
+    public record TagItem(int Id, string Name);
+    public record CopyRow(int Id, string Isbn, BookFormat Format, BookCondition Condition, string? PublisherName, DateOnly? DatePrinted, string? CustomCoverArtUrl);
+
+    public class CopyEditInput
+    {
+        public string? Isbn { get; set; }
+        public BookFormat Format { get; set; }
+        public BookCondition Condition { get; set; }
+        public string? Publisher { get; set; }
+        public DateOnly? DatePrinted { get; set; }
+    }
+}

--- a/BookTracker.Web/ViewModels/BookFormViewModel.cs
+++ b/BookTracker.Web/ViewModels/BookFormViewModel.cs
@@ -1,0 +1,37 @@
+using System.ComponentModel.DataAnnotations;
+using BookTracker.Data.Models;
+
+namespace BookTracker.Web.ViewModels;
+
+public class BookFormViewModel
+{
+    public static string FormatCategory(BookCategory c) => c switch
+    {
+        BookCategory.NonFiction => "Non-Fiction",
+        _ => c.ToString()
+    };
+
+    public class BookFormInput
+    {
+        [Required, StringLength(300)]
+        public string? Title { get; set; }
+
+        [StringLength(300)]
+        public string? Subtitle { get; set; }
+
+        [Required, StringLength(200)]
+        public string? Author { get; set; }
+
+        public BookCategory Category { get; set; } = BookCategory.Fiction;
+
+        public BookStatus Status { get; set; } = BookStatus.Read;
+
+        [Range(0, 5)]
+        public int Rating { get; set; }
+
+        public string? Notes { get; set; }
+
+        [StringLength(500)]
+        public string? DefaultCoverArtUrl { get; set; }
+    }
+}

--- a/BookTracker.Web/ViewModels/BookListViewModel.cs
+++ b/BookTracker.Web/ViewModels/BookListViewModel.cs
@@ -1,0 +1,162 @@
+using BookTracker.Data;
+using BookTracker.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookTracker.Web.ViewModels;
+
+public class BookListViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory)
+{
+    public const int PageSize = 20;
+
+    public bool Loading { get; private set; } = true;
+    public List<BookListItem> Books { get; private set; } = [];
+    public int TotalCount { get; private set; }
+    public int CurrentPage { get; private set; } = 1;
+    public int TotalPages { get; private set; }
+
+    public string SearchTerm { get; set; } = "";
+    public string SelectedCategory { get; set; } = "";
+    public int SelectedGenreId { get; set; }
+    public int SelectedTagId { get; set; }
+    public string SelectedAuthor { get; set; } = "";
+
+    public List<GenreOption> AllGenres { get; private set; } = [];
+    public List<TagOption> AllTags { get; private set; } = [];
+    public List<string> AllAuthors { get; private set; } = [];
+
+    public async Task InitializeAsync()
+    {
+        await LoadFilterOptionsAsync();
+        await LoadBooksAsync();
+    }
+
+    private async Task LoadFilterOptionsAsync()
+    {
+        await using var db = await dbFactory.CreateDbContextAsync();
+
+        var genres = await db.Genres
+            .OrderBy(g => g.Name)
+            .Select(g => new GenreOption(g.Id, g.Name, g.ParentGenreId))
+            .ToListAsync();
+
+        var topLevel = genres.Where(g => g.ParentGenreId is null).OrderBy(g => g.Name).ToList();
+        AllGenres = [];
+        foreach (var parent in topLevel)
+        {
+            AllGenres.Add(parent);
+            var children = genres.Where(g => g.ParentGenreId == parent.Id).OrderBy(g => g.Name);
+            AllGenres.AddRange(children);
+        }
+
+        AllTags = await db.Tags
+            .OrderBy(t => t.Name)
+            .Select(t => new TagOption(t.Id, t.Name))
+            .ToListAsync();
+
+        AllAuthors = await db.Books
+            .Select(b => b.Author)
+            .Distinct()
+            .OrderBy(a => a)
+            .ToListAsync();
+    }
+
+    public async Task LoadBooksAsync()
+    {
+        Loading = true;
+
+        await using var db = await dbFactory.CreateDbContextAsync();
+
+        IQueryable<Book> query = db.Books
+            .Include(b => b.Genres)
+            .Include(b => b.Tags);
+
+        if (!string.IsNullOrWhiteSpace(SearchTerm))
+        {
+            var term = SearchTerm.Trim();
+            query = query.Where(b => b.Title.Contains(term) || b.Author.Contains(term));
+        }
+
+        if (!string.IsNullOrEmpty(SelectedCategory) && Enum.TryParse<BookCategory>(SelectedCategory, out var cat))
+        {
+            query = query.Where(b => b.Category == cat);
+        }
+
+        if (SelectedGenreId > 0)
+        {
+            query = query.Where(b => b.Genres.Any(g => g.Id == SelectedGenreId));
+        }
+
+        if (SelectedTagId > 0)
+        {
+            query = query.Where(b => b.Tags.Any(t => t.Id == SelectedTagId));
+        }
+
+        if (!string.IsNullOrWhiteSpace(SelectedAuthor))
+        {
+            var author = SelectedAuthor.Trim();
+            query = query.Where(b => b.Author == author);
+        }
+
+        TotalCount = await query.CountAsync();
+        TotalPages = Math.Max(1, (int)Math.Ceiling(TotalCount / (double)PageSize));
+        if (CurrentPage > TotalPages) CurrentPage = TotalPages;
+
+        Books = await query
+            .OrderByDescending(b => b.DateAdded)
+            .Skip((CurrentPage - 1) * PageSize)
+            .Take(PageSize)
+            .Select(b => new BookListItem(
+                b.Id,
+                b.Title,
+                b.Subtitle,
+                b.Author,
+                b.DefaultCoverArtUrl,
+                b.Status,
+                b.Rating,
+                b.Genres.Select(g => g.Name).ToList(),
+                b.Tags.Select(t => t.Name).ToList()
+            ))
+            .ToListAsync();
+
+        Loading = false;
+    }
+
+    public async Task ApplyFiltersAsync()
+    {
+        CurrentPage = 1;
+        await LoadBooksAsync();
+    }
+
+    public async Task ClearFiltersAsync()
+    {
+        SearchTerm = "";
+        SelectedCategory = "";
+        SelectedGenreId = 0;
+        SelectedTagId = 0;
+        SelectedAuthor = "";
+        CurrentPage = 1;
+        await LoadBooksAsync();
+    }
+
+    public async Task GoToPageAsync(int page)
+    {
+        if (page < 1 || page > TotalPages) return;
+        CurrentPage = page;
+        await LoadBooksAsync();
+    }
+
+    public static string StatusBadgeClass(BookStatus status) => status switch
+    {
+        BookStatus.Reading => "bg-primary",
+        BookStatus.Read => "bg-success",
+        BookStatus.Unread => "bg-secondary",
+        _ => "bg-secondary"
+    };
+
+    public record BookListItem(
+        int Id, string Title, string? Subtitle, string Author, string? CoverUrl,
+        BookStatus Status, int Rating, List<string> Genres, List<string> Tags);
+
+    public record GenreOption(int Id, string Name, int? ParentGenreId);
+    public record TagOption(int Id, string Name);
+}

--- a/BookTracker.Web/ViewModels/BulkAddViewModel.cs
+++ b/BookTracker.Web/ViewModels/BulkAddViewModel.cs
@@ -1,0 +1,245 @@
+using BookTracker.Data;
+using BookTracker.Data.Models;
+using BookTracker.Web.Services;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookTracker.Web.ViewModels;
+
+public class BulkAddViewModel(
+    IDbContextFactory<BookTrackerDbContext> dbFactory,
+    IBookLookupService lookup)
+{
+    /// <summary>
+    /// Callback for the component to marshal state changes back to the UI thread.
+    /// Wire this to <c>() => InvokeAsync(StateHasChanged)</c> in the component.
+    /// </summary>
+    public Func<Task>? OnStateChanged { get; set; }
+
+    public string IsbnInput { get; set; } = "";
+    public List<DiscoveryRow> Rows { get; } = [];
+
+    public void RemoveRow(DiscoveryRow row) => Rows.Remove(row);
+
+    public async Task AddIsbnAsync()
+    {
+        var isbn = IsbnInput.Trim();
+        if (string.IsNullOrWhiteSpace(isbn)) return;
+
+        if (Rows.Any(r => string.Equals(r.Isbn, isbn, StringComparison.OrdinalIgnoreCase)))
+        {
+            IsbnInput = "";
+            return;
+        }
+
+        var row = new DiscoveryRow { Isbn = isbn, Status = RowStatus.Searching };
+        Rows.Insert(0, row);
+        IsbnInput = "";
+
+        await CheckDuplicateAsync(row);
+
+        _ = LookupRowAsync(row);
+    }
+
+    private async Task CheckDuplicateAsync(DiscoveryRow row)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync();
+        row.IsDuplicate = await db.BookCopies.AnyAsync(c => c.Isbn == row.Isbn);
+    }
+
+    private async Task LookupRowAsync(DiscoveryRow row)
+    {
+        try
+        {
+            var result = await lookup.LookupByIsbnAsync(row.Isbn, CancellationToken.None);
+            if (result is not null)
+            {
+                row.Title = result.Title;
+                row.Author = result.Author;
+                row.CoverUrl = result.CoverUrl;
+                row.Source = result.Source;
+                row.Publisher = result.Publisher;
+                row.Subtitle = result.Subtitle;
+                row.DatePrinted = result.DatePrinted;
+                row.GenreCandidates = result.GenreCandidates.ToList();
+                row.Status = RowStatus.Found;
+            }
+            else
+            {
+                row.Title = $"Unknown book — {row.Isbn}";
+                row.Status = RowStatus.NotFound;
+            }
+        }
+        catch
+        {
+            row.Title = $"Unknown book — {row.Isbn}";
+            row.Status = RowStatus.NotFound;
+        }
+
+        if (OnStateChanged is not null)
+            await OnStateChanged();
+    }
+
+    public async Task AcceptRowAsync(DiscoveryRow row)
+    {
+        await SaveBookAsync(row, followUp: false);
+        row.Action = RowAction.Accepted;
+    }
+
+    public async Task FollowUpRowAsync(DiscoveryRow row)
+    {
+        await SaveBookAsync(row, followUp: true);
+        row.Action = RowAction.FollowUp;
+    }
+
+    public async Task FollowUpNotFoundAsync(DiscoveryRow row)
+    {
+        if (string.IsNullOrWhiteSpace(row.Title))
+        {
+            row.Title = $"Unknown book — {row.Isbn}";
+        }
+        await SaveBookAsync(row, followUp: true);
+        row.Action = RowAction.FollowUp;
+    }
+
+    public async Task AcceptAllFoundAsync()
+    {
+        var pending = Rows.Where(r => r.Status == RowStatus.Found && r.Action == RowAction.Pending && !r.IsDuplicate).ToList();
+        foreach (var row in pending)
+        {
+            await AcceptRowAsync(row);
+        }
+    }
+
+    private async Task SaveBookAsync(DiscoveryRow row, bool followUp)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync();
+
+        if (row.IsDuplicate)
+        {
+            var existingCopy = await db.BookCopies
+                .Include(c => c.Book)
+                .FirstOrDefaultAsync(c => c.Isbn == row.Isbn);
+
+            if (existingCopy is not null)
+            {
+                var newCopy = new BookCopy
+                {
+                    BookId = existingCopy.BookId,
+                    Isbn = row.Isbn,
+                    Format = BookFormat.Softcopy,
+                    Condition = BookCondition.Good
+                };
+                db.BookCopies.Add(newCopy);
+
+                if (followUp)
+                {
+                    var book = await db.Books.Include(b => b.Tags).FirstAsync(b => b.Id == existingCopy.BookId);
+                    await EnsureFollowUpTagAsync(db, book);
+                }
+
+                await db.SaveChangesAsync();
+                return;
+            }
+        }
+
+        Publisher? publisher = null;
+        var pubName = row.Publisher?.Trim();
+        if (!string.IsNullOrEmpty(pubName))
+        {
+            publisher = await db.Publishers.FirstOrDefaultAsync(p => p.Name == pubName);
+            if (publisher is null)
+            {
+                publisher = new Publisher { Name = pubName };
+                db.Publishers.Add(publisher);
+            }
+        }
+
+        var newBook = new Book
+        {
+            Title = (row.Title ?? $"Unknown book — {row.Isbn}").Trim(),
+            Subtitle = row.Subtitle,
+            Author = (row.Author ?? "Unknown").Trim(),
+            DefaultCoverArtUrl = row.CoverUrl,
+            Copies =
+            [
+                new BookCopy
+                {
+                    Isbn = row.Isbn,
+                    Format = BookFormat.Softcopy,
+                    Condition = BookCondition.Good,
+                    DatePrinted = row.DatePrinted,
+                    Publisher = publisher
+                }
+            ]
+        };
+
+        if (row.GenreCandidates.Count > 0)
+        {
+            var allGenres = await db.Genres.ToListAsync();
+            var matched = new HashSet<int>();
+            foreach (var candidate in row.GenreCandidates)
+            {
+                var genre = allGenres.FirstOrDefault(g => GenrePickerViewModel.FuzzyGenreMatch(candidate, g.Name));
+                if (genre is not null && matched.Add(genre.Id))
+                {
+                    newBook.Genres.Add(genre);
+                    if (genre.ParentGenreId is int parentId && matched.Add(parentId))
+                    {
+                        var parent = allGenres.FirstOrDefault(g => g.Id == parentId);
+                        if (parent is not null) newBook.Genres.Add(parent);
+                    }
+                }
+            }
+        }
+
+        db.Books.Add(newBook);
+        await db.SaveChangesAsync();
+
+        if (followUp)
+        {
+            await EnsureFollowUpTagAsync(db, newBook);
+            await db.SaveChangesAsync();
+        }
+    }
+
+    private static async Task EnsureFollowUpTagAsync(BookTrackerDbContext db, Book book)
+    {
+        var tag = await db.Tags.FirstOrDefaultAsync(t => t.Name == "follow-up");
+        if (tag is null)
+        {
+            tag = new Tag { Name = "follow-up" };
+            db.Tags.Add(tag);
+        }
+        if (!book.Tags.Any(t => t.Name == "follow-up"))
+        {
+            book.Tags.Add(tag);
+        }
+    }
+
+    public static string RowCssClass(DiscoveryRow row) => row.Action switch
+    {
+        RowAction.Accepted => "table-success",
+        RowAction.FollowUp => "table-warning",
+        RowAction.Duplicate => "table-secondary",
+        _ => ""
+    };
+
+    public class DiscoveryRow
+    {
+        public string Isbn { get; set; } = "";
+        public string? Title { get; set; }
+        public string? Subtitle { get; set; }
+        public string? Author { get; set; }
+        public string? CoverUrl { get; set; }
+        public string? Source { get; set; }
+        public string? Publisher { get; set; }
+        public DateOnly? DatePrinted { get; set; }
+        public List<string> GenreCandidates { get; set; } = [];
+        public RowStatus Status { get; set; }
+        public RowAction Action { get; set; } = RowAction.Pending;
+        public bool IsDuplicate { get; set; }
+    }
+
+    public enum RowStatus { Searching, Found, NotFound }
+    public enum RowAction { Pending, Accepted, FollowUp, Duplicate }
+}

--- a/BookTracker.Web/ViewModels/CopyFormViewModel.cs
+++ b/BookTracker.Web/ViewModels/CopyFormViewModel.cs
@@ -1,0 +1,48 @@
+using System.ComponentModel.DataAnnotations;
+using BookTracker.Data;
+using BookTracker.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookTracker.Web.ViewModels;
+
+public class CopyFormViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory)
+{
+    public List<PublisherOption> ExistingPublishers { get; private set; } = [];
+
+    public async Task InitializeAsync()
+    {
+        await using var db = await dbFactory.CreateDbContextAsync();
+        ExistingPublishers = await db.Publishers
+            .OrderBy(p => p.Name)
+            .Select(p => new PublisherOption(p.Id, p.Name))
+            .ToListAsync();
+    }
+
+    public static string FormatCondition(BookCondition c) => c switch
+    {
+        BookCondition.AsNew => "As New",
+        BookCondition.VeryGood => "Very Good",
+        _ => c.ToString()
+    };
+
+    public record PublisherOption(int Id, string Name);
+
+    public class CopyFormInput
+    {
+        [Required, StringLength(20)]
+        [RegularExpression(@"^(97(8|9))?\d{9}(\d|X|x)$", ErrorMessage = "Enter a valid 10- or 13-digit ISBN.")]
+        public string? Isbn { get; set; }
+
+        public BookFormat Format { get; set; } = BookFormat.Softcopy;
+
+        public DateOnly? DatePrinted { get; set; }
+
+        public BookCondition Condition { get; set; } = BookCondition.Good;
+
+        [StringLength(200)]
+        public string? Publisher { get; set; }
+
+        [StringLength(500)]
+        public string? CustomCoverArtUrl { get; set; }
+    }
+}

--- a/BookTracker.Web/ViewModels/GenrePickerViewModel.cs
+++ b/BookTracker.Web/ViewModels/GenrePickerViewModel.cs
@@ -1,0 +1,78 @@
+using BookTracker.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookTracker.Web.ViewModels;
+
+public class GenrePickerViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory)
+{
+    public List<GenreNode> TopLevelGenres { get; private set; } = [];
+    public Dictionary<int, GenreNode> GenreById { get; private set; } = [];
+    public List<int> SelectedGenreIds { get; set; } = [];
+    public List<string> LookupCandidates { get; set; } = [];
+
+    public async Task InitializeAsync()
+    {
+        await using var db = await dbFactory.CreateDbContextAsync();
+        var all = await db.Genres
+            .OrderBy(g => g.Name)
+            .Select(g => new GenreNode(g.Id, g.Name, g.ParentGenreId))
+            .ToListAsync();
+        GenreById = all.ToDictionary(g => g.Id);
+        foreach (var g in all.Where(g => g.ParentGenreId.HasValue))
+        {
+            if (GenreById.TryGetValue(g.ParentGenreId!.Value, out var parent))
+            {
+                parent.Children.Add(g);
+            }
+        }
+        TopLevelGenres = all.Where(g => g.ParentGenreId is null).OrderBy(g => g.Name).ToList();
+    }
+
+    public void ToggleGenre(int id, bool isChecked)
+    {
+        if (isChecked)
+        {
+            if (!SelectedGenreIds.Contains(id)) SelectedGenreIds.Add(id);
+            if (GenreById.TryGetValue(id, out var node) && node.ParentGenreId is int parentId
+                && !SelectedGenreIds.Contains(parentId))
+            {
+                SelectedGenreIds.Add(parentId);
+            }
+        }
+        else
+        {
+            SelectedGenreIds.Remove(id);
+        }
+    }
+
+    public void ApplyLookupCandidates(IReadOnlyList<string> candidates)
+    {
+        foreach (var candidate in candidates)
+        {
+            var match = GenreById.Values.FirstOrDefault(g => FuzzyGenreMatch(candidate, g.Name));
+            if (match is not null)
+            {
+                ToggleGenre(match.Id, true);
+            }
+        }
+    }
+
+    public static bool FuzzyGenreMatch(string candidate, string preset)
+    {
+        var nc = Normalize(candidate);
+        var np = Normalize(preset);
+        if (nc.Length == 0 || np.Length == 0) return false;
+        return nc == np || nc.Contains(np) || np.Contains(nc);
+    }
+
+    public static string Normalize(string s) =>
+        new string(s.Where(char.IsLetterOrDigit).ToArray()).ToLowerInvariant();
+
+    public class GenreNode(int id, string name, int? parentGenreId)
+    {
+        public int Id { get; } = id;
+        public string Name { get; } = name;
+        public int? ParentGenreId { get; } = parentGenreId;
+        public List<GenreNode> Children { get; } = [];
+    }
+}

--- a/BookTracker.Web/ViewModels/HomeViewModel.cs
+++ b/BookTracker.Web/ViewModels/HomeViewModel.cs
@@ -1,0 +1,50 @@
+using BookTracker.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookTracker.Web.ViewModels;
+
+public class HomeViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory)
+{
+    public int TotalBooks { get; private set; }
+    public int TotalAuthors { get; private set; }
+    public List<AuthorCount> TopAuthors { get; private set; } = [];
+    public List<GenreCount> TopGenres { get; private set; } = [];
+    public int MaxAuthor { get; private set; }
+    public int MaxGenre { get; private set; }
+
+    public async Task InitializeAsync()
+    {
+        await using var db = await dbFactory.CreateDbContextAsync();
+
+        TotalBooks = await db.Books.CountAsync();
+
+        TotalAuthors = await db.Books
+            .Select(b => b.Author)
+            .Distinct()
+            .CountAsync();
+
+        var authors = await db.Books
+            .GroupBy(b => b.Author)
+            .Select(g => new { Author = g.Key, Count = g.Count() })
+            .OrderByDescending(x => x.Count)
+            .ThenBy(x => x.Author)
+            .Take(10)
+            .ToListAsync();
+        TopAuthors = authors.Select(x => new AuthorCount(x.Author, x.Count)).ToList();
+
+        var genres = await db.Genres
+            .Select(g => new { Genre = g.Name, Count = g.Books.Count })
+            .Where(x => x.Count > 0)
+            .OrderByDescending(x => x.Count)
+            .ThenBy(x => x.Genre)
+            .Take(10)
+            .ToListAsync();
+        TopGenres = genres.Select(x => new GenreCount(x.Genre, x.Count)).ToList();
+
+        MaxAuthor = TopAuthors.Count > 0 ? TopAuthors.Max(a => a.Count) : 0;
+        MaxGenre = TopGenres.Count > 0 ? TopGenres.Max(g => g.Count) : 0;
+    }
+
+    public record AuthorCount(string Author, int Count);
+    public record GenreCount(string Genre, int Count);
+}

--- a/BookTracker.slnx
+++ b/BookTracker.slnx
@@ -1,4 +1,5 @@
 <Solution>
   <Project Path="BookTracker.Data/BookTracker.Data.csproj" />
+  <Project Path="BookTracker.Tests/BookTracker.Tests.csproj" />
   <Project Path="BookTracker.Web/BookTracker.Web.csproj" />
 </Solution>


### PR DESCRIPTION
Moves all business logic, state, and data access out of @code blocks into standalone C# ViewModel classes under BookTracker.Web/ViewModels/. Components become thin binding layers that delegate to their VM.

ViewModels:
- HomeViewModel — dashboard stats
- BookFormViewModel — book metadata input model + formatting
- CopyFormViewModel — copy input model, publisher loading, formatting
- GenrePickerViewModel — genre loading, toggle logic, fuzzy matching
- BookListViewModel — filtering, pagination, book loading
- BookAddViewModel — ISBN lookup, book creation
- BookEditViewModel — book/tag/copy CRUD, delete with confirmation
- BulkAddViewModel — discovery grid, async lookup, accept/follow-up

All VMs registered as transient in DI. Scanner JS interop remains in the BulkAdd component (UI concern, not business logic).

Adds BookTracker.Tests project (xUnit + NSubstitute + EF InMemory) with 24 tests covering HomeViewModel, BulkAddViewModel, and GenrePickerViewModel to prove the pattern is testable.