### PR TITLE
feat: add series gaps section to Shopping page

### DIFF
--- a/BookTracker.Web/Components/Pages/Shopping/Index.razor
+++ b/BookTracker.Web/Components/Pages/Shopping/Index.razor
@@ -170,6 +170,72 @@
     </div>
 }
 
+@* Series gaps — incomplete series where you're missing books *@
+<div class="card mb-4">
+    <div class="card-header bg-white d-flex justify-content-between align-items-center">
+        <h2 class="h5 mb-0">Series gaps</h2>
+        @if (!VM.GapsLoaded)
+        {
+            <button type="button" class="btn btn-outline-primary btn-sm" @onclick="VM.LoadSeriesGapsAsync">
+                Check gaps
+            </button>
+        }
+    </div>
+    <div class="card-body">
+        @if (!VM.GapsLoaded)
+        {
+            <p class="text-muted small mb-0">Tap "Check gaps" to see which numbered series you're missing books from.</p>
+        }
+        else if (VM.SeriesGaps.Count == 0)
+        {
+            <p class="text-muted small mb-0">No gaps found — all your numbered series are complete!</p>
+        }
+        else
+        {
+            @foreach (var gap in VM.SeriesGaps)
+            {
+                <div class="mb-3 @(gap != VM.SeriesGaps.Last() ? "pb-3 border-bottom" : "")">
+                    <div class="d-flex justify-content-between align-items-start">
+                        <div>
+                            <a href="@($"/series/{gap.SeriesId}")" class="fw-semibold text-decoration-none">@gap.SeriesName</a>
+                            @if (gap.Author is not null)
+                            {
+                                <span class="text-muted small ms-1">by @gap.Author</span>
+                            }
+                        </div>
+                        <span class="badge bg-warning text-dark">@gap.OwnedCount / @gap.ExpectedCount</span>
+                    </div>
+                    @if (gap.MissingPositions.Count > 0)
+                    {
+                        <div class="mt-1 small">
+                            <span class="text-muted">Missing:</span>
+                            @foreach (var pos in gap.MissingPositions)
+                            {
+                                <span class="badge bg-danger me-1">#@pos</span>
+                            }
+                        </div>
+                    }
+                    <details class="mt-1">
+                        <summary class="small text-muted" style="cursor: pointer;">You have @gap.OwnedBooks.Count books</summary>
+                        <ul class="list-unstyled small mt-1 mb-0 ms-2">
+                            @foreach (var book in gap.OwnedBooks)
+                            {
+                                <li>
+                                    @if (book.SeriesOrder.HasValue)
+                                    {
+                                        <span class="text-muted">#@book.SeriesOrder</span>
+                                    }
+                                    <a href="@($"/books/{book.Id}/edit")" class="text-decoration-none">@book.Title</a>
+                                </li>
+                            }
+                        </ul>
+                    </details>
+                </div>
+            }
+        }
+    </div>
+</div>
+
 @code {
     private bool scannerActive;
     private string? scannerError;

--- a/BookTracker.Web/ViewModels/ShoppingViewModel.cs
+++ b/BookTracker.Web/ViewModels/ShoppingViewModel.cs
@@ -12,6 +12,54 @@ public class ShoppingViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
     public LookupResult? Result { get; private set; }
     public bool Searching { get; private set; }
 
+    // Series gaps
+    public List<SeriesGap> SeriesGaps { get; private set; } = [];
+    public bool GapsLoaded { get; private set; }
+
+    public async Task LoadSeriesGapsAsync()
+    {
+        await using var db = await dbFactory.CreateDbContextAsync();
+
+        // Structured series with a known expected count where we're missing books
+        var incompleteSeries = await db.Series
+            .Include(s => s.Books)
+            .Where(s => s.Type == SeriesType.Series && s.ExpectedCount != null)
+            .ToListAsync();
+
+        SeriesGaps = incompleteSeries
+            .Where(s => s.Books.Count < s.ExpectedCount!.Value)
+            .OrderBy(s => s.Name)
+            .Select(s =>
+            {
+                var ownedPositions = s.Books
+                    .Where(b => b.SeriesOrder.HasValue)
+                    .Select(b => b.SeriesOrder!.Value)
+                    .OrderBy(n => n)
+                    .ToList();
+
+                var missing = new List<int>();
+                for (int i = 1; i <= s.ExpectedCount!.Value; i++)
+                {
+                    if (!ownedPositions.Contains(i))
+                        missing.Add(i);
+                }
+
+                return new SeriesGap(
+                    s.Id,
+                    s.Name,
+                    s.Author,
+                    s.Books.Count,
+                    s.ExpectedCount.Value,
+                    missing,
+                    s.Books.OrderBy(b => b.SeriesOrder ?? int.MaxValue)
+                        .Select(b => new OwnedSeriesBook(b.Id, b.Title, b.SeriesOrder))
+                        .ToList());
+            })
+            .ToList();
+
+        GapsLoaded = true;
+    }
+
     public void ClearResult()
     {
         Result = null;
@@ -180,4 +228,12 @@ public class ShoppingViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
     public record SearchResultItem(int Id, string Title, string Author, int CopyCount, string? CoverUrl);
 
     public record SeriesInfo(int SeriesId, string SeriesName, SeriesType Type, int OwnedCount, int? ExpectedCount);
+
+    public record SeriesGap(
+        int SeriesId, string SeriesName, string? Author,
+        int OwnedCount, int ExpectedCount,
+        List<int> MissingPositions,
+        List<OwnedSeriesBook> OwnedBooks);
+
+    public record OwnedSeriesBook(int Id, string Title, int? SeriesOrder);
 }


### PR DESCRIPTION
Shows incomplete numbered series where books are missing. Loads on demand via "Check gaps" button (avoids unnecessary DB queries).

For each incomplete series displays: name, author, owned/expected count, missing position numbers as badges, and a collapsible list of owned books with links to edit. Only shows Structured series with a known ExpectedCount where OwnedCount < ExpectedCount.