### PR TITLE
feat: extend WishlistItem with ISBN and Series fields

### DIFF
--- a/BookTracker.Data/BookTrackerDbContext.cs
+++ b/BookTracker.Data/BookTrackerDbContext.cs
@@ -54,6 +54,15 @@ public class BookTrackerDbContext(DbContextOptions<BookTrackerDbContext> options
             .HasForeignKey(b => b.SeriesId)
             .OnDelete(DeleteBehavior.SetNull);
 
+        modelBuilder.Entity<WishlistItem>()
+            .HasOne(w => w.Series)
+            .WithMany()
+            .HasForeignKey(w => w.SeriesId)
+            .OnDelete(DeleteBehavior.SetNull);
+
+        modelBuilder.Entity<WishlistItem>()
+            .HasIndex(w => w.Isbn);
+
         modelBuilder.Entity<Tag>()
             .HasIndex(t => t.Name)
             .IsUnique();

--- a/BookTracker.Data/Migrations/20260417023044_ExtendWishlistItem.Designer.cs
+++ b/BookTracker.Data/Migrations/20260417023044_ExtendWishlistItem.Designer.cs
@@ -4,6 +4,7 @@ using BookTracker.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BookTracker.Data.Migrations
 {
     [DbContext(typeof(BookTrackerDbContext))]
-    partial class BookTrackerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260417023044_ExtendWishlistItem")]
+    partial class ExtendWishlistItem
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BookTracker.Data/Migrations/20260417023044_ExtendWishlistItem.cs
+++ b/BookTracker.Data/Migrations/20260417023044_ExtendWishlistItem.cs
@@ -1,0 +1,79 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BookTracker.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class ExtendWishlistItem : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Isbn",
+                table: "WishlistItems",
+                type: "nvarchar(20)",
+                maxLength: 20,
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "SeriesId",
+                table: "WishlistItems",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "SeriesOrder",
+                table: "WishlistItems",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_WishlistItems_Isbn",
+                table: "WishlistItems",
+                column: "Isbn");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_WishlistItems_SeriesId",
+                table: "WishlistItems",
+                column: "SeriesId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_WishlistItems_Series_SeriesId",
+                table: "WishlistItems",
+                column: "SeriesId",
+                principalTable: "Series",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_WishlistItems_Series_SeriesId",
+                table: "WishlistItems");
+
+            migrationBuilder.DropIndex(
+                name: "IX_WishlistItems_Isbn",
+                table: "WishlistItems");
+
+            migrationBuilder.DropIndex(
+                name: "IX_WishlistItems_SeriesId",
+                table: "WishlistItems");
+
+            migrationBuilder.DropColumn(
+                name: "Isbn",
+                table: "WishlistItems");
+
+            migrationBuilder.DropColumn(
+                name: "SeriesId",
+                table: "WishlistItems");
+
+            migrationBuilder.DropColumn(
+                name: "SeriesOrder",
+                table: "WishlistItems");
+        }
+    }
+}

--- a/BookTracker.Data/Models/WishlistItem.cs
+++ b/BookTracker.Data/Models/WishlistItem.cs
@@ -26,4 +26,13 @@ public class WishlistItem
     public decimal? Price { get; set; }
 
     public DateTime DateAdded { get; set; } = DateTime.UtcNow;
+
+    [MaxLength(20)]
+    public string? Isbn { get; set; }
+
+    public int? SeriesId { get; set; }
+    public Series? Series { get; set; }
+
+    /// <summary>Position in the series this item would fill.</summary>
+    public int? SeriesOrder { get; set; }
 }


### PR DESCRIPTION
Adds Isbn (indexed), SeriesId (FK with SetNull), and SeriesOrder to WishlistItem so shopping list items can reference a specific ISBN and link to a series position. Non-breaking migration — all new columns are nullable, existing wishlist items unaffected.