### PR TITLE
chore: align EF Core packages to 10.0.6 and group in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 10
+    groups:
+      ef-core:
+        patterns:
+          - "Microsoft.EntityFrameworkCore*"
 
   # npm packages (vendored JS libraries like html5-qrcode)
   - package-ecosystem: "npm"

--- a/BookTracker.Data/BookTracker.Data.csproj
+++ b/BookTracker.Data/BookTracker.Data.csproj
@@ -11,7 +11,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.6">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/BookTracker.Web/BookTracker.Web.csproj
+++ b/BookTracker.Web/BookTracker.Web.csproj
@@ -11,7 +11,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.6" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Bumps Microsoft.EntityFrameworkCore.SqlServer to 10.0.6 in both projects to match Design/Tools, resolving version conflict warnings.

Adds an ef-core group to dependabot.yml so all EF Core packages are always bumped together in a single PR, preventing version mismatches.