### PR TITLE
feat: add series assignment to book edit page

### DIFF
--- a/BookTracker.Web/Components/Pages/Books/Edit.razor
+++ b/BookTracker.Web/Components/Pages/Books/Edit.razor
@@ -47,6 +47,39 @@ else
 
             <div class="col-12">
                 <div class="card">
+                    <div class="card-header bg-white"><h2 class="h5 mb-0">Series</h2></div>
+                    <div class="card-body">
+                        <div class="row g-3">
+                            <div class="col-md-6">
+                                <label class="form-label">Series / Collection</label>
+                                <select class="form-select" @bind="VM.SelectedSeriesId">
+                                    <option value="">None</option>
+                                    @foreach (var s in VM.AvailableSeries)
+                                    {
+                                        <option value="@s.Id">@s.Name (@s.Type)</option>
+                                    }
+                                </select>
+                            </div>
+                            @if (VM.SelectedSeriesId.HasValue)
+                            {
+                                <div class="col-md-3">
+                                    <label class="form-label">Order / Position</label>
+                                    <InputNumber @bind-Value="VM.SeriesOrder" class="form-control" placeholder="e.g. 1" />
+                                </div>
+                                <div class="col-md-3 d-flex align-items-end">
+                                    <a href="@($"/series/{VM.SelectedSeriesId}")" class="btn btn-outline-secondary btn-sm">View series</a>
+                                </div>
+                            }
+                        </div>
+                        <div class="form-text mt-2">
+                            <a href="/series/new" target="_blank" class="text-decoration-none">Create a new series</a> if it doesn't exist yet.
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-12">
+                <div class="card">
                     <div class="card-header bg-white d-flex justify-content-between align-items-center">
                         <h2 class="h5 mb-0">Tags</h2>
                     </div>

--- a/BookTracker.Web/ViewModels/BookEditViewModel.cs
+++ b/BookTracker.Web/ViewModels/BookEditViewModel.cs
@@ -27,6 +27,11 @@ public class BookEditViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
     public CopyEditInput EditCopyInput { get; set; } = new();
     public int? ConfirmingDeleteCopyId { get; set; }
 
+    // Series
+    public int? SelectedSeriesId { get; set; }
+    public int? SeriesOrder { get; set; }
+    public List<SeriesOption> AvailableSeries { get; private set; } = [];
+
     // Book deletion
     public bool ConfirmingDeleteBook { get; set; }
     public bool Deleting { get; private set; }
@@ -64,7 +69,20 @@ public class BookEditViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
         AssignedTags = book.Tags.Select(t => new TagItem(t.Id, t.Name)).ToList();
         Copies = book.Copies.Select(c => new CopyRow(c.Id, c.Isbn, c.Format, c.Condition, c.Publisher?.Name, c.DatePrinted, c.CustomCoverArtUrl)).ToList();
 
+        SelectedSeriesId = book.SeriesId;
+        SeriesOrder = book.SeriesOrder;
+
         await LoadAvailableTagsAsync();
+        await LoadAvailableSeriesAsync();
+    }
+
+    public async Task LoadAvailableSeriesAsync()
+    {
+        await using var db = await dbFactory.CreateDbContextAsync();
+        AvailableSeries = await db.Series
+            .OrderBy(s => s.Name)
+            .Select(s => new SeriesOption(s.Id, s.Name, s.Type))
+            .ToListAsync();
     }
 
     public async Task LoadAvailableTagsAsync()
@@ -277,6 +295,9 @@ public class BookEditViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
             book.Tags.Clear();
             book.Tags.AddRange(selectedTags);
 
+            book.SeriesId = SelectedSeriesId;
+            book.SeriesOrder = SelectedSeriesId.HasValue ? SeriesOrder : null;
+
             await db.SaveChangesAsync();
             SuccessMessage = "Book saved successfully.";
         }
@@ -286,6 +307,7 @@ public class BookEditViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
         }
     }
 
+    public record SeriesOption(int Id, string Name, SeriesType Type);
     public record TagItem(int Id, string Name);
     public record CopyRow(int Id, string Isbn, BookFormat Format, BookCondition Condition, string? PublisherName, DateOnly? DatePrinted, string? CustomCoverArtUrl);
 


### PR DESCRIPTION
Adds a Series section to the book edit page between genres and tags. Users can assign a book to an existing series/collection via dropdown, set the order/position within the series, and link to the series detail page or create a new series. Clears series order when unassigned.