### PR TITLE
feat: mobile-responsive layouts for library list and bulk add

### DIFF
--- a/BookTracker.Web/Components/Pages/Books/BulkAdd.razor
+++ b/BookTracker.Web/Components/Pages/Books/BulkAdd.razor
@@ -10,8 +10,22 @@
 
 <div class="card mb-4">
     <div class="card-body">
+        @* Mobile: scanner button first, full-width and prominent *@
+        <div class="d-md-none mb-3">
+            <button type="button" class="btn w-100 @(scannerActive ? "btn-danger" : "btn-primary")" @onclick="ToggleScannerAsync">
+                @if (scannerActive)
+                {
+                    <span>Stop scanner</span>
+                }
+                else
+                {
+                    <span>Scan barcode</span>
+                }
+            </button>
+        </div>
+
         <label class="form-label fw-semibold">Add ISBN</label>
-        <div class="input-group" style="max-width: 500px;">
+        <div class="input-group">
             <input type="text" class="form-control" placeholder="9780345391803" @bind="VM.IsbnInput"
                    @onkeyup="HandleIsbnKeyUp" />
             <button type="button" class="btn btn-outline-primary" @onclick="AddIsbnAsync" disabled="@string.IsNullOrWhiteSpace(VM.IsbnInput)">
@@ -19,7 +33,9 @@
             </button>
         </div>
         <div class="form-text">Type or paste an ISBN and press Enter, or scan a barcode with your camera.</div>
-        <div class="mt-3">
+
+        @* Desktop: scanner button below input, secondary style *@
+        <div class="d-none d-md-block mt-3">
             <button type="button" class="btn @(scannerActive ? "btn-danger" : "btn-outline-secondary")" @onclick="ToggleScannerAsync">
                 @if (scannerActive)
                 {
@@ -31,6 +47,7 @@
                 }
             </button>
         </div>
