### PR TITLE
feat: add Series list and edit pages

### DIFF
--- a/BookTracker.Web/Components/Layout/MainLayout.razor
+++ b/BookTracker.Web/Components/Layout/MainLayout.razor
@@ -23,6 +23,9 @@
                         <NavLink class="nav-link text-dark" href="books/bulk-add">Bulk add</NavLink>
                     </li>
                     <li class="nav-item">
+                        <NavLink class="nav-link text-dark" href="series">Series</NavLink>
+                    </li>
+                    <li class="nav-item">
                         <NavLink class="nav-link text-dark" href="privacy">Privacy</NavLink>
                     </li>
                 </ul>

--- a/BookTracker.Web/Components/Pages/Series/Edit.razor
+++ b/BookTracker.Web/Components/Pages/Series/Edit.razor
@@ -1,0 +1,244 @@
+@page "/series/new"
+@page "/series/{SeriesId:int}"
+@inject SeriesEditViewModel VM
+@inject NavigationManager Nav
+
+<PageTitle>@(VM.IsNew ? "New series" : "Edit series") - BookTracker</PageTitle>
+
+@if (VM.NotFound)
+{
+    <h1 class="mb-3">Series not found</h1>
+    <p>No series with ID @SeriesId exists.</p>
+    <a href="/series" class="btn btn-outline-secondary">Back to series</a>
+}
+else if (VM.Input is null)
+{
+    <div class="text-center py-5">
+        <div class="spinner-border" role="status">
+            <span class="visually-hidden">Loading...</span>
+        </div>
+    </div>
+}
+else
+{
+    <h1 class="mb-3">@(VM.IsNew ? "New series" : "Edit series")</h1>
+
+    @if (!string.IsNullOrEmpty(VM.SuccessMessage))
+    {
+        <div class="alert alert-success alert-dismissible fade show" role="alert">
+            @VM.SuccessMessage
+            <button type="button" class="btn-close" @onclick="() => VM.SuccessMessage = null" aria-label="Close"></button>
+        </div>
+    }
+
+    <EditForm Model="VM.Input" OnValidSubmit="SaveAsync" FormName="editSeries">
+        <DataAnnotationsValidator />
+
+        <div class="row g-4">
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-header bg-white"><h2 class="h5 mb-0">Details</h2></div>
+                    <div class="card-body">
+                        <div class="row g-3">
+                            <div class="col-md-6">
+                                <label class="form-label">Name</label>
+                                <InputText @bind-Value="VM.Input.Name" class="form-control" />
+                                <ValidationMessage For="() => VM.Input.Name" class="text-danger small" />
+                            </div>
+                            <div class="col-md-4">
+                                <label class="form-label">Author</label>
+                                <InputText @bind-Value="VM.Input.Author" class="form-control" placeholder="Optional" />
+                            </div>
+                            <div class="col-md-2">
+                                <label class="form-label">Type</label>
+                                <InputSelect @bind-Value="VM.Input.Type" class="form-select">
+                                    <option value="@SeriesType.Series">Series</option>
+                                    <option value="@SeriesType.Collection">Collection</option>
+                                </InputSelect>
+                            </div>
+                            @if (VM.Input.Type == SeriesType.Series)
+                            {
+                                <div class="col-md-3">
+                                    <label class="form-label">Expected books</label>
+                                    <InputNumber @bind-Value="VM.Input.ExpectedCount" class="form-control" placeholder="Optional" />
+                                </div>
+                            }
+                            <div class="col-12">
+                                <label class="form-label">Description</label>
+                                <InputTextArea @bind-Value="VM.Input.Description" class="form-control" rows="2" />
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            @if (!VM.IsNew)
+            {
+                <div class="col-12">
+                    <div class="card">
+                        <div class="card-header bg-white d-flex justify-content-between align-items-center">
+                            <h2 class="h5 mb-0">Books in this series (@VM.Books.Count)</h2>
+                            <button type="button" class="btn btn-outline-primary btn-sm" @onclick="() => VM.ShowingAddBook = !VM.ShowingAddBook">
+                                @(VM.ShowingAddBook ? "Cancel" : "Add book")
+                            </button>
+                        </div>
+                        <div class="card-body">
+                            @if (VM.ShowingAddBook)
+                            {
+                                <div class="mb-3 p-3 bg-light rounded">
+                                    <div class="input-group" style="max-width: 500px;">
+                                        <input type="text" class="form-control" placeholder="Search by title or author..."
+                                               @bind="VM.BookSearchTerm" @onkeyup="HandleBookSearchKeyUp" />
+                                        <button type="button" class="btn btn-outline-primary" @onclick="VM.SearchBooksAsync">Search</button>
+                                    </div>
+                                    @if (VM.BookSearchResults.Count > 0)
+                                    {
+                                        <div class="list-group mt-2">
+                                            @foreach (var result in VM.BookSearchResults)
+                                            {
+                                                <div class="list-group-item d-flex justify-content-between align-items-center">
+                                                    <div>
+                                                        <span class="fw-semibold">@result.Title</span>
+                                                        <span class="text-muted small ms-2">@result.Author</span>
+                                                        @if (result.CurrentSeriesId.HasValue)
+                                                        {
+                                                            <span class="badge bg-warning text-dark ms-1">Already in a series</span>
+                                                        }
+                                                    </div>
+                                                    <button type="button" class="btn btn-outline-success btn-sm" @onclick="() => AddBookAsync(result.Id)">
+                                                        Add
+                                                    </button>
+                                                </div>
+                                            }
+                                        </div>
+                                    }
+                                </div>
+                            }
+
+                            @if (VM.Books.Count == 0)
+                            {
+                                <p class="text-muted mb-0">No books in this series yet.</p>
+                            }
+                            else
+                            {
+                                <div class="table-responsive">
+                                    <table class="table table-sm align-middle mb-0">
+                                        <thead class="table-light">
+                                            <tr>
+                                                <th style="width: 80px;">#</th>
+                                                <th>Title</th>
+                                                <th>Author</th>
+                                                <th style="width: 120px;"></th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            @foreach (var book in VM.Books)
+                                            {
+                                                <tr>
+                                                    <td>
+                                                        <input type="number" class="form-control form-control-sm" style="width: 70px;"
+                                                               value="@book.SeriesOrder"
+                                                               @onchange="e => UpdateOrderAsync(book.Id, e)" />
+                                                    </td>
+                                                    <td>
+                                                        <a href="@($"/books/{book.Id}/edit")" class="text-decoration-none">@book.Title</a>
+                                                    </td>
+                                                    <td>@book.Author</td>
+                                                    <td>
+                                                        <button type="button" class="btn btn-outline-danger btn-sm" @onclick="() => VM.RemoveBookFromSeriesAsync(book.Id)">
+                                                            Remove
+                                                        </button>
+                                                    </td>
+                                                </tr>
+                                            }
+                                        </tbody>
+                                    </table>
+                                </div>
+                            }
+                        </div>
+                    </div>
+                </div>
+            }
+
+            <div class="col-12 d-flex gap-2">
+                <button type="submit" class="btn btn-primary" disabled="@VM.Saving">
+                    @if (VM.Saving)
+                    {
+                        <span class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>
+                    }
+                    @(VM.IsNew ? "Create series" : "Save changes")
+                </button>
+                <a class="btn btn-outline-secondary" href="/series">Back to series</a>
+                @if (!VM.IsNew)
+                {
+                    <div class="ms-auto">
+                        @if (VM.ConfirmingDeleteSeries)
+                        {
+                            <span class="me-2 text-danger fw-semibold">Delete this series?</span>
+                            <button type="button" class="btn btn-danger btn-sm" @onclick="DeleteSeriesAsync" disabled="@VM.Deleting">
+                                @if (VM.Deleting)
+                                {
+                                    <span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>
+                                }
+                                Yes, delete
+                            </button>
+                            <button type="button" class="btn btn-outline-secondary btn-sm" @onclick="() => VM.ConfirmingDeleteSeries = false">Cancel</button>
+                        }
+                        else
+                        {
+                            <button type="button" class="btn btn-outline-danger" @onclick="() => VM.ConfirmingDeleteSeries = true">Delete series</button>
+                        }
+                    </div>
+                }
+            </div>
+        </div>
+    </EditForm>
+}
+
+@code {
+    [Parameter]
+    public int? SeriesId { get; set; }
+
+    protected override async Task OnInitializedAsync()
+    {
+        if (SeriesId.HasValue)
+            await VM.InitializeAsync(SeriesId.Value);
+        else
+            VM.InitializeNew();
+    }
+
+    private async Task SaveAsync()
+    {
+        var resultId = await VM.SaveAsync(SeriesId);
+        if (VM.IsNew && resultId.HasValue)
+        {
+            Nav.NavigateTo($"/series/{resultId.Value}");
+        }
+    }
+
+    private async Task DeleteSeriesAsync()
+    {
+        if (SeriesId.HasValue && await VM.DeleteSeriesAsync(SeriesId.Value))
+        {
+            Nav.NavigateTo("/series");
+        }
+    }
+
+    private async Task HandleBookSearchKeyUp(KeyboardEventArgs e)
+    {
+        if (e.Key == "Enter")
+            await VM.SearchBooksAsync();
+    }
+
+    private async Task AddBookAsync(int bookId)
+    {
+        if (SeriesId.HasValue)
+            await VM.AddBookToSeriesAsync(SeriesId.Value, bookId);
+    }
+
+    private async Task UpdateOrderAsync(int bookId, ChangeEventArgs e)
+    {
+        int? newOrder = int.TryParse(e.Value?.ToString(), out var val) ? val : null;
+        await VM.UpdateBookOrderAsync(bookId, newOrder);
+    }
+}

