### PR TITLE
chore: back up Claude Code memories to repo

### DIFF
--- a/.claude-memory/MEMORY.md
+++ b/.claude-memory/MEMORY.md
@@ -1,0 +1,11 @@
+- [GitHub push/PR hand-off](feedback_github_push.md) — never push branches or open PRs; tell the user to do it and wait for merge confirmation.
+- ["plan:" prefix](feedback_plan_prefix.md) — when a message starts with "plan:", propose with defaults + open questions and wait; don't execute.
+- [Drew — solo developer](user_drew.md) — context on the user, their stack (Windows/PowerShell/Azure/GitHub `N3rdage/the-library`, Gandi DNS), and collaboration style.
+- [Auto-commit locally](feedback_commit_locally.md) — always stage and commit before handing off; don't wait to be asked.
+- [Delete merged branches](feedback_delete_merged_branch.md) — delete local feature branch after pulling the merge into main.
+- [Ask about mobile priority](feedback_mobile_priority.md) — when planning features, ask if mobile+web or web-only.
+- [Feature planning conventions](feedback_planning_conventions.md) — always plan first, PR breakdown for medium+, flag 5+ file changes as complex.
+- [Testing conventions](feedback_testing_conventions.md) — minimal tests for new logic to prevent regression; skip for pure markup.
+- [Deployment safety](feedback_deployment_safety.md) — migrations must retain data; breaking changes need defaults and review tags.
+- [Performance target](project_performance_target.md) — system must handle 3000+ copies; flag designs that might struggle at scale.
+- [TODO tracking](feedback_todo_tracking.md) — all TODOs in TODO.md; "sync TODOs" reconciles memory + code + TODO.md.

--- a/.claude-memory/feedback_commit_locally.md
+++ b/.claude-memory/feedback_commit_locally.md
@@ -1,0 +1,11 @@
+---
+name: Auto-commit locally
+description: Always stage and commit changes locally before handing off — don't wait to be asked.
+type: feedback
+originSessionId: f4ac39e5-d24f-4335-a75d-edce7263c131
+---
+Always stage and commit changes locally (with a descriptive commit message) before telling Drew the branch is ready. Do this by default — don't wait for him to ask.
+
+**Why:** Drew prefers the branch to be commit-ready when he picks it up for push/PR.
+
+**How to apply:** After finishing work on a branch, stage the relevant files and commit with a conventional-commit-style message before reporting completion.

--- a/.claude-memory/feedback_delete_merged_branch.md
+++ b/.claude-memory/feedback_delete_merged_branch.md
@@ -1,0 +1,11 @@
+---
+name: Delete merged branches
+description: Always delete the local feature branch after switching to main and pulling the merge.
+type: feedback
+originSessionId: f4ac39e5-d24f-4335-a75d-edce7263c131
+---
+After a PR is merged, when switching back to main and pulling, also delete the local feature branch with `git branch -d <branch>`.
+
+**Why:** Drew wants a clean local branch list — no stale merged branches.
+
+**How to apply:** Run `git checkout main && git pull && git branch -d <branch>` as a single step when Drew confirms a PR is merged.

--- a/.claude-memory/feedback_deployment_safety.md
+++ b/.claude-memory/feedback_deployment_safety.md
@@ -1,0 +1,13 @@
+---
+name: Deployment and migration safety
+description: All migrations must retain existing data. Breaking model changes need defaults and review tags.
+type: feedback
+originSessionId: f4ac39e5-d24f-4335-a75d-edce7263c131
+---
+Always discuss deployment impact in feature plans. Once the system is in use, data loss is unacceptable.
+
+All EF migrations must retain existing data. If a model change is breaking (e.g. new required column on existing table), add a default value and consider adding a "review" tag so the user can audit affected records.
+
+**Why:** The system will have real user data. A migration that drops or corrupts data is worse than a delayed feature.
+
+**How to apply:** In every plan that involves model changes, explicitly state the migration strategy and confirm data is preserved. Flag any migration that could be destructive.

