### PR TITLE
feat: add shopping list section with quick-add and bought action

### DIFF
--- a/BookTracker.Web/Components/Pages/Shopping/Index.razor
+++ b/BookTracker.Web/Components/Pages/Shopping/Index.razor
@@ -236,6 +236,105 @@
     </div>
 </div>
 
+@* Shopping list — books you're looking for *@
+<div class="card mb-4">
+    <div class="card-header bg-white d-flex justify-content-between align-items-center">
+        <h2 class="h5 mb-0">Shopping list</h2>
+        <div class="d-flex gap-2">
+            @if (VM.ShoppingListLoaded)
+            {
+                <button type="button" class="btn btn-outline-primary btn-sm" @onclick="() => VM.ShowingQuickAdd = !VM.ShowingQuickAdd">
+                    @(VM.ShowingQuickAdd ? "Cancel" : "Add item")
+                </button>
+            }
+            else
+            {
+                <button type="button" class="btn btn-outline-primary btn-sm" @onclick="VM.LoadShoppingListAsync">
+                    Load list
+                </button>
+            }
+        </div>
+    </div>
+    <div class="card-body">
+        @if (!VM.ShoppingListLoaded)
+        {
+            <p class="text-muted small mb-0">Tap "Load list" to see books you're looking for.</p>
+        }
+        else
+        {
+            @if (VM.ShowingQuickAdd)
+            {
+                <div class="p-3 bg-light rounded mb-3">
+                    <div class="row g-2">
+                        <div class="col-12 col-md-4">
+                            <input type="text" class="form-control form-control-sm" placeholder="Title" @bind="VM.QuickAdd.Title" />
+                        </div>
+                        <div class="col-12 col-md-3">
+                            <input type="text" class="form-control form-control-sm" placeholder="Author" @bind="VM.QuickAdd.Author" />
+                        </div>
+                        <div class="col-6 col-md-2">
+                            <input type="text" class="form-control form-control-sm" placeholder="ISBN (optional)" @bind="VM.QuickAdd.Isbn" />
+                        </div>
+                        <div class="col-6 col-md-2">
+                            <select class="form-select form-select-sm" @bind="VM.QuickAdd.Priority">
+                                @foreach (var p in Enum.GetValues<WishlistPriority>())
+                                {
+                                    <option value="@p">@p</option>
+                                }
+                            </select>
+                        </div>
+                        <div class="col-12 col-md-1">
+                            <button type="button" class="btn btn-success btn-sm w-100" @onclick="VM.AddToShoppingListAsync">Add</button>
+                        </div>
+                    </div>
+                </div>
+            }
+
+            @if (VM.ShoppingList.Count == 0)
+            {
+                <p class="text-muted small mb-0">Your shopping list is empty.</p>
+            }
+            else
+            {
+                @foreach (var item in VM.ShoppingList)
+                {
+                    <div class="d-flex gap-3 align-items-center py-2 @(item != VM.ShoppingList.Last() ? "border-bottom" : "")">
+                        <div class="flex-grow-1 min-width-0">
+                            <div class="fw-semibold text-truncate">@item.Title</div>
+                            <div class="text-muted small">@item.Author</div>
+                            <div class="d-flex flex-wrap gap-1 mt-1">
+                                <span class="badge @ShoppingViewModel.PriorityBadgeClass(item.Priority)">@item.Priority</span>
+                                @if (item.Isbn is not null)
+                                {
+                                    <span class="badge bg-light text-dark border font-monospace">@item.Isbn</span>
+                                }
+                                @if (item.SeriesName is not null)
+                                {
+                                    <span class="badge bg-light text-dark border">
+                                        @item.SeriesName
+                                        @if (item.SeriesOrder.HasValue)
+                                        {
+                                            <span> #@item.SeriesOrder</span>
+                                        }
+                                    </span>
+                                }
+                            </div>
+                        </div>
+                        <div class="d-flex flex-column gap-1 flex-shrink-0">
+                            <button type="button" class="btn btn-success btn-sm" @onclick="() => BoughtAsync(item)" title="Mark as bought — adds to library with follow-up tag">
+                                Bought
+                            </button>
+                            <button type="button" class="btn btn-outline-danger btn-sm" @onclick="() => VM.RemoveFromShoppingListAsync(item.Id)" title="Remove from list">
+                                Remove
+                            </button>
+                        </div>
+                    </div>
+                }
+            }
+        }
+    </div>
+</div>
+
 @code {
     private bool scannerActive;
     private string? scannerError;
@@ -261,6 +360,15 @@
         else
         {
             await VM.SearchByTextAsync();
+        }
+    }
+
+    private async Task BoughtAsync(ShoppingViewModel.ShoppingListItem item)
+    {
+        var bookId = await VM.MarkAsBoughtAsync(item);
+        if (bookId.HasValue)
+        {
+            Nav.NavigateTo($"/books/{bookId}/edit");
         }
     }
 

--- a/BookTracker.Web/ViewModels/ShoppingViewModel.cs
+++ b/BookTracker.Web/ViewModels/ShoppingViewModel.cs
@@ -229,6 +229,133 @@ public class ShoppingViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
 
     public record SeriesInfo(int SeriesId, string SeriesName, SeriesType Type, int OwnedCount, int? ExpectedCount);
 
