### PR TITLE
feat: add Shopping mode with ISBN scan and search lookup

### DIFF
--- a/BookTracker.Web/Components/Layout/MainLayout.razor
+++ b/BookTracker.Web/Components/Layout/MainLayout.razor
@@ -26,6 +26,9 @@
                         <NavLink class="nav-link text-dark" href="series">Series</NavLink>
                     </li>
                     <li class="nav-item">
+                        <NavLink class="nav-link text-dark" href="shopping">Shopping</NavLink>
+                    </li>
+                    <li class="nav-item">
                         <NavLink class="nav-link text-dark" href="privacy">Privacy</NavLink>
                     </li>
                 </ul>

--- a/BookTracker.Web/Components/Pages/Shopping/Index.razor
+++ b/BookTracker.Web/Components/Pages/Shopping/Index.razor
@@ -1,0 +1,269 @@
+@page "/shopping"
+@implements IAsyncDisposable
+@inject ShoppingViewModel VM
+@inject NavigationManager Nav
+@inject IJSRuntime JS
+
+<PageTitle>Shopping - BookTracker</PageTitle>
+
+<h1 class="mb-3">Shopping</h1>
+
+<div class="card mb-4">
+    <div class="card-body">
+        @* Mobile: scanner first, prominent *@
+        <div class="d-md-none mb-3">
+            <button type="button" class="btn w-100 @(scannerActive ? "btn-danger" : "btn-primary")" @onclick="ToggleScannerAsync">
+                @if (scannerActive)
+                {
+                    <span>Stop scanner</span>
+                }
+                else
+                {
+                    <span>Scan ISBN</span>
+                }
+            </button>
+        </div>
+
+        <label class="form-label fw-semibold">Do I have this book?</label>
+        <div class="input-group">
+            <input type="text" class="form-control" placeholder="Search by title, author, or ISBN..." @bind="VM.SearchTerm"
+                   @onkeyup="HandleSearchKeyUp" />
+            <button type="button" class="btn btn-outline-primary" @onclick="SearchAsync" disabled="@VM.Searching">
+                @if (VM.Searching)
+                {
+                    <span class="spinner-border spinner-border-sm" role="status"></span>
+                }
+                else
+                {
+                    <span>Search</span>
+                }
+            </button>
+        </div>
+
+        @* Desktop: scanner below *@
+        <div class="d-none d-md-block mt-3">
+            <button type="button" class="btn @(scannerActive ? "btn-danger" : "btn-outline-secondary")" @onclick="ToggleScannerAsync">
+                @if (scannerActive)
+                {
+                    <span>Stop scanner</span>
+                }
+                else
+                {
+                    <span>Scan barcode</span>
+                }
+            </button>
+        </div>
+
+        @if (!string.IsNullOrEmpty(scannerError))
+        {
+            <div class="alert alert-warning mt-2 mb-0 py-2 small">@scannerError</div>
+        }
+    </div>
+</div>
+
+@if (scannerActive)
+{
+    <div class="card mb-4">
+        <div class="card-body text-center">
+            <div id="shopping-barcode-reader" class="scanner-container"></div>
+            <div class="form-text mt-2">Point your camera at the ISBN barcode.</div>
+        </div>
+    </div>
+}
+
+@if (VM.Result is not null)
+{
+    <div class="card mb-4">
+        <div class="card-body">
+            @if (VM.ScannedIsbn is not null)
+            {
+                <div class="text-muted small mb-2">ISBN: <span class="font-monospace">@VM.ScannedIsbn</span></div>
+            }
+
+            @if (VM.Result.MultipleResults is not null)
+            {
+                <h2 class="h6 mb-3">Found @VM.Result.MultipleResults.Count matches</h2>
+                @foreach (var item in VM.Result.MultipleResults)
+                {
+                    <div class="d-flex gap-3 align-items-center py-2 border-bottom" role="button" style="cursor: pointer;" @onclick="() => VM.SelectBookAsync(item.Id)">
+                        @if (!string.IsNullOrWhiteSpace(item.CoverUrl))
+                        {
+                            <img src="@item.CoverUrl" alt="" class="rounded flex-shrink-0" style="width: 40px; height: 56px; object-fit: cover;" />
+                        }
+                        else
+                        {
+                            <div class="rounded bg-light d-flex align-items-center justify-content-center flex-shrink-0" style="width: 40px; height: 56px;">
+                                <span class="text-muted small">--</span>
+                            </div>
+                        }
+                        <div>
+                            <div class="fw-semibold">@item.Title</div>
+                            <div class="text-muted small">@item.Author</div>
+                        </div>
+                        <span class="badge bg-success ms-auto">@item.CopyCount copies</span>
+                    </div>
+                }
+            }
+            else if (VM.Result.Found)
+            {
+                <div class="d-flex gap-3 align-items-start">
+                    @if (!string.IsNullOrWhiteSpace(VM.Result.CoverUrl))
+                    {
+                        <img src="@VM.Result.CoverUrl" alt="" class="rounded flex-shrink-0" style="width: 60px; height: 84px; object-fit: cover;" />
+                    }
+                    <div class="flex-grow-1">
+                        <div class="d-flex align-items-center gap-2 mb-1">
+                            <span class="badge bg-success fs-6">Yes, you have it!</span>
+                        </div>
+                        <div class="fw-semibold fs-5">@VM.Result.Title</div>
+                        <div class="text-muted">@VM.Result.Author</div>
+                        <div class="small mt-1">You own <strong>@VM.Result.CopyCount</strong> @(VM.Result.CopyCount == 1 ? "copy" : "copies")</div>
+
+                        @if (VM.Result.SeriesInfo is not null)
+                        {
+                            var si = VM.Result.SeriesInfo;
+                            <div class="mt-2 p-2 bg-light rounded">
+                                <div class="small fw-semibold">
+                                    Part of <a href="@($"/series/{si.SeriesId}")">@si.SeriesName</a>
+                                    <span class="badge bg-light text-dark border ms-1">@si.Type</span>
+                                </div>
+                                <div class="small text-muted">
+                                    You have @si.OwnedCount
+                                    @if (si.ExpectedCount.HasValue)
+                                    {
+                                        <span> of @si.ExpectedCount books</span>
+                                        @if (si.OwnedCount >= si.ExpectedCount.Value)
+                                        {
+                                            <span class="text-success ms-1">- Complete!</span>
+                                        }
+                                        else
+                                        {
+                                            <span class="text-warning ms-1">- @(si.ExpectedCount.Value - si.OwnedCount) missing</span>
+                                        }
+                                    }
+                                    else
+                                    {
+                                        <span> books in this @si.Type.ToString().ToLowerInvariant()</span>
+                                    }
+                                </div>
+                            </div>
+                        }
+
+                        <div class="mt-2">
+                            <a href="@($"/books/{VM.Result.BookId}/edit")" class="btn btn-outline-primary btn-sm">View book</a>
+                        </div>
+                    </div>
+                </div>
+            }
+            else
+            {
+                <div class="text-center py-3">
+                    <span class="badge bg-secondary fs-6 mb-2">Not in your library</span>
+                    <p class="text-muted small mb-2">This book isn't in your collection yet.</p>
+                    <div class="d-flex gap-2 justify-content-center">
+                        <a href="@AddBookUrl()" class="btn btn-primary btn-sm">Add to library</a>
+                        <button type="button" class="btn btn-outline-secondary btn-sm" @onclick="ClearAsync">New search</button>
+                    </div>
+                </div>
+            }
+        </div>
+    </div>
+}
+
+@code {
+    private bool scannerActive;
+    private string? scannerError;
+    private DotNetObjectReference<Index>? dotNetRef;
+
+    private async Task HandleSearchKeyUp(KeyboardEventArgs e)
+    {
+        if (e.Key == "Enter")
+            await SearchAsync();
+    }
+
+    private async Task SearchAsync()
+    {
+        var term = VM.SearchTerm.Trim();
+        if (string.IsNullOrWhiteSpace(term)) return;
+
+        // If the search term looks like an ISBN (10+ digits), search by ISBN
+        var cleaned = new string(term.Where(c => char.IsLetterOrDigit(c)).ToArray());
+        if (cleaned.Length >= 10 && cleaned.Length <= 13 && cleaned.All(c => char.IsDigit(c) || c == 'X' || c == 'x'))
+        {
+            await VM.SearchByIsbnAsync(cleaned);
+        }
+        else
+        {
+            await VM.SearchByTextAsync();
+        }
+    }
+
+    private void ClearAsync()
+    {
+        VM.SearchTerm = "";
+        VM.ClearResult();
+    }
+
+    private string AddBookUrl()
+    {
+        if (VM.ScannedIsbn is not null)
+            return $"/books/add";
+        return "/books/add";
+    }
+
+    // Scanner — reuses the same barcode-scanner.js interop
+    private async Task ToggleScannerAsync()
+    {
+        scannerError = null;
+        if (scannerActive)
+        {
+            await JS.InvokeVoidAsync("BarcodeScanner.stop");
+            scannerActive = false;
+        }
+        else
+        {
+            scannerActive = true;
+            dotNetRef ??= DotNetObjectReference.Create(this);
+            StateHasChanged();
+            await Task.Delay(100);
+            await JS.InvokeVoidAsync("BarcodeScanner.start", "shopping-barcode-reader", dotNetRef);
+        }
+    }
+
+    [JSInvokable]
+    public async Task OnBarcodeScanned(string decodedText)
+    {
+        var isbn = decodedText.Trim();
+        if (string.IsNullOrWhiteSpace(isbn)) return;
+
+        // Stop scanner after successful scan for cleaner UX
+        await JS.InvokeVoidAsync("BarcodeScanner.stop");
+
+        await InvokeAsync(async () =>
+        {
+            scannerActive = false;
+            await VM.SearchByIsbnAsync(isbn);
+            StateHasChanged();
+        });
+    }
+
+    [JSInvokable]
+    public async Task OnScannerError(string error)
+    {
+        await InvokeAsync(() =>
+        {
+            scannerError = $"Camera error: {error}";
+            scannerActive = false;
+            StateHasChanged();
+        });
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (scannerActive)
+        {
+            try { await JS.InvokeVoidAsync("BarcodeScanner.stop"); } catch { }
+        }
+        dotNetRef?.Dispose();
+    }
+}