--- a/.claude-memory/feedback_github_push.md
+++ b/.claude-memory/feedback_github_push.md
@@ -1,0 +1,15 @@
+---
+name: Do not push branches or open PRs — ask the user to do it
+description: Workflow rule for GitHub interaction on this project — Claude stages/commits locally but hands off push + PR creation to the user, who also confirms merge.
+type: feedback
+originSessionId: 8924a252-f12e-4d8b-98b2-37192eef16f6
+---
+When work is ready to leave the local machine, do **not** run `git push` or try to create a pull request. Instead, tell the user: **"push the changes and create a PR"** and stop. Wait for the user to confirm the PR has been merged into `main` before treating the change as landed or moving on to follow-up branches.
+
+**Why:** The user wants control over what hits the remote and when the PR is opened. Unilateral pushes bypass that review step.
+
+**How to apply:**
+- Local work (branch creation, commits, building, testing) is fine to do autonomously.
+- After the final commit on a feature branch, do not push — output the hand-off phrase.
+- Do not poll, retry, or assume merge status. Wait for the user to say it's merged.
+- Only after the user confirms merge should you `git checkout main`, `git pull`, and start the next branch.

--- a/.claude-memory/feedback_mobile_priority.md
+++ b/.claude-memory/feedback_mobile_priority.md
@@ -1,0 +1,11 @@
+---
+name: Ask about mobile priority
+description: When planning new features, always ask whether the feature should be prioritised for mobile+web or web-only.
+type: feedback
+originSessionId: f4ac39e5-d24f-4335-a75d-edce7263c131
+---
+When planning a new feature, always ask Drew whether it should be prioritised for mobile and web, or web-only. He may forget to mention this.
+
+**Why:** The app is used on phones (barcode scanning, quick library checks) as well as desktop. Mobile-first features need different layout and interaction patterns.
+
+**How to apply:** During the planning phase of any new feature, include an explicit question: "Should this be mobile-prioritised or web-only?"

--- a/.claude-memory/feedback_plan_prefix.md
+++ b/.claude-memory/feedback_plan_prefix.md
@@ -1,0 +1,16 @@
+---
+name: "plan:" prefix means propose, don't execute
+description: Workflow rule — when the user starts a message with "plan:", lay out options with defaults + open questions and wait for answers before writing any code.
+type: feedback
+originSessionId: 8924a252-f12e-4d8b-98b2-37192eef16f6
+---
+When the user prefixes a request with **"plan:"** (or similar planning language), do NOT execute. Produce a tight plan: the approach you'd take, concrete defaults you'd pick, and any open questions that meaningfully change the work. Then stop and wait for confirmation or answers.
+
+**Why:** The user wants to steer architectural choices before implementation starts. Going straight to code skips that steering step and ends up with work that has to be redone.
+
+**How to apply:**
+- Recognize "plan:", "plan out", "think through", and similar planning prompts as signals to propose-not-execute.
+- Keep the plan concise: bullets, not essays. Cover file structure, trade-offs, and the one or two decisions that matter.
+- Pose open questions with sensible recommended defaults so the user can answer "go with your defaults" and move on fast.
+- Once the user answers (or says "execute"), go directly to work — don't re-plan.
+- A "plan:"-flagged message does not override the push/PR hand-off rule: still stop at commit time and wait for the user to push.

--- a/.claude-memory/feedback_planning_conventions.md
+++ b/.claude-memory/feedback_planning_conventions.md
@@ -1,0 +1,26 @@
+---
+name: Feature planning conventions
+description: Rules for how to structure feature plans, PR sizing, complexity callouts, and when to plan.
+type: feedback
+originSessionId: f4ac39e5-d24f-4335-a75d-edce7263c131
+---
+Always plan before implementing, even for small changes. If Drew doesn't use the "plan:" prefix, plan anyway. For truly trivial items (typo, single-line fix), gently note it may not have needed the plan phase, but still plan it.
+
+**PR breakdown:** Always suggest a PR breakdown for medium+ complexity features. Small changes can be a single PR.
+
+**Single vs multiple PRs:** Prefer one concern per PR. Multiple concerns in a single PR are OK when: (a) separating them would be more complex (ask for clarification if unsure), or (b) the total impact is small (3 files or fewer, or a few single-line changes).
+
+**Complexity callout:** If a change is complex or touches 5+ files, explicitly flag it as a complex task in the plan.
+
+**Plan structure:**
+- What changes, broken into logical sections
+- New/modified files
+- Open questions with suggested defaults
+- PR breakdown (for medium+ features)
+- Mobile priority question
+- Performance considerations (3000+ copies)
+- Deployment impact (migrations, data safety)
+
+**Why:** Drew wants to test planning everything to build good habits. Planning catches issues early and helps align on scope before code is written.
+
+**How to apply:** Every feature request gets a plan proposal first. Flag complexity, suggest PR splits for medium+ work, and include all standard questions.