+    // Shopping list (wishlist)
+    public List<ShoppingListItem> ShoppingList { get; private set; } = [];
+    public bool ShoppingListLoaded { get; private set; }
+    public bool ShowingQuickAdd { get; set; }
+    public QuickAddInput QuickAdd { get; set; } = new();
+
+    public async Task LoadShoppingListAsync()
+    {
+        await using var db = await dbFactory.CreateDbContextAsync();
+        ShoppingList = await db.WishlistItems
+            .Include(w => w.Series)
+            .OrderByDescending(w => w.Priority)
+            .ThenBy(w => w.Title)
+            .Select(w => new ShoppingListItem(
+                w.Id, w.Title, w.Author, w.Priority, w.Isbn,
+                w.Series != null ? w.Series.Name : null,
+                w.SeriesOrder))
+            .ToListAsync();
+        ShoppingListLoaded = true;
+    }
+
+    public async Task AddToShoppingListAsync()
+    {
+        if (string.IsNullOrWhiteSpace(QuickAdd.Title)) return;
+
+        await using var db = await dbFactory.CreateDbContextAsync();
+        var item = new WishlistItem
+        {
+            Title = QuickAdd.Title.Trim(),
+            Author = string.IsNullOrWhiteSpace(QuickAdd.Author) ? "Unknown" : QuickAdd.Author.Trim(),
+            Priority = QuickAdd.Priority,
+            Isbn = string.IsNullOrWhiteSpace(QuickAdd.Isbn) ? null : QuickAdd.Isbn.Trim()
+        };
+
+        db.WishlistItems.Add(item);
+        await db.SaveChangesAsync();
+
+        ShoppingList.Insert(0, new ShoppingListItem(
+            item.Id, item.Title, item.Author, item.Priority, item.Isbn, null, null));
+        // Re-sort by priority
+        ShoppingList = ShoppingList
+            .OrderByDescending(i => i.Priority)
+            .ThenBy(i => i.Title)
+            .ToList();
+
+        QuickAdd = new();
+        ShowingQuickAdd = false;
+    }
+
+    public async Task RemoveFromShoppingListAsync(int itemId)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync();
+        var item = await db.WishlistItems.FindAsync(itemId);
+        if (item is not null)
+        {
+            db.WishlistItems.Remove(item);
+            await db.SaveChangesAsync();
+        }
+        ShoppingList.RemoveAll(i => i.Id == itemId);
+    }
+
+    /// <summary>
+    /// Marks a wishlist item as "bought" — creates a Book + BookCopy with
+    /// follow-up tag and default values, then removes the wishlist item.
+    /// Returns the new book ID for navigation.
+    /// </summary>
+    public async Task<int?> MarkAsBoughtAsync(ShoppingListItem item)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync();
+
+        var followUpTag = await db.Tags.FirstOrDefaultAsync(t => t.Name == "follow-up");
+        if (followUpTag is null)
+        {
+            followUpTag = new Tag { Name = "follow-up" };
+            db.Tags.Add(followUpTag);
+        }
+
+        var book = new Book
+        {
+            Title = item.Title,
+            Author = item.Author,
+            Tags = [followUpTag],
+            Copies = []
+        };
+
+        if (!string.IsNullOrWhiteSpace(item.Isbn))
+        {
+            book.Copies.Add(new BookCopy
+            {
+                Isbn = item.Isbn,
+                Format = BookFormat.Softcopy,
+                Condition = BookCondition.Good
+            });
+        }
+
+        db.Books.Add(book);
+
+        var wishlistItem = await db.WishlistItems.FindAsync(item.Id);
+        if (wishlistItem is not null)
+            db.WishlistItems.Remove(wishlistItem);
+
+        await db.SaveChangesAsync();
+
+        ShoppingList.RemoveAll(i => i.Id == item.Id);
+        return book.Id;
+    }
+
+    public static string PriorityBadgeClass(WishlistPriority p) => p switch
+    {
+        WishlistPriority.High => "bg-danger",
+        WishlistPriority.Medium => "bg-warning text-dark",
+        WishlistPriority.Low => "bg-secondary",
+        _ => "bg-light text-dark"
+    };
+
+    public class QuickAddInput
+    {
+        public string? Title { get; set; }
+        public string? Author { get; set; }
+        public string? Isbn { get; set; }
+        public WishlistPriority Priority { get; set; } = WishlistPriority.Medium;
+    }
+
+    public record ShoppingListItem(
+        int Id, string Title, string Author, WishlistPriority Priority,
+        string? Isbn, string? SeriesName, int? SeriesOrder);
+
     public record SeriesGap(
         int SeriesId, string SeriesName, string? Author,
         int OwnedCount, int ExpectedCount,


### PR DESCRIPTION
New "Shopping list" section on the Shopping page for managing books you're looking for while out at a bookshop.

Features:
- Load on demand to keep the page fast
- Quick-add form: title, author, ISBN (optional), priority
- Items sorted by priority (High first), showing title, author, priority badge, ISBN, and series context if linked
- "Bought" button: auto-creates the book in the library with a follow-up tag and default copy (if ISBN known), removes from wishlist, then navigates to the book edit page for review
- "Remove" button to discard items