--- a/BookTracker.Web/Components/Pages/Series/List.razor
+++ b/BookTracker.Web/Components/Pages/Series/List.razor
@@ -1,0 +1,106 @@
+@page "/series"
+@inject SeriesListViewModel VM
+@inject NavigationManager Nav
+
+<PageTitle>Series &amp; Collections - BookTracker</PageTitle>
+
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <h1 class="mb-0">Series &amp; Collections</h1>
+    <a href="/series/new" class="btn btn-primary btn-sm">New series</a>
+</div>
+
+<div class="card mb-4">
+    <div class="card-body">
+        <div class="row g-3 align-items-end">
+            <div class="col-12 col-md-5">
+                <label class="form-label small text-muted">Search</label>
+                <input type="text" class="form-control" placeholder="Name or author..." @bind="VM.SearchTerm" @bind:event="oninput" @onkeyup="HandleSearchKeyUp" />
+            </div>
+            <div class="col-6 col-md-3">
+                <label class="form-label small text-muted">Type</label>
+                <select class="form-select" @bind="VM.SelectedType" @bind:after="() => VM.ApplyFiltersAsync()">
+                    <option value="">All</option>
+                    <option value="Series">Series</option>
+                    <option value="Collection">Collection</option>
+                </select>
+            </div>
+            <div class="col-6 col-md-1">
+                <button type="button" class="btn btn-outline-secondary w-100" @onclick="VM.ClearFiltersAsync" title="Clear filters">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
+@if (VM.Loading)
+{
+    <div class="text-center py-5">
+        <div class="spinner-border" role="status">
+            <span class="visually-hidden">Loading...</span>
+        </div>
+    </div>
+}
+else if (VM.AllSeries.Count == 0)
+{
+    <div class="text-center py-5 text-muted">
+        <p class="mb-2">No series or collections found.</p>
+        <a href="/series/new" class="btn btn-primary btn-sm">Create your first series</a>
+    </div>
+}
+else
+{
+    @* Desktop table *@
+    <div class="d-none d-md-block table-responsive">
+        <table class="table table-hover align-middle">
+            <thead class="table-light">
+                <tr>
+                    <th>Name</th>
+                    <th>Author</th>
+                    <th>Type</th>
+                    <th>Books</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var item in VM.AllSeries)
+                {
+                    <tr role="button" @onclick="() => NavigateToEdit(item.Id)" style="cursor: pointer;">
+                        <td class="fw-semibold">@item.Name</td>
+                        <td>@(item.Author ?? "\u2014")</td>
+                        <td><span class="badge bg-light text-dark border">@item.Type</span></td>
+                        <td><span class="badge @SeriesListViewModel.CompletionBadgeClass(item)">@SeriesListViewModel.CompletionText(item)</span></td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    </div>
+
+    @* Mobile cards *@
+    <div class="d-md-none">
+        @foreach (var item in VM.AllSeries)
+        {
+            <div class="book-card-mobile d-flex justify-content-between align-items-center" @onclick="() => NavigateToEdit(item.Id)">
+                <div>
+                    <div class="fw-semibold">@item.Name</div>
+                    <div class="text-muted small">@(item.Author ?? "Various / unspecified")</div>
+                </div>
+                <div class="d-flex gap-1 flex-shrink-0">
+                    <span class="badge bg-light text-dark border">@item.Type</span>
+                    <span class="badge @SeriesListViewModel.CompletionBadgeClass(item)">@SeriesListViewModel.CompletionText(item)</span>
+                </div>
+            </div>
+        }
+    </div>
+}
+
+@code {
+    protected override async Task OnInitializedAsync() => await VM.InitializeAsync();
+
+    private async Task HandleSearchKeyUp(KeyboardEventArgs e)
+    {
+        if (e.Key == "Enter")
+            await VM.ApplyFiltersAsync();
+    }
+
+    private void NavigateToEdit(int seriesId) => Nav.NavigateTo($"/series/{seriesId}");
+}