--- a/.claude-memory/feedback_testing_conventions.md
+++ b/.claude-memory/feedback_testing_conventions.md
@@ -1,0 +1,13 @@
+---
+name: Testing conventions
+description: Include minimal tests for new logic to prevent regression. Skip tests for pure markup/CSS.
+type: feedback
+originSessionId: f4ac39e5-d24f-4335-a75d-edce7263c131
+---
+Include a minimal set of tests to cover new ViewModel/business logic. The primary goal is regression prevention as complexity grows, not exhaustive coverage.
+
+Pure markup/CSS changes don't need tests.
+
+**Why:** The test suite is a safety net against regression, not a coverage target. Keep tests focused on logic that could break silently.
+
+**How to apply:** When adding new VM methods or business logic, add tests that cover the happy path and key edge cases. Don't over-test trivial logic.

--- a/.claude-memory/feedback_todo_tracking.md
+++ b/.claude-memory/feedback_todo_tracking.md
@@ -1,0 +1,20 @@
+---
+name: TODO tracking conventions
+description: All TODOs go in TODO.md. Code TODOs mirror there. "Sync TODOs" means reconcile memory + code + TODO.md.
+type: feedback
+originSessionId: f4ac39e5-d24f-4335-a75d-edce7263c131
+---
+All TODO items go in `TODO.md` at the repo root — this is the master list.
+
+When Drew asks to add a TODO, add it to `TODO.md`. If it has a specific code location, also add a `// TODO` comment in the code for local context.
+
+When Drew says "sync TODO items" (or similar), scan:
+1. Memory for any TODO-type entries
+2. Code for `// TODO` comments (grep for `TODO`)
+3. `TODO.md` for the current list
+
+Reconcile all three — add anything missing to `TODO.md`, flag any stale entries that look completed.
+
+**Why:** TODOs were scattered across memory, code comments, and README files. A single `TODO.md` is visible to both Drew and Claude, versioned in git, and has no size limits.
+
+**How to apply:** New TODOs always go to `TODO.md` first. Keep code-level `// TODO` comments for local context but treat `TODO.md` as the source of truth when enumerating outstanding work.

--- a/.claude-memory/project_performance_target.md
+++ b/.claude-memory/project_performance_target.md
@@ -1,0 +1,11 @@
+---
+name: Performance target — 3000 book copies
+description: All screens showing multiple books must handle 3000+ copies without performance issues.
+type: project
+originSessionId: f4ac39e5-d24f-4335-a75d-edce7263c131
+---
+The system should be able to handle 3,000 book instances (copies). All screens that display multiple books (library list, search results, bulk add grid, home dashboard stats) must consider this as part of layout design and query performance.
+
+**Why:** This is the expected scale of Drew's library. Designs that paginate, virtualise, or limit query results are preferred over loading everything at once.
+
+**How to apply:** When planning or reviewing any feature that lists books, flag any design that might struggle at 3000+ copies (e.g. loading all books without pagination, client-side filtering of full dataset, unbounded genre/tag queries). The library list already paginates at 20 — this is the right pattern.

--- a/.claude-memory/user_drew.md
+++ b/.claude-memory/user_drew.md
@@ -1,0 +1,15 @@
+---
+name: Drew — solo developer on BookTracker
+description: Who the user is, how they're collaborating, and the level of autonomy they grant — use to pitch explanations and defaults appropriately.
+type: user
+originSessionId: 8924a252-f12e-4d8b-98b2-37192eef16f6
+---
+Drew is a solo developer building BookTracker, a personal Azure-hosted book tracker. Works on Windows 11 with PowerShell, deploys from GitHub (`N3rdage/the-library`) to Azure via Bicep + OIDC. DNS for `silly.ninja` lives at Gandi.
+
+Experienced enough with the .NET ecosystem to have converted the app from Razor Pages to Blazor Web App mid-project and to follow along on EF Core + migration strategy discussions. Comfortable reviewing Bicep and PowerShell changes. Reads the diffs.
+
+Collaboration style:
+- Terse. Gives short answers ("OK", "go with A", numbered replies to my questions).
+- Trusts me to pick sensible defaults when the choice is low-stakes; pushes back explicitly when they want something different.
+- Prefers a single PR per cohesive feature rather than micro-PRs (even though branch protection is enforced, he's solo).
+- Expects me to propose-then-execute for non-trivial work (see the `plan:` prefix feedback memory).


### PR DESCRIPTION
Moves the Claude Code memory folder into the repo as .claude-memory/ so it's version-controlled and backed up with the project. A directory symlink at the original .claude path points here so Claude Code reads and writes transparently.