+
         @if (!string.IsNullOrEmpty(scannerError))
         {
             <div class="alert alert-warning mt-2 mb-0 py-2 small">@scannerError</div>
@@ -42,7 +59,7 @@
 {
     <div class="card mb-4">
         <div class="card-body text-center">
-            <div id="barcode-reader" style="max-width: 500px; margin: 0 auto;"></div>
+            <div id="barcode-reader" class="scanner-container"></div>
             <div class="form-text mt-2">Point your camera at the ISBN barcode on the back of the book.</div>
         </div>
     </div>
@@ -52,24 +69,26 @@
 {
     <div class="card mb-4">
         <div class="card-header bg-white d-flex justify-content-between align-items-center">
-            <h2 class="h5 mb-0">Discovered books (@VM.Rows.Count)</h2>
-            <div class="d-flex gap-2">
+            <h2 class="h5 mb-0">Discovered (@VM.Rows.Count)</h2>
+            <div class="d-flex gap-2 align-items-center">
                 @if (VM.Rows.Any(r => r.Status == BulkAddViewModel.RowStatus.Found && r.Action == BulkAddViewModel.RowAction.Pending))
                 {
                     <button type="button" class="btn btn-success btn-sm" @onclick="VM.AcceptAllFoundAsync">
-                        Accept all found
+                        Accept all
                     </button>
                 }
                 @if (VM.Rows.Any(r => r.Action == BulkAddViewModel.RowAction.Accepted || r.Action == BulkAddViewModel.RowAction.FollowUp))
                 {
-                    <span class="text-muted small align-self-center">
+                    <span class="text-muted small d-none d-md-inline">
                         @VM.Rows.Count(r => r.Action == BulkAddViewModel.RowAction.Accepted) accepted,
                         @VM.Rows.Count(r => r.Action == BulkAddViewModel.RowAction.FollowUp) follow-up
                     </span>
                 }
             </div>
         </div>
-        <div class="card-body p-0">
+
+        @* Desktop table *@
+        <div class="card-body p-0 d-none d-md-block">
             <div class="table-responsive">
                 <table class="table table-hover align-middle mb-0">
                     <thead class="table-light">
@@ -88,16 +107,7 @@
                         {
                             <tr class="@BulkAddViewModel.RowCssClass(row)">
                                 <td>
-                                    @if (!string.IsNullOrWhiteSpace(row.CoverUrl))
-                                    {
-                                        <img src="@row.CoverUrl" alt="" class="rounded" style="width: 40px; height: 56px; object-fit: cover;" />
-                                    }
-                                    else
-                                    {
-                                        <div class="rounded bg-light d-flex align-items-center justify-content-center" style="width: 40px; height: 56px;">
-                                            <span class="text-muted small">--</span>
-                                        </div>
-                                    }
+                                    @RenderCover(row)
                                 </td>
                                 <td class="font-monospace small">@row.Isbn</td>
                                 <td>
@@ -108,93 +118,19 @@
                                     }
                                     else
                                     {
-                                        @(row.Title ?? "—")
+                                        @(row.Title ?? "\u2014")
                                     }
                                 </td>
-                                <td>@(row.Author ?? "—")</td>
+                                <td>@(row.Author ?? "\u2014")</td>
                                 <td>
-                                    @if (row.Status == BulkAddViewModel.RowStatus.Searching)
-                                    {
-                                        <span class="spinner-border spinner-border-sm" role="status"></span>
-                                    }
-                                    else
-                                    {
-                                        <span class="text-muted small">@(row.Source ?? "—")</span>
-                                    }
+                                    @RenderSource(row)
                                 </td>
                                 <td>
-                                    @switch (row.Action)
-                                    {
-                                        case BulkAddViewModel.RowAction.Accepted:
-                                            <span class="badge bg-success">Accepted</span>
-                                            break;
-                                        case BulkAddViewModel.RowAction.FollowUp:
-                                            <span class="badge bg-warning text-dark">Follow-up</span>
-                                            break;
-                                        case BulkAddViewModel.RowAction.Duplicate:
-                                            <span class="badge bg-secondary">Duplicate</span>
-                                            break;
-                                        default:
-                                            @if (row.IsDuplicate)
-                                            {
-                                                <span class="badge bg-warning text-dark">Already in library</span>
-                                            }
-                                            else
-                                            {
-                                                switch (row.Status)
-                                                {
-                                                    case BulkAddViewModel.RowStatus.Found:
-                                                        <span class="badge bg-info text-dark">Found</span>
-                                                        break;
-                                                    case BulkAddViewModel.RowStatus.NotFound:
-                                                        <span class="badge bg-danger">Not found</span>
-                                                        break;
-                                                    case BulkAddViewModel.RowStatus.Searching:
-                                                        <span class="badge bg-light text-dark">Searching...</span>
-                                                        break;
-                                                }
-                                            }
-                                            break;
-                                    }
+                                    @RenderStatusBadge(row)
                                 </td>
                                 <td>
                                     <div class="d-flex gap-1 align-items-center">
-                                        @if (row.Action == BulkAddViewModel.RowAction.Pending)
-                                        {
-                                            @if (row.Status == BulkAddViewModel.RowStatus.Found)
-                                            {
-                                                <div class="btn-group btn-group-sm">
-                                                    @if (row.IsDuplicate)
-                                                    {
-                                                        <button type="button" class="btn btn-outline-success" @onclick="() => VM.AcceptRowAsync(row)" title="Add another copy">
-                                                            Add copy
-                                                        </button>
-                                                        <button type="button" class="btn btn-outline-secondary" @onclick="() => row.Action = BulkAddViewModel.RowAction.Duplicate" title="Skip duplicate">
-                                                            Skip
-                                                        </button>
-                                                    }
-                                                    else
-                                                    {
-                                                        <button type="button" class="btn btn-outline-success" @onclick="() => VM.AcceptRowAsync(row)">
-                                                            Accept
-                                                        </button>
-                                                    }
-                                                    <button type="button" class="btn btn-outline-warning" @onclick="() => VM.FollowUpRowAsync(row)">
-                                                        Follow-up
-                                                    </button>
-                                                </div>
-                                            }
-                                            else if (row.Status == BulkAddViewModel.RowStatus.NotFound)
-                                            {
-                                                <button type="button" class="btn btn-outline-warning btn-sm" @onclick="() => VM.FollowUpNotFoundAsync(row)">
-                                                    Add as follow-up
-                                                </button>
-                                            }
-                                        }
-                                        else
-                                        {
-                                            <span class="text-muted small">Done</span>
-                                        }
+                                        @RenderActions(row)
                                         <button type="button" class="btn btn-outline-danger btn-sm ms-1" @onclick="() => VM.RemoveRow(row)" title="Remove from grid">
                                             &times;
                                         </button>
@@ -205,6 +141,47 @@
                     </tbody>
                 </table>
             </div>
+        </div>
+
+        @* Mobile card layout *@
+        <div class="card-body d-md-none">
+            @foreach (var row in VM.Rows)
+            {
+                <div class="discovery-card">
+                    <div class="d-flex gap-3 align-items-start">
+                        <div class="flex-shrink-0">
+                            @RenderCover(row)
+                        </div>
+                        <div class="flex-grow-1 min-width-0">
+                            <div class="d-flex justify-content-between align-items-start">
+                                <div class="min-width-0">
+                                    @if (row.Status == BulkAddViewModel.RowStatus.NotFound && row.Action != BulkAddViewModel.RowAction.FollowUp)
+                                    {
+                                        <input type="text" class="form-control form-control-sm mb-1" placeholder="Book title..."
+                                               @bind="row.Title" />
+                                    }
+                                    else
+                                    {
+                                        <div class="fw-semibold text-truncate">@(row.Title ?? "\u2014")</div>
+                                    }
+                                    <div class="text-muted small">@(row.Author ?? "\u2014")</div>
+                                    <div class="font-monospace text-muted" style="font-size: 0.7rem;">@row.Isbn</div>
+                                </div>
+                                <button type="button" class="btn btn-outline-danger btn-sm flex-shrink-0 ms-2" @onclick="() => VM.RemoveRow(row)" title="Remove">
+                                    &times;
+                                </button>
+                            </div>
+                            <div class="mt-2 d-flex flex-wrap gap-1 align-items-center">
+                                @RenderStatusBadge(row)
+                                @RenderSource(row)
+                            </div>
+                            <div class="mt-2">
+                                @RenderActions(row)
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            }
         </div>
     </div>
 
@@ -292,4 +269,107 @@
         }
         dotNetRef?.Dispose();
     }
+
+    private RenderFragment RenderCover(BulkAddViewModel.DiscoveryRow row) => __builder =>
+    {
+        if (!string.IsNullOrWhiteSpace(row.CoverUrl))
+        {
+            <img src="@row.CoverUrl" alt="" class="rounded" style="width: 40px; height: 56px; object-fit: cover;" />
+        }
+        else
+        {
+            <div class="rounded bg-light d-flex align-items-center justify-content-center" style="width: 40px; height: 56px;">
+                <span class="text-muted small">--</span>
+            </div>
+        }
+    };
+
+    private RenderFragment RenderSource(BulkAddViewModel.DiscoveryRow row) => __builder =>
+    {
+        if (row.Status == BulkAddViewModel.RowStatus.Searching)
+        {
+            <span class="spinner-border spinner-border-sm" role="status"></span>
+        }
+        else if (row.Source is not null)
+        {
+            <span class="text-muted small">@row.Source</span>
+        }
+    };
+
+    private RenderFragment RenderStatusBadge(BulkAddViewModel.DiscoveryRow row) => __builder =>
+    {
+        switch (row.Action)
+        {
+            case BulkAddViewModel.RowAction.Accepted:
+                <span class="badge bg-success">Accepted</span>
+                break;
+            case BulkAddViewModel.RowAction.FollowUp:
+                <span class="badge bg-warning text-dark">Follow-up</span>
+                break;
+            case BulkAddViewModel.RowAction.Duplicate:
+                <span class="badge bg-secondary">Duplicate</span>
+                break;
+            default:
+                if (row.IsDuplicate)
+                {
+                    <span class="badge bg-warning text-dark">In library</span>
+                }
+                else
+                {
+                    switch (row.Status)
+                    {
+                        case BulkAddViewModel.RowStatus.Found:
+                            <span class="badge bg-info text-dark">Found</span>
+                            break;
+                        case BulkAddViewModel.RowStatus.NotFound:
+                            <span class="badge bg-danger">Not found</span>
+                            break;
+                        case BulkAddViewModel.RowStatus.Searching:
+                            <span class="badge bg-light text-dark">Searching...</span>
+                            break;
+                    }
+                }
+                break;
+        }
+    };
+
+    private RenderFragment RenderActions(BulkAddViewModel.DiscoveryRow row) => __builder =>
+    {
+        if (row.Action == BulkAddViewModel.RowAction.Pending)
+        {
+            if (row.Status == BulkAddViewModel.RowStatus.Found)
+            {
+                <div class="btn-group btn-group-sm">
+                    @if (row.IsDuplicate)
+                    {
+                        <button type="button" class="btn btn-outline-success" @onclick="() => VM.AcceptRowAsync(row)" title="Add another copy">
+                            Add copy
+                        </button>
+                        <button type="button" class="btn btn-outline-secondary" @onclick="() => row.Action = BulkAddViewModel.RowAction.Duplicate" title="Skip duplicate">
+                            Skip
+                        </button>
+                    }
+                    else
+                    {
+                        <button type="button" class="btn btn-outline-success" @onclick="() => VM.AcceptRowAsync(row)">
+                            Accept
+                        </button>
+                    }
+                    <button type="button" class="btn btn-outline-warning" @onclick="() => VM.FollowUpRowAsync(row)">
+                        Follow-up
+                    </button>
+                </div>
+            }
+            else if (row.Status == BulkAddViewModel.RowStatus.NotFound)
+            {
+                <button type="button" class="btn btn-outline-warning btn-sm" @onclick="() => VM.FollowUpNotFoundAsync(row)">
+                    Add as follow-up
+                </button>
+            }
+        }
+        else
+        {
+            <span class="text-muted small">Done</span>
+        }
+    };
 }