--- a/BookTracker.Web/Program.cs
+++ b/BookTracker.Web/Program.cs
@@ -37,6 +37,7 @@ builder.Services.AddTransient<BookEditViewModel>();
 builder.Services.AddTransient<BulkAddViewModel>();
 builder.Services.AddTransient<SeriesListViewModel>();
 builder.Services.AddTransient<SeriesEditViewModel>();
+builder.Services.AddTransient<ShoppingViewModel>();
 
 var app = builder.Build();
 

--- a/BookTracker.Web/ViewModels/ShoppingViewModel.cs
+++ b/BookTracker.Web/ViewModels/ShoppingViewModel.cs
@@ -1,0 +1,183 @@
+using BookTracker.Data;
+using BookTracker.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookTracker.Web.ViewModels;
+
+public class ShoppingViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory)
+{
+    // "Do I have this?" state
+    public string SearchTerm { get; set; } = "";
+    public string? ScannedIsbn { get; set; }
+    public LookupResult? Result { get; private set; }
+    public bool Searching { get; private set; }
+
+    public void ClearResult()
+    {
+        Result = null;
+        ScannedIsbn = null;
+    }
+
+    public async Task SearchByIsbnAsync(string isbn)
+    {
+        Searching = true;
+        try
+        {
+            ScannedIsbn = isbn;
+            SearchTerm = "";
+            await using var db = await dbFactory.CreateDbContextAsync();
+
+            var copies = await db.BookCopies
+                .Include(c => c.Book)
+                    .ThenInclude(b => b.Series)
+                .Where(c => c.Isbn == isbn)
+                .ToListAsync();
+
+            if (copies.Count > 0)
+            {
+                var book = copies[0].Book;
+                var seriesInfo = await GetSeriesInfoAsync(db, book);
+                Result = new LookupResult(
+                    Found: true,
+                    BookId: book.Id,
+                    Title: book.Title,
+                    Author: book.Author,
+                    CopyCount: copies.Count,
+                    CoverUrl: book.DefaultCoverArtUrl,
+                    SeriesInfo: seriesInfo);
+            }
+            else
+            {
+                Result = new LookupResult(
+                    Found: false,
+                    BookId: null,
+                    Title: null,
+                    Author: null,
+                    CopyCount: 0,
+                    CoverUrl: null,
+                    SeriesInfo: null);
+            }
+        }
+        finally
+        {
+            Searching = false;
+        }
+    }
+
+    public async Task SearchByTextAsync()
+    {
+        if (string.IsNullOrWhiteSpace(SearchTerm)) return;
+
+        Searching = true;
+        try
+        {
+            ScannedIsbn = null;
+            var term = SearchTerm.Trim();
+            await using var db = await dbFactory.CreateDbContextAsync();
+
+            var books = await db.Books
+                .Include(b => b.Copies)
+                .Include(b => b.Series)
+                .Where(b => b.Title.Contains(term) || b.Author.Contains(term))
+                .OrderBy(b => b.Title)
+                .Take(10)
+                .ToListAsync();
+
+            if (books.Count == 1)
+            {
+                var book = books[0];
+                var seriesInfo = await GetSeriesInfoAsync(db, book);
+                Result = new LookupResult(
+                    Found: true,
+                    BookId: book.Id,
+                    Title: book.Title,
+                    Author: book.Author,
+                    CopyCount: book.Copies.Count,
+                    CoverUrl: book.DefaultCoverArtUrl,
+                    SeriesInfo: seriesInfo);
+            }
+            else if (books.Count > 1)
+            {
+                Result = new LookupResult(
+                    Found: true,
+                    BookId: null,
+                    Title: null,
+                    Author: null,
+                    CopyCount: 0,
+                    CoverUrl: null,
+                    SeriesInfo: null,
+                    MultipleResults: books.Select(b => new SearchResultItem(
+                        b.Id, b.Title, b.Author, b.Copies.Count, b.DefaultCoverArtUrl
+                    )).ToList());
+            }
+            else
+            {
+                Result = new LookupResult(
+                    Found: false,
+                    BookId: null,
+                    Title: null,
+                    Author: null,
+                    CopyCount: 0,
+                    CoverUrl: null,
+                    SeriesInfo: null);
+            }
+        }
+        finally
+        {
+            Searching = false;
+        }
+    }
+
+    public async Task SelectBookAsync(int bookId)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync();
+        var book = await db.Books
+            .Include(b => b.Copies)
+            .Include(b => b.Series)
+            .FirstOrDefaultAsync(b => b.Id == bookId);
+
+        if (book is null) return;
+
+        var seriesInfo = await GetSeriesInfoAsync(db, book);
+        Result = new LookupResult(
+            Found: true,
+            BookId: book.Id,
+            Title: book.Title,
+            Author: book.Author,
+            CopyCount: book.Copies.Count,
+            CoverUrl: book.DefaultCoverArtUrl,
+            SeriesInfo: seriesInfo);
+    }
+
+    private static async Task<SeriesInfo?> GetSeriesInfoAsync(BookTrackerDbContext db, Book book)
+    {
+        if (book.SeriesId is null || book.Series is null)
+            return null;
+
+        var series = book.Series;
+        var booksInSeries = await db.Books
+            .Where(b => b.SeriesId == series.Id)
+            .CountAsync();
+
+        return new SeriesInfo(
+            series.Id,
+            series.Name,
+            series.Type,
+            booksInSeries,
+            series.ExpectedCount);
+    }
+
+    public record LookupResult(
+        bool Found,
+        int? BookId,
+        string? Title,
+        string? Author,
+        int CopyCount,
+        string? CoverUrl,
+        SeriesInfo? SeriesInfo,
+        List<SearchResultItem>? MultipleResults = null);
+
+    public record SearchResultItem(int Id, string Title, string Author, int CopyCount, string? CoverUrl);
+
+    public record SeriesInfo(int SeriesId, string SeriesName, SeriesType Type, int OwnedCount, int? ExpectedCount);
+}


### PR DESCRIPTION
New mobile-optimised /shopping page for checking if a book is already in the library while browsing a bookshop.

"Do I have this?" flow:
- Barcode scanner (full-width primary button on mobile, reuses existing barcode-scanner.js) — auto-stops after successful scan
- Text search box (detects ISBN-shaped input vs title/author search)
- Found: shows cover, title, author, copy count, and series info with completion status ("3 of 5 books — 2 missing")
- Not found: links to Add Book page
- Multiple matches: shows list, tap to select

ShoppingViewModel handles ISBN lookup (via BookCopies index), text search (title/author with 10 result limit), and series context loading. Nav link added.