### PR TITLE
feat: series detection and suggestions on Add and Bulk Add

### DIFF
--- a/BookTracker.Tests/Services/SeriesMatchServiceTests.cs
+++ b/BookTracker.Tests/Services/SeriesMatchServiceTests.cs
@@ -1,0 +1,101 @@
+using BookTracker.Data.Models;
+using BookTracker.Web.Services;
+
+namespace BookTracker.Tests.Services;
+
+public class SeriesMatchServiceTests
+{
+    [Fact]
+    public async Task FindMatchAsync_AuthorWithExistingSeries_ReturnsSuggestion()
+    {
+        var factory = new TestDbContextFactory();
+        using (var db = factory.CreateDbContext())
+        {
+            var series = new Series { Name = "Discworld", Author = "Terry Pratchett", Type = SeriesType.Collection };
+            db.Series.Add(series);
+            await db.SaveChangesAsync();
+        }
+
+        var service = new SeriesMatchService(factory);
+        var match = await service.FindMatchAsync("The Colour of Magic", "Terry Pratchett");
+
+        Assert.NotNull(match);
+        Assert.Equal(MatchReason.AuthorMatch, match.Reason);
+        Assert.Equal("Discworld", match.SeriesName);
+    }
+
+    [Fact]
+    public async Task FindMatchAsync_AuthorWithMultipleSeries_TitleMatch_ReturnsSpecificSeries()
+    {
+        var factory = new TestDbContextFactory();
+        using (var db = factory.CreateDbContext())
+        {
+            db.Series.Add(new Series { Name = "Discworld", Author = "Terry Pratchett", Type = SeriesType.Collection });
+            db.Series.Add(new Series { Name = "Long Earth", Author = "Terry Pratchett", Type = SeriesType.Series });
+            await db.SaveChangesAsync();
+        }
+
+        var service = new SeriesMatchService(factory);
+        var match = await service.FindMatchAsync("The Long Earth", "Terry Pratchett");
+
+        Assert.NotNull(match);
+        Assert.Equal(MatchReason.TitleAndAuthorMatch, match.Reason);
+        Assert.Equal("Long Earth", match.SeriesName);
+    }
+
+    [Fact]
+    public async Task FindMatchAsync_AuthorWithMultipleUngroupedBooks_SuggestsCollection()
+    {
+        var factory = new TestDbContextFactory();
+        using (var db = factory.CreateDbContext())
+        {
+            db.Books.AddRange(
+                new Book { Title = "Book A", Author = "Some Author" },
+                new Book { Title = "Book B", Author = "Some Author" }
+            );
+            await db.SaveChangesAsync();
+        }
+
+        var service = new SeriesMatchService(factory);
+        var match = await service.FindMatchAsync("Book C", "Some Author");
+
+        Assert.NotNull(match);
+        Assert.Equal(MatchReason.AuthorHasMultipleBooks, match.Reason);
+    }
+
+    [Fact]
+    public async Task FindMatchAsync_NoMatch_ReturnsNull()
+    {
+        var factory = new TestDbContextFactory();
+        var service = new SeriesMatchService(factory);
+
+        var match = await service.FindMatchAsync("Random Book", "Unknown Author");
+
+        Assert.Null(match);
+    }
+
+    [Fact]
+    public async Task FindMatchAsync_NullInputs_ReturnsNull()
+    {
+        var factory = new TestDbContextFactory();
+        var service = new SeriesMatchService(factory);
+
+        Assert.Null(await service.FindMatchAsync(null, "Author"));
+        Assert.Null(await service.FindMatchAsync("Title", null));
+        Assert.Null(await service.FindMatchAsync(null, null));
+    }
+
+    [Theory]
+    [InlineData("The Hobbit: Book 3", 3)]
+    [InlineData("Ender's Game #2", 2)]
+    [InlineData("No. 5 in the series", 5)]
+    [InlineData("Vol. 1", 1)]
+    [InlineData("Volume 3: The Return", 3)]
+    [InlineData("Part II", 2)]
+    [InlineData("Part III of the Saga", 3)]
+    [InlineData("Just a Normal Title", null)]
+    public void ExtractSeriesNumber_ParsesCorrectly(string title, int? expected)
+    {
+        Assert.Equal(expected, SeriesMatchService.ExtractSeriesNumber(title));
+    }
+}