--- a/BookTracker.Web/Components/Pages/Books/List.razor
+++ b/BookTracker.Web/Components/Pages/Books/List.razor
@@ -9,50 +9,64 @@
 <div class="card mb-4">
     <div class="card-body">
         <div class="row g-3 align-items-end">
-            <div class="col-md-3">
+            <div class="col-12 col-md-3">
                 <label class="form-label small text-muted">Search</label>
                 <input type="text" class="form-control" placeholder="Title or author..." @bind="VM.SearchTerm" @bind:event="oninput" @onkeyup="HandleSearchKeyUp" />
             </div>
-            <div class="col-md-2">
-                <label class="form-label small text-muted">Category</label>
-                <select class="form-select" @bind="VM.SelectedCategory" @bind:after="() => VM.ApplyFiltersAsync()">
-                    <option value="">All</option>
-                    <option value="Fiction">Fiction</option>
-                    <option value="NonFiction">Non-Fiction</option>
-                </select>
+            <div class="col-6 col-md-1 d-md-none">
+                <button type="button" class="btn btn-outline-secondary w-100" @onclick="() => showFilters = !showFilters">
+                    Filters @(showFilters ? "▲" : "▼")
+                </button>
             </div>
-            <div class="col-md-2">
-                <label class="form-label small text-muted">Genre</label>
-                <select class="form-select" @bind="VM.SelectedGenreId" @bind:after="() => VM.ApplyFiltersAsync()">
-                    <option value="0">All</option>
-                    @foreach (var g in VM.AllGenres)
-                    {
-                        var prefix = g.ParentGenreId.HasValue ? "\u00A0\u00A0\u00A0\u00A0" : "";
-                        <option value="@g.Id">@prefix@g.Name</option>
-                    }
-                </select>
+            <div class="col-6 col-md-1 d-md-none">
+                <button type="button" class="btn btn-outline-secondary w-100" @onclick="VM.ClearFiltersAsync" title="Clear filters">
+                    Clear
+                </button>
             </div>
