### PR TITLE
fix: remove custom labels from dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,6 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-    labels:
-      - "dependencies"
-      - "nuget"
     open-pull-requests-limit: 10
 
   # npm packages (vendored JS libraries like html5-qrcode)
@@ -18,7 +15,4 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-    labels:
-      - "dependencies"
-      - "javascript"
     open-pull-requests-limit: 5


### PR DESCRIPTION
The custom labels (dependencies, nuget, javascript) don't exist on the repo and Dependabot can't create them. Remove them so Dependabot uses its default labelling.