--- a/BookTracker.Web/Program.cs
+++ b/BookTracker.Web/Program.cs
@@ -33,6 +33,8 @@ builder.Services.AddTransient<BookListViewModel>();
 builder.Services.AddTransient<BookAddViewModel>();
 builder.Services.AddTransient<BookEditViewModel>();
 builder.Services.AddTransient<BulkAddViewModel>();
+builder.Services.AddTransient<SeriesListViewModel>();
+builder.Services.AddTransient<SeriesEditViewModel>();
 
 var app = builder.Build();
 

--- a/BookTracker.Web/ViewModels/SeriesEditViewModel.cs
+++ b/BookTracker.Web/ViewModels/SeriesEditViewModel.cs
@@ -1,0 +1,211 @@
+using System.ComponentModel.DataAnnotations;
+using BookTracker.Data;
+using BookTracker.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookTracker.Web.ViewModels;
+
+public class SeriesEditViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory)
+{
+    public SeriesFormInput? Input { get; private set; }
+    public List<SeriesBookRow> Books { get; private set; } = [];
+    public bool NotFound { get; private set; }
+    public bool Saving { get; private set; }
+    public string? SuccessMessage { get; set; }
+    public bool IsNew { get; private set; }
+
+    // Book deletion
+    public bool ConfirmingDeleteSeries { get; set; }
+    public bool Deleting { get; private set; }
+
+    // Add book
+    public bool ShowingAddBook { get; set; }
+    public string BookSearchTerm { get; set; } = "";
+    public List<BookSearchResult> BookSearchResults { get; private set; } = [];
+
+    public void InitializeNew()
+    {
+        IsNew = true;
+        Input = new SeriesFormInput();
+    }
+
+    public async Task InitializeAsync(int seriesId)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync();
+
+        var series = await db.Series
+            .Include(s => s.Books)
+            .FirstOrDefaultAsync(s => s.Id == seriesId);
+
+        if (series is null)
+        {
+            NotFound = true;
+            return;
+        }
+
+        Input = new SeriesFormInput
+        {
+            Name = series.Name,
+            Author = series.Author,
+            Type = series.Type,
+            ExpectedCount = series.ExpectedCount,
+            Description = series.Description
+        };
+
+        Books = series.Books
+            .OrderBy(b => b.SeriesOrder ?? int.MaxValue)
+            .ThenBy(b => b.Title)
+            .Select(b => new SeriesBookRow(b.Id, b.Title, b.Author, b.SeriesOrder))
+            .ToList();
+    }
+
+    public async Task<int?> SaveAsync(int? seriesId)
+    {
+        Saving = true;
+        try
+        {
+            await using var db = await dbFactory.CreateDbContextAsync();
+
+            if (IsNew)
+            {
+                var series = new Series
+                {
+                    Name = Input!.Name!.Trim(),
+                    Author = string.IsNullOrWhiteSpace(Input.Author) ? null : Input.Author.Trim(),
+                    Type = Input.Type,
+                    ExpectedCount = Input.Type == SeriesType.Series ? Input.ExpectedCount : null,
+                    Description = string.IsNullOrWhiteSpace(Input.Description) ? null : Input.Description.Trim()
+                };
+
+                db.Series.Add(series);
+                await db.SaveChangesAsync();
+                return series.Id;
+            }
+            else
+            {
+                var series = await db.Series.FindAsync(seriesId!.Value);
+                if (series is null) { NotFound = true; return null; }
+
+                series.Name = Input!.Name!.Trim();
+                series.Author = string.IsNullOrWhiteSpace(Input.Author) ? null : Input.Author.Trim();
+                series.Type = Input.Type;
+                series.ExpectedCount = Input.Type == SeriesType.Series ? Input.ExpectedCount : null;
+                series.Description = string.IsNullOrWhiteSpace(Input.Description) ? null : Input.Description.Trim();
+
+                await db.SaveChangesAsync();
+                SuccessMessage = "Series saved successfully.";
+                return seriesId;
+            }
+        }
+        finally
+        {
+            Saving = false;
+        }
+    }
+
+    public async Task<bool> DeleteSeriesAsync(int seriesId)
+    {
+        Deleting = true;
+        try
+        {
+            await using var db = await dbFactory.CreateDbContextAsync();
+            var series = await db.Series.FindAsync(seriesId);
+            if (series is not null)
+            {
+                db.Series.Remove(series);
+                await db.SaveChangesAsync();
+            }
+            return true;
+        }
+        finally
+        {
+            Deleting = false;
+        }
+    }
+
+    public async Task SearchBooksAsync()
+    {
+        if (string.IsNullOrWhiteSpace(BookSearchTerm))
+        {
+            BookSearchResults = [];
+            return;
+        }
+
+        var term = BookSearchTerm.Trim();
+        var currentBookIds = Books.Select(b => b.Id).ToHashSet();
+
+        await using var db = await dbFactory.CreateDbContextAsync();
+        BookSearchResults = await db.Books
+            .Where(b => !currentBookIds.Contains(b.Id))
+            .Where(b => b.Title.Contains(term) || b.Author.Contains(term))
+            .OrderBy(b => b.Title)
+            .Take(10)
+            .Select(b => new BookSearchResult(b.Id, b.Title, b.Author, b.SeriesId))
+            .ToListAsync();
+    }
+
+    public async Task AddBookToSeriesAsync(int seriesId, int bookId)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync();
+        var book = await db.Books.FindAsync(bookId);
+        if (book is null) return;
+
+        var nextOrder = Books.Count > 0 ? Books.Max(b => b.SeriesOrder ?? 0) + 1 : 1;
+
+        book.SeriesId = seriesId;
+        book.SeriesOrder = nextOrder;
+        await db.SaveChangesAsync();
+
+        Books.Add(new SeriesBookRow(book.Id, book.Title, book.Author, nextOrder));
+        BookSearchResults.RemoveAll(r => r.Id == bookId);
+    }
+
+    public async Task RemoveBookFromSeriesAsync(int bookId)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync();
+        var book = await db.Books.FindAsync(bookId);
+        if (book is not null)
+        {
+            book.SeriesId = null;
+            book.SeriesOrder = null;
+            await db.SaveChangesAsync();
+        }
+        Books.RemoveAll(b => b.Id == bookId);
+    }
+
+    public async Task UpdateBookOrderAsync(int bookId, int? newOrder)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync();
+        var book = await db.Books.FindAsync(bookId);
+        if (book is not null)
+        {
+            book.SeriesOrder = newOrder;
+            await db.SaveChangesAsync();
+        }
+
+        var row = Books.FirstOrDefault(b => b.Id == bookId);
+        if (row is not null)
+        {
+            var idx = Books.IndexOf(row);
+            Books[idx] = row with { SeriesOrder = newOrder };
+        }
+    }
+
+    public record SeriesBookRow(int Id, string Title, string Author, int? SeriesOrder);
+    public record BookSearchResult(int Id, string Title, string Author, int? CurrentSeriesId);
+
+    public class SeriesFormInput
+    {
+        [Required, StringLength(300)]
+        public string? Name { get; set; }
+
+        [StringLength(200)]
+        public string? Author { get; set; }
+
+        public SeriesType Type { get; set; } = SeriesType.Series;
+
+        public int? ExpectedCount { get; set; }
+
+        public string? Description { get; set; }
+    }
+}