-            <div class="col-md-2">
-                <label class="form-label small text-muted">Tag</label>
-                <select class="form-select" @bind="VM.SelectedTagId" @bind:after="() => VM.ApplyFiltersAsync()">
-                    <option value="0">All</option>
-                    @foreach (var t in VM.AllTags)
-                    {
-                        <option value="@t.Id">@t.Name</option>
-                    }
-                </select>
+            <div class="@FilterPanelCss">
+                <div class="row g-3 align-items-end">
+                    <div class="col-6 col-md">
+                        <label class="form-label small text-muted">Category</label>
+                        <select class="form-select" @bind="VM.SelectedCategory" @bind:after="() => VM.ApplyFiltersAsync()">
+                            <option value="">All</option>
+                            <option value="Fiction">Fiction</option>
+                            <option value="NonFiction">Non-Fiction</option>
+                        </select>
+                    </div>
+                    <div class="col-6 col-md">
+                        <label class="form-label small text-muted">Genre</label>
+                        <select class="form-select" @bind="VM.SelectedGenreId" @bind:after="() => VM.ApplyFiltersAsync()">
+                            <option value="0">All</option>
+                            @foreach (var g in VM.AllGenres)
+                            {
+                                var prefix = g.ParentGenreId.HasValue ? "\u00A0\u00A0\u00A0\u00A0" : "";
+                                <option value="@g.Id">@prefix@g.Name</option>
+                            }
+                        </select>
+                    </div>
+                    <div class="col-6 col-md">
+                        <label class="form-label small text-muted">Tag</label>
+                        <select class="form-select" @bind="VM.SelectedTagId" @bind:after="() => VM.ApplyFiltersAsync()">
+                            <option value="0">All</option>
+                            @foreach (var t in VM.AllTags)
+                            {
+                                <option value="@t.Id">@t.Name</option>
+                            }
+                        </select>
+                    </div>
+                    <div class="col-6 col-md">
+                        <label class="form-label small text-muted">Author</label>
+                        <input type="text" class="form-control" placeholder="Author..." list="author-filter-options" @bind="VM.SelectedAuthor" @bind:after="() => VM.ApplyFiltersAsync()" />
+                        <datalist id="author-filter-options">
+                            @foreach (var a in VM.AllAuthors)
+                            {
+                                <option value="@a"></option>
+                            }
+                        </datalist>
+                    </div>
+                </div>
             </div>