--- a/BookTracker.Tests/ViewModels/BulkAddViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/BulkAddViewModelTests.cs
@@ -10,7 +10,7 @@ public class BulkAddViewModelTests
     private readonly TestDbContextFactory _factory = new();
     private readonly IBookLookupService _lookup = Substitute.For<IBookLookupService>();
 
-    private BulkAddViewModel CreateVm() => new(_factory, _lookup);
+    private BulkAddViewModel CreateVm() => new(_factory, _lookup, new SeriesMatchService(_factory));
 
     [Fact]
     public async Task AddIsbnAsync_AddsRowToGrid()

--- a/BookTracker.Web/BookTracker.Web.csproj
+++ b/BookTracker.Web/BookTracker.Web.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="BookTracker.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.6">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/BookTracker.Web/Components/Pages/Books/Add.razor
+++ b/BookTracker.Web/Components/Pages/Books/Add.razor
@@ -29,6 +29,19 @@
                     {
                         <div class="alert alert-info mt-3 mb-0 py-2">@VM.LookupMessage</div>
                     }
+                    @if (VM.SeriesSuggestion is not null && !VM.SeriesSuggestionDismissed)
+                    {
+                        <div class="alert alert-warning mt-3 mb-0 py-2 d-flex justify-content-between align-items-center">
+                            <div>
+                                <strong>Series suggestion:</strong> @VM.SeriesSuggestion.Message
+                                @if (VM.SeriesSuggestion.SeriesId.HasValue)
+                                {
+                                    <span> &mdash; <a href="@($"/series/{VM.SeriesSuggestion.SeriesId}")">View series</a></span>
+                                }
+                            </div>
+                            <button type="button" class="btn-close btn-close-sm ms-2" @onclick="() => VM.SeriesSuggestionDismissed = true" aria-label="Dismiss"></button>
+                        </div>
+                    }
                 </div>
             </div>
         </div>

--- a/BookTracker.Web/Components/Pages/Books/BulkAdd.razor
+++ b/BookTracker.Web/Components/Pages/Books/BulkAdd.razor
@@ -120,6 +120,7 @@
                                     {
                                         @(row.Title ?? "\u2014")
                                     }
+                                    @RenderSeriesSuggestion(row)
                                 </td>
                                 <td>@(row.Author ?? "\u2014")</td>
                                 <td>
@@ -178,6 +179,7 @@
                             <div class="mt-2">
                                 @RenderActions(row)
                             </div>
+                            @RenderSeriesSuggestion(row)
                         </div>
                     </div>
                 </div>
@@ -330,6 +332,20 @@
                     }
                 }
                 break;
+        }
+    };
+
+    private RenderFragment RenderSeriesSuggestion(BulkAddViewModel.DiscoveryRow row) => __builder =>
+    {
+        if (row.SeriesSuggestion is not null && row.Action == BulkAddViewModel.RowAction.Pending)
+        {
+            <div class="text-warning small mt-1">
+                <strong>Series:</strong> @row.SeriesSuggestion.Message
+                @if (row.SeriesSuggestion.SeriesId.HasValue)
+                {
+                    <a href="@($"/series/{row.SeriesSuggestion.SeriesId}")" class="ms-1" target="_blank">View</a>
+                }
+            </div>
         }
     };
 

--- a/BookTracker.Web/Program.cs
+++ b/BookTracker.Web/Program.cs
@@ -24,6 +24,8 @@ builder.Services.AddHttpClient<IBookLookupService, BookLookupService>(client =>
     client.DefaultRequestHeaders.UserAgent.ParseAdd("BookTracker/0.1 (+github.com/N3rdage/the-library)");
 });
 
+builder.Services.AddTransient<SeriesMatchService>();
+
 // ViewModels — transient so each component instance gets its own VM.
 builder.Services.AddTransient<HomeViewModel>();
 builder.Services.AddTransient<BookFormViewModel>();