--- a/BookTracker.Web/ViewModels/SeriesListViewModel.cs
+++ b/BookTracker.Web/ViewModels/SeriesListViewModel.cs
@@ -1,0 +1,83 @@
+using BookTracker.Data;
+using BookTracker.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookTracker.Web.ViewModels;
+
+public class SeriesListViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory)
+{
+    public bool Loading { get; private set; } = true;
+    public List<SeriesListItem> AllSeries { get; private set; } = [];
+
+    public string SearchTerm { get; set; } = "";
+    public string SelectedType { get; set; } = "";
+
+    public async Task InitializeAsync()
+    {
+        await LoadSeriesAsync();
+    }
+
+    public async Task LoadSeriesAsync()
+    {
+        Loading = true;
+
+        await using var db = await dbFactory.CreateDbContextAsync();
+
+        IQueryable<Series> query = db.Series.Include(s => s.Books);
+
+        if (!string.IsNullOrWhiteSpace(SearchTerm))
+        {
+            var term = SearchTerm.Trim();
+            query = query.Where(s => s.Name.Contains(term) || (s.Author != null && s.Author.Contains(term)));
+        }
+
+        if (!string.IsNullOrEmpty(SelectedType) && Enum.TryParse<SeriesType>(SelectedType, out var type))
+        {
+            query = query.Where(s => s.Type == type);
+        }
+
+        AllSeries = await query
+            .OrderBy(s => s.Name)
+            .Select(s => new SeriesListItem(
+                s.Id,
+                s.Name,
+                s.Author,
+                s.Type,
+                s.Books.Count,
+                s.ExpectedCount
+            ))
+            .ToListAsync();
+
+        Loading = false;
+    }
+
+    public async Task ApplyFiltersAsync()
+    {
+        await LoadSeriesAsync();
+    }
+
+    public async Task ClearFiltersAsync()
+    {
+        SearchTerm = "";
+        SelectedType = "";
+        await LoadSeriesAsync();
+    }
+
+    public static string CompletionText(SeriesListItem item)
+    {
+        if (item.Type == SeriesType.Series && item.ExpectedCount.HasValue)
+            return $"{item.BookCount} / {item.ExpectedCount}";
+        return $"{item.BookCount} books";
+    }
+
+    public static string CompletionBadgeClass(SeriesListItem item)
+    {
+        if (item.Type == SeriesType.Series && item.ExpectedCount.HasValue)
+            return item.BookCount >= item.ExpectedCount.Value ? "bg-success" : "bg-warning text-dark";
+        return "bg-light text-dark border";
+    }
+
+    public record SeriesListItem(
+        int Id, string Name, string? Author, SeriesType Type,
+        int BookCount, int? ExpectedCount);
+}


### PR DESCRIPTION
New pages for managing book series and collections:

Series List (/series):
- Filterable by search term and type (Series/Collection)
- Shows name, author, type badge, and completion count
- Desktop table + mobile card layout
- "New series" button

Series Edit (/series/{id} and /series/new):
- Create or edit series metadata (name, author, type, expected count for numbered series, description)
- Books section: search and add existing books to the series, editable order number per book, remove books
- Warns if a book already belongs to another series
- Delete series with inline confirmation (SetNull preserves books)
- Links to book edit page from the books table

Also adds "Series" nav link and registers ViewModels in DI.