### PR TITLE
feat: add Series entity with Book relationship

### DIFF
--- a/BookTracker.Data/BookTrackerDbContext.cs
+++ b/BookTracker.Data/BookTrackerDbContext.cs
@@ -9,6 +9,7 @@ public class BookTrackerDbContext(DbContextOptions<BookTrackerDbContext> options
     public DbSet<BookCopy> BookCopies => Set<BookCopy>();
     public DbSet<Genre> Genres => Set<Genre>();
     public DbSet<Publisher> Publishers => Set<Publisher>();
+    public DbSet<Series> Series => Set<Series>();
     public DbSet<Tag> Tags => Set<Tag>();
     public DbSet<WishlistItem> WishlistItems => Set<WishlistItem>();
 
@@ -42,6 +43,16 @@ public class BookTrackerDbContext(DbContextOptions<BookTrackerDbContext> options
         modelBuilder.Entity<Publisher>()
             .HasIndex(p => p.Name)
             .IsUnique();
+
+        modelBuilder.Entity<Series>()
+            .HasIndex(s => s.Name)
+            .IsUnique();
+
+        modelBuilder.Entity<Book>()
+            .HasOne(b => b.Series)
+            .WithMany(s => s.Books)
+            .HasForeignKey(b => b.SeriesId)
+            .OnDelete(DeleteBehavior.SetNull);
 
         modelBuilder.Entity<Tag>()
             .HasIndex(t => t.Name)

--- a/BookTracker.Data/Migrations/20260417014935_AddSeries.Designer.cs
+++ b/BookTracker.Data/Migrations/20260417014935_AddSeries.Designer.cs
@@ -4,6 +4,7 @@ using BookTracker.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BookTracker.Data.Migrations
 {
     [DbContext(typeof(BookTrackerDbContext))]
-    partial class BookTrackerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260417014935_AddSeries")]
+    partial class AddSeries
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BookTracker.Data/Migrations/20260417014935_AddSeries.cs
+++ b/BookTracker.Data/Migrations/20260417014935_AddSeries.cs
@@ -1,0 +1,85 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BookTracker.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSeries : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "SeriesId",
+                table: "Books",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "SeriesOrder",
+                table: "Books",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "Series",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Name = table.Column<string>(type: "nvarchar(300)", maxLength: 300, nullable: false),
+                    Author = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    Type = table.Column<int>(type: "int", nullable: false),
+                    ExpectedCount = table.Column<int>(type: "int", nullable: true),
+                    Description = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Series", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Books_SeriesId",
+                table: "Books",
+                column: "SeriesId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Series_Name",
+                table: "Series",
+                column: "Name",
+                unique: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Books_Series_SeriesId",
+                table: "Books",
+                column: "SeriesId",
+                principalTable: "Series",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Books_Series_SeriesId",
+                table: "Books");
+
+            migrationBuilder.DropTable(
+                name: "Series");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Books_SeriesId",
+                table: "Books");
+
+            migrationBuilder.DropColumn(
+                name: "SeriesId",
+                table: "Books");
+
+            migrationBuilder.DropColumn(
+                name: "SeriesOrder",
+                table: "Books");
+        }
+    }
+}

--- a/BookTracker.Data/Models/Book.cs
+++ b/BookTracker.Data/Models/Book.cs
@@ -47,4 +47,10 @@ public class Book
     public List<BookCopy> Copies { get; set; } = [];
 
     public List<Tag> Tags { get; set; } = [];
+
+    public int? SeriesId { get; set; }
+    public Series? Series { get; set; }
+
+    /// <summary>Position in a Series (1-based). Defaults to publication order for Collections.</summary>
+    public int? SeriesOrder { get; set; }
 }

--- a/BookTracker.Data/Models/Series.cs
+++ b/BookTracker.Data/Models/Series.cs
@@ -1,0 +1,40 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace BookTracker.Data.Models;
+
+// TODO: revisit whether Series needs multiple authors (many-to-many) for
+// anthology collections — e.g. "The Best Science Fiction of the Year" has
+// a different editor each volume. For now, use "Various Authors" or leave
+// blank; per-book authors carry the detail.
+// TODO: consider API enrichment for series detection — Open Library has
+// series data for some books that could be used to auto-suggest series
+// membership during ISBN lookup.
+
+public enum SeriesType
+{
+    /// <summary>Numbered series with a known order (e.g. The Ender's Game Saga).</summary>
+    Series,
+
+    /// <summary>Loose collection without strict ordering (e.g. Discworld, Hercule Poirot).</summary>
+    Collection
+}
+
+public class Series
+{
+    public int Id { get; set; }
+
+    [Required, MaxLength(300)]
+    public string Name { get; set; } = string.Empty;
+
+    [MaxLength(200)]
+    public string? Author { get; set; }
+
+    public SeriesType Type { get; set; } = SeriesType.Series;
+
+    /// <summary>Expected number of books in a Series. Null for Collections or unknown.</summary>
+    public int? ExpectedCount { get; set; }
+
+    public string? Description { get; set; }
+
+    public List<Book> Books { get; set; } = [];
+}

--- a/TODO.md
+++ b/TODO.md
@@ -15,6 +15,14 @@ Outstanding work items for BookTracker. This is the single source of truth — c
 - [ ] Accessibility review — screen reader support, keyboard nav, ARIA labels, colour contrast, focus management
 - [ ] UI testing approach — evaluate bUnit (component-level) and/or Playwright (browser-level) for testing screens and views
 
+## Series / Collections
+
+- [ ] Revisit Collection ordering once more data is captured — currently defaults to publication order (`Series.cs`)
+- [ ] Investigate multiple authors on Series for anthology collections — e.g. "The Best Science Fiction of the Year" has different editors. Per-book authors carry the detail for now; use "Various Authors" or leave blank (`Series.cs`)
+- [ ] Investigate multi-series membership — a book like a Discworld novel could belong to both "Discworld" and "Discworld: City Watch" sub-series. Currently one series per book (`Series.cs`)
+- [ ] API enrichment for series detection — Open Library has series data that could auto-suggest series membership during ISBN lookup (`Series.cs`)
+- [ ] Context help tips in the UI explaining the difference between a "Series" (numbered, known order like The Ender's Game Saga) and a "Collection" (loose grouping like Discworld or Hercule Poirot)
+
 ## Planned features
 
 - [ ] AI book recommendations via the Anthropic API


### PR DESCRIPTION
New Series model (Name, Author, SeriesType enum Series/Collection, ExpectedCount, Description) with one-to-many relationship to Book. Book gains nullable SeriesId FK (SetNull on delete) and SeriesOrder for position within a series.

Non-breaking migration — existing books get null SeriesId/SeriesOrder.

Also adds Series-related TODOs to TODO.md: collection ordering, multi-author anthologies, multi-series membership, API enrichment, and UI context help tips.