-            <div class="col-md-2">
-                <label class="form-label small text-muted">Author</label>
-                <input type="text" class="form-control" placeholder="Author..." list="author-filter-options" @bind="VM.SelectedAuthor" @bind:after="() => VM.ApplyFiltersAsync()" />
-                <datalist id="author-filter-options">
-                    @foreach (var a in VM.AllAuthors)
-                    {
-                        <option value="@a"></option>
-                    }
-                </datalist>
-            </div>
-            <div class="col-md-1">
+            <div class="col-md-1 d-none d-md-block">
                 <button type="button" class="btn btn-outline-secondary w-100" @onclick="VM.ClearFiltersAsync" title="Clear filters">
                     <span aria-hidden="true">&times;</span>
                 </button>
@@ -78,7 +92,8 @@ else if (VM.Books.Count == 0)
 }
 else
 {
-    <div class="table-responsive">
+    @* Desktop table — hidden on mobile *@
+    <div class="d-none d-md-block table-responsive">
         <table class="table table-hover align-middle">
             <thead class="table-light">
                 <tr>
@@ -134,7 +149,7 @@ else
                             @for (int i = 1; i <= 5; i++)
                             {
                                 var filled = i <= book.Rating;
-                                <span class="@(filled ? "text-warning" : "text-muted" )" style="font-size: 0.85rem;">&#9733;</span>
+                                <span class="@(filled ? "text-warning" : "text-muted")" style="font-size: 0.85rem;">&#9733;</span>
                             }
                         </td>
                     </tr>
@@ -143,12 +158,43 @@ else
         </table>
     </div>
 
+    @* Mobile card layout — hidden on desktop *@
+    <div class="d-md-none">
+        @foreach (var book in VM.Books)
+        {
+            <div class="book-card-mobile d-flex gap-3 align-items-start" @onclick="() => NavigateToEdit(book.Id)">
+                @if (!string.IsNullOrWhiteSpace(book.CoverUrl))
+                {
+                    <img src="@book.CoverUrl" alt="" class="rounded flex-shrink-0" style="width: 48px; height: 68px; object-fit: cover;" />
+                }
+                else
+                {
+                    <div class="rounded bg-light d-flex align-items-center justify-content-center flex-shrink-0" style="width: 48px; height: 68px;">
+                        <span class="text-muted small">--</span>
+                    </div>
+                }
+                <div class="flex-grow-1 min-width-0">
+                    <div class="fw-semibold text-truncate">@book.Title</div>
+                    <div class="text-muted small">@book.Author</div>
+                    <div class="mt-1 d-flex flex-wrap gap-1 align-items-center">
+                        <span class="badge @BookListViewModel.StatusBadgeClass(book.Status)">@book.Status</span>
+                        @for (int i = 1; i <= 5; i++)
+                        {
+                            var filled = i <= book.Rating;
+                            <span class="@(filled ? "text-warning" : "text-muted")" style="font-size: 0.75rem;">&#9733;</span>
+                        }
+                    </div>
+                </div>
+            </div>
+        }
+    </div>
+
     @if (VM.TotalPages > 1)
     {
-        <nav aria-label="Book list pagination">
-            <ul class="pagination justify-content-center">
+        <nav aria-label="Book list pagination" class="mt-3">
+            <ul class="pagination pagination-sm justify-content-center">
                 <li class="page-item @(VM.CurrentPage <= 1 ? "disabled" : "")">
-                    <button class="page-link" @onclick="() => VM.GoToPageAsync(VM.CurrentPage - 1)" disabled="@(VM.CurrentPage <= 1)">Previous</button>
+                    <button class="page-link" @onclick="() => VM.GoToPageAsync(VM.CurrentPage - 1)" disabled="@(VM.CurrentPage <= 1)">Prev</button>
                 </li>
                 @for (int p = 1; p <= VM.TotalPages; p++)
                 {
@@ -170,6 +216,12 @@ else
 }
 
 @code {
+    private bool showFilters;
+
+    private string FilterPanelCss => showFilters
+        ? "col-12 mt-2 d-md-contents"
+        : "col-12 mt-2 d-none d-md-contents";
+
     protected override async Task OnInitializedAsync() => await VM.InitializeAsync();
 
     private async Task HandleSearchKeyUp(KeyboardEventArgs e)

--- a/BookTracker.Web/wwwroot/css/site.css
+++ b/BookTracker.Web/wwwroot/css/site.css
@@ -48,3 +48,40 @@ body {
   font-size: 2rem;
   line-height: 1;
 }
+
+/* Book list — mobile card layout */
+.book-card-mobile {
+  border-bottom: 1px solid #e9ecef;
+  padding: 0.75rem 0;
+  cursor: pointer;
+}
+
+.book-card-mobile:last-child {
+  border-bottom: none;
+}
+
+.book-card-mobile:active {
+  background: #f8f9fa;
+}
+
+/* Discovery grid — mobile card layout */
+.discovery-card {
+  border-bottom: 1px solid #e9ecef;
+  padding: 0.75rem 0;
+}
+
+.discovery-card:last-child {
+  border-bottom: none;
+}
+
+/* Barcode scanner — responsive container */
+.scanner-container {
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+@media (max-width: 767.98px) {
+  .scanner-container {
+    max-width: 100%;
+  }
+}

--- a/BookTracker.Web/wwwroot/js/barcode-scanner.js
+++ b/BookTracker.Web/wwwroot/js/barcode-scanner.js
@@ -14,7 +14,7 @@ window.BarcodeScanner = {
 
         const config = {
             fps: 10,
-            qrbox: { width: 250, height: 150 },
+            qrbox: { width: 280, height: 80 },
             formatsToSupport: [
                 Html5QrcodeSupportedFormats.EAN_13,
                 Html5QrcodeSupportedFormats.EAN_8

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,10 @@ docker compose down         # stop (add -v to wipe the volume)
 
 Typical first-run loop: `docker compose up -d` → `dotnet ef database update ...` → `dotnet run --project .\BookTracker.Web`.
 
+## Mobile considerations
+
+The app is used on both desktop and mobile (phones for barcode scanning and quick library checks). When planning new features, always clarify whether the feature should be **mobile-prioritised** (responsive-first, tested at small breakpoints) or **web-only** (desktop layout sufficient). Key mobile workflows: bulk ISBN scanning, library search.
+
 ## Not yet in the repo
 
-No test project, no CI workflow, no Anthropic integration. When adding tests, create a sibling `BookTracker.Tests\` project and add it to `BookTracker.slnx`.
+No Anthropic integration. When adding tests, add them to the existing `BookTracker.Tests\` project.


### PR DESCRIPTION
Library list:
- Collapsible filter panel on mobile (search always visible, other filters behind a toggle button)
- Card-based layout on mobile showing cover, title, author, status badge and rating — replaces the wide table
- Desktop table layout unchanged

Bulk add:
- Scanner button full-width and primary-styled on mobile, positioned above the ISBN text input (scanning is the primary mobile workflow)
- Desktop keeps current layout (text input first, scanner secondary)
- Discovery grid uses card layout on mobile with stacked info and action buttons — replaces the wide table
- Shared RenderFragment helpers eliminate markup duplication between desktop table and mobile cards

Barcode scanner:
- qrbox changed from 250x150 to 280x80 to match the wide, thin shape of EAN-13/EAN-8 book barcodes (not square QR codes)
- Scanner container full-width on mobile, capped at 600px on desktop

Also updates CLAUDE.md with mobile considerations note.