--- a/BookTracker.Web/Services/SeriesMatchService.cs
+++ b/BookTracker.Web/Services/SeriesMatchService.cs
@@ -1,0 +1,154 @@
+using System.Text.RegularExpressions;
+using BookTracker.Data;
+using BookTracker.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookTracker.Web.Services;
+
+// TODO: enhance series detection with Open Library series data from ISBN
+// lookup results. Currently uses local-only matching (author + title patterns).
+
+public partial class SeriesMatchService(IDbContextFactory<BookTrackerDbContext> dbFactory)
+{
+    /// <summary>
+    /// Checks if a book (by title and author) likely belongs to an existing series.
+    /// Returns a match suggestion or null if no match found.
+    /// </summary>
+    public async Task<SeriesMatch?> FindMatchAsync(string? title, string? author)
+    {
+        if (string.IsNullOrWhiteSpace(title) || string.IsNullOrWhiteSpace(author))
+            return null;
+
+        await using var db = await dbFactory.CreateDbContextAsync();
+
+        // Strategy 1: Check if the author already has books in a series
+        var authorSeries = await db.Series
+            .Include(s => s.Books)
+            .Where(s => s.Author != null && s.Author == author.Trim())
+            .ToListAsync();
+
+        if (authorSeries.Count > 0)
+        {
+            // If author has exactly one series, suggest it
+            if (authorSeries.Count == 1)
+            {
+                var series = authorSeries[0];
+                return new SeriesMatch(series.Id, series.Name, series.Type, MatchReason.AuthorMatch,
+                    $"This author has an existing {series.Type.ToString().ToLowerInvariant()}: \"{series.Name}\"");
+            }
+
+            // Multiple series — check if title hints at one of them
+            foreach (var series in authorSeries)
+            {
+                if (TitleContainsSeriesName(title, series.Name))
+                {
+                    return new SeriesMatch(series.Id, series.Name, series.Type, MatchReason.TitleAndAuthorMatch,
+                        $"Title and author match the {series.Type.ToString().ToLowerInvariant()} \"{series.Name}\"");
+                }
+            }
+
+            // Multiple series, no title match — suggest the first as a hint
+            return new SeriesMatch(authorSeries[0].Id, authorSeries[0].Name, authorSeries[0].Type, MatchReason.AuthorMatch,
+                $"This author has {authorSeries.Count} series/collections in the library");
+        }
+
+        // Strategy 2: Check if the author has other books (not yet in a series)
+        // that might suggest grouping
+        var authorBookCount = await db.Books
+            .CountAsync(b => b.Author == author.Trim() && b.SeriesId == null);
+
+        if (authorBookCount >= 2)
+        {
+            return new SeriesMatch(null, null, null, MatchReason.AuthorHasMultipleBooks,
+                $"This author has {authorBookCount} other books not in any series — consider creating a collection");
+        }
+
+        // Strategy 3: Title pattern matching for series indicators
+        var orderNumber = ExtractSeriesNumber(title);
+        if (orderNumber.HasValue)
+        {
+            return new SeriesMatch(null, null, null, MatchReason.TitlePattern,
+                $"Title suggests this is book #{orderNumber} in a series");
+        }
+
+        return null;
+    }
+
+    private static bool TitleContainsSeriesName(string title, string seriesName)
+    {
+        var normalizedTitle = title.ToLowerInvariant();
+        var normalizedSeries = seriesName.ToLowerInvariant();
+
+        // Direct containment
+        if (normalizedTitle.Contains(normalizedSeries) || normalizedSeries.Contains(normalizedTitle))
+            return true;
+
+        // Check if significant words from the series name appear in the title
+        var seriesWords = normalizedSeries.Split(' ', StringSplitOptions.RemoveEmptyEntries)
+            .Where(w => w.Length > 3)
+            .ToList();
+
+        if (seriesWords.Count > 0)
+        {
+            var matchCount = seriesWords.Count(w => normalizedTitle.Contains(w));
+            return matchCount >= Math.Ceiling(seriesWords.Count * 0.6);
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Extracts a series/volume number from a title.
+    /// Matches patterns like "Book 3", "#2", "Vol. 1", "Volume 5", "Part II".
+    /// </summary>
+    internal static int? ExtractSeriesNumber(string title)
+    {
+        // "Book 3", "#2", "No. 5"
+        var match = NumberPatternRegex().Match(title);
+        if (match.Success && int.TryParse(match.Groups[1].Value, out var num))
+            return num;
+
+        // "Vol. 1", "Volume 3"
+        match = VolumePatternRegex().Match(title);
+        if (match.Success && int.TryParse(match.Groups[1].Value, out num))
+            return num;
+
+        // "Part II", "Part III" etc.
+        match = RomanPartPatternRegex().Match(title);
+        if (match.Success)
+            return RomanToInt(match.Groups[1].Value);
+
+        return null;
+    }
+
+    private static int? RomanToInt(string roman) => roman.Trim().ToUpperInvariant() switch
+    {
+        "I" => 1, "II" => 2, "III" => 3, "IV" => 4, "V" => 5,
+        "VI" => 6, "VII" => 7, "VIII" => 8, "IX" => 9, "X" => 10,
+        _ => null
+    };
+
+    [GeneratedRegex(@"(?:book|#|no\.?)\s*(\d+)", RegexOptions.IgnoreCase)]
+    private static partial Regex NumberPatternRegex();
+
+    [GeneratedRegex(@"vol(?:ume)?\.?\s*(\d+)", RegexOptions.IgnoreCase)]
+    private static partial Regex VolumePatternRegex();
+
+    [GeneratedRegex(@"part\s+(I{1,3}|IV|VI{0,3}|IX|X)", RegexOptions.IgnoreCase)]
+    private static partial Regex RomanPartPatternRegex();
+}
+
+public record SeriesMatch(
+    int? SeriesId,
+    string? SeriesName,
+    SeriesType? SeriesType,
+    MatchReason Reason,
+    string Message);
+
+public enum MatchReason
+{
+    AuthorMatch,
+    TitleAndAuthorMatch,
+    AuthorHasMultipleBooks,
+    TitlePattern
+}

--- a/BookTracker.Web/ViewModels/BookAddViewModel.cs
+++ b/BookTracker.Web/ViewModels/BookAddViewModel.cs
@@ -7,7 +7,8 @@ namespace BookTracker.Web.ViewModels;
 
 public class BookAddViewModel(
     IDbContextFactory<BookTrackerDbContext> dbFactory,
-    IBookLookupService lookup)
+    IBookLookupService lookup,
+    SeriesMatchService seriesMatch)
 {
     public BookFormViewModel.BookFormInput BookInput { get; set; } = new();
     public CopyFormViewModel.CopyFormInput CopyInput { get; set; } = new();
@@ -17,6 +18,9 @@ public class BookAddViewModel(
     public string? LookupMessage { get; private set; }
     public bool LookingUp { get; private set; }
     public bool Saving { get; private set; }
+
+    public SeriesMatch? SeriesSuggestion { get; private set; }
+    public bool SeriesSuggestionDismissed { get; set; }
 
     public async Task LookupAsync(GenrePickerViewModel genrePicker)
     {
@@ -50,6 +54,9 @@ public class BookAddViewModel(
             genrePicker.ApplyLookupCandidates(LookupCandidates);
 
             LookupMessage = $"Prefilled from {result.Source}. Edit anything before saving.";
+
+            SeriesSuggestion = await seriesMatch.FindMatchAsync(result.Title, result.Author);
+            SeriesSuggestionDismissed = false;
         }
         finally
         {

--- a/BookTracker.Web/ViewModels/BulkAddViewModel.cs
+++ b/BookTracker.Web/ViewModels/BulkAddViewModel.cs
@@ -7,7 +7,8 @@ namespace BookTracker.Web.ViewModels;
 
 public class BulkAddViewModel(
     IDbContextFactory<BookTrackerDbContext> dbFactory,
-    IBookLookupService lookup)
+    IBookLookupService lookup,
+    SeriesMatchService seriesMatch)
 {
     /// <summary>
     /// Callback for the component to marshal state changes back to the UI thread.
@@ -62,6 +63,8 @@ public class BulkAddViewModel(
                 row.DatePrinted = result.DatePrinted;
                 row.GenreCandidates = result.GenreCandidates.ToList();
                 row.Status = RowStatus.Found;
+
+                row.SeriesSuggestion = await seriesMatch.FindMatchAsync(result.Title, result.Author);
             }
             else
             {
@@ -238,6 +241,7 @@ public class BulkAddViewModel(
         public RowStatus Status { get; set; }
         public RowAction Action { get; set; } = RowAction.Pending;
         public bool IsDuplicate { get; set; }
+        public SeriesMatch? SeriesSuggestion { get; set; }
     }
 
     public enum RowStatus { Searching, Found, NotFound }


### PR DESCRIPTION
New SeriesMatchService with local-only detection strategies:
1. Author already has a series — suggests it directly
2. Author has multiple series — matches by title similarity
3. Author has 2+ ungrouped books — suggests creating a collection
4. Title contains series indicators (Book #, Vol., Part II) — flags it

Add page: shows a dismissible warning banner after ISBN lookup if a series match is found, with a link to view the matched series.

Bulk Add: shows series suggestion inline on each discovery row (both desktop table and mobile card) after async lookup completes.

Also adds InternalsVisibleTo for test project and 13 new tests covering SeriesMatchService (author matching, title matching, ungrouped books, null handling, series number extraction with Theory data).