### PR TITLE
chore: add TODO.md as centralised task tracking

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,21 @@
+# TODO
+
+Outstanding work items for BookTracker. This is the single source of truth — code-level `// TODO` comments provide local context but this file is the master list.
+
+## Infrastructure
+
+- [ ] Replace migrate-on-startup with deploy-time migration step (`Program.cs:39`) — use `dotnet ef migrations bundle` from GitHub Actions once the app goes multi-instance
+- [ ] Proper error handling — structured logging, correlation IDs, user-friendly messages by category, separate 404 handling (`Program.cs:50`, `Error.razor`)
+- [ ] GitHub Environment with required reviewers for staging-to-production slot swap (`infra/README.md`)
+
+## UI / UX
+
+- [ ] Evaluate Blazor component library (MudBlazor, Radzen, FluentUI) to replace hand-rolled Bootstrap (`Program.cs:9`)
+- [ ] Manage publishers UI — rename/merge duplicates, delete unused (`Publisher.cs:5`)
+- [ ] Accessibility review — screen reader support, keyboard nav, ARIA labels, colour contrast, focus management
+- [ ] UI testing approach — evaluate bUnit (component-level) and/or Playwright (browser-level) for testing screens and views
+
+## Planned features
+
+- [ ] AI book recommendations via the Anthropic API
+- [ ] Wishlist UI (model exists, no pages yet)


### PR DESCRIPTION
Consolidates scattered TODO items from code comments, memory, and README files into a single master list. Code-level // TODO comments remain for local context but TODO.md is the source of truth.