### PR TITLE
feat: replace BookCopy with Edition + Copy model

### DIFF
--- a/BookTracker.Data/BookTrackerDbContext.cs
+++ b/BookTracker.Data/BookTrackerDbContext.cs
@@ -6,7 +6,8 @@ namespace BookTracker.Data;
 public class BookTrackerDbContext(DbContextOptions<BookTrackerDbContext> options) : DbContext(options)
 {
     public DbSet<Book> Books => Set<Book>();
-    public DbSet<BookCopy> BookCopies => Set<BookCopy>();
+    public DbSet<Edition> Editions => Set<Edition>();
+    public DbSet<Copy> Copies => Set<Copy>();
     public DbSet<Genre> Genres => Set<Genre>();
     public DbSet<Publisher> Publishers => Set<Publisher>();
     public DbSet<Series> Series => Set<Series>();
@@ -15,20 +16,27 @@ public class BookTrackerDbContext(DbContextOptions<BookTrackerDbContext> options
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        modelBuilder.Entity<BookCopy>()
-            .HasOne(c => c.Book)
-            .WithMany(b => b.Copies)
-            .HasForeignKey(c => c.BookId)
+        modelBuilder.Entity<Edition>()
+            .HasOne(e => e.Book)
+            .WithMany(b => b.Editions)
+            .HasForeignKey(e => e.BookId)
             .OnDelete(DeleteBehavior.Cascade);
 
-        modelBuilder.Entity<BookCopy>()
-            .HasIndex(c => c.Isbn);
+        modelBuilder.Entity<Edition>()
+            .HasIndex(e => e.Isbn)
+            .IsUnique();
 
-        modelBuilder.Entity<BookCopy>()
-            .HasOne(c => c.Publisher)
-            .WithMany(p => p.Copies)
-            .HasForeignKey(c => c.PublisherId)
+        modelBuilder.Entity<Edition>()
+            .HasOne(e => e.Publisher)
+            .WithMany(p => p.Editions)
+            .HasForeignKey(e => e.PublisherId)
             .OnDelete(DeleteBehavior.Restrict);
+
+        modelBuilder.Entity<Copy>()
+            .HasOne(c => c.Edition)
+            .WithMany(e => e.Copies)
+            .HasForeignKey(c => c.EditionId)
+            .OnDelete(DeleteBehavior.Cascade);
 
         modelBuilder.Entity<Genre>()
             .HasIndex(g => g.Name)

--- a/BookTracker.Data/Migrations/20260417062950_ReplaceBookCopyWithEditionAndCopy.Designer.cs
+++ b/BookTracker.Data/Migrations/20260417062950_ReplaceBookCopyWithEditionAndCopy.Designer.cs
@@ -4,6 +4,7 @@ using BookTracker.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BookTracker.Data.Migrations
 {
     [DbContext(typeof(BookTrackerDbContext))]
-    partial class BookTrackerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260417062950_ReplaceBookCopyWithEditionAndCopy")]
+    partial class ReplaceBookCopyWithEditionAndCopy
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BookTracker.Data/Migrations/20260417062950_ReplaceBookCopyWithEditionAndCopy.cs
+++ b/BookTracker.Data/Migrations/20260417062950_ReplaceBookCopyWithEditionAndCopy.cs
@@ -1,0 +1,180 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BookTracker.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class ReplaceBookCopyWithEditionAndCopy : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // 1. Create new tables
+            migrationBuilder.CreateTable(
+                name: "Editions",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    BookId = table.Column<int>(type: "int", nullable: false),
+                    Isbn = table.Column<string>(type: "nvarchar(20)", maxLength: 20, nullable: false),
+                    Format = table.Column<int>(type: "int", nullable: false),
+                    DatePrinted = table.Column<DateOnly>(type: "date", nullable: true),
+                    CoverUrl = table.Column<string>(type: "nvarchar(500)", maxLength: 500, nullable: true),
+                    PublisherId = table.Column<int>(type: "int", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Editions", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Editions_Books_BookId",
+                        column: x => x.BookId,
+                        principalTable: "Books",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_Editions_Publishers_PublisherId",
+                        column: x => x.PublisherId,
+                        principalTable: "Publishers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Copies",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    EditionId = table.Column<int>(type: "int", nullable: false),
+                    Condition = table.Column<int>(type: "int", nullable: false),
+                    DateAcquired = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    Notes = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Copies", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Copies_Editions_EditionId",
+                        column: x => x.EditionId,
+                        principalTable: "Editions",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Editions_BookId",
+                table: "Editions",
+                column: "BookId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Editions_Isbn",
+                table: "Editions",
+                column: "Isbn",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Editions_PublisherId",
+                table: "Editions",
+                column: "PublisherId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Copies_EditionId",
+                table: "Copies",
+                column: "EditionId");
+
+            // 2. Migrate data: each BookCopy becomes one Edition + one Copy.
+            // BookCopies with the same ISBN get merged into one Edition with
+            // multiple Copies (to respect the unique ISBN constraint).
+            migrationBuilder.Sql(@"
+                -- Create one Edition per distinct ISBN+BookId combination
+                INSERT INTO Editions (BookId, Isbn, Format, DatePrinted, CoverUrl, PublisherId)
+                SELECT BookId, Isbn, Format, DatePrinted, CustomCoverArtUrl, PublisherId
+                FROM BookCopies bc
+                WHERE bc.Id = (
+                    SELECT MIN(bc2.Id)
+                    FROM BookCopies bc2
+                    WHERE bc2.Isbn = bc.Isbn AND bc2.BookId = bc.BookId
+                );
+
+                -- Create one Copy per original BookCopy, linked to its Edition
+                INSERT INTO Copies (EditionId, Condition, DateAcquired, Notes)
+                SELECT e.Id, bc.Condition, NULL, NULL
+                FROM BookCopies bc
+                INNER JOIN Editions e ON e.Isbn = bc.Isbn AND e.BookId = bc.BookId;
+            ");
+
+            // 3. Drop old table
+            migrationBuilder.DropTable(
+                name: "BookCopies");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // Recreate BookCopies
+            migrationBuilder.CreateTable(
+                name: "BookCopies",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    BookId = table.Column<int>(type: "int", nullable: false),
+                    PublisherId = table.Column<int>(type: "int", nullable: true),
+                    Condition = table.Column<int>(type: "int", nullable: false),
+                    CustomCoverArtUrl = table.Column<string>(type: "nvarchar(500)", maxLength: 500, nullable: true),
+                    DatePrinted = table.Column<DateOnly>(type: "date", nullable: true),
+                    Format = table.Column<int>(type: "int", nullable: false),
+                    Isbn = table.Column<string>(type: "nvarchar(20)", maxLength: 20, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_BookCopies", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_BookCopies_Books_BookId",
+                        column: x => x.BookId,
+                        principalTable: "Books",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_BookCopies_Publishers_PublisherId",
+                        column: x => x.PublisherId,
+                        principalTable: "Publishers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            // Migrate data back: flatten Edition+Copy into BookCopies
+            migrationBuilder.Sql(@"
+                INSERT INTO BookCopies (BookId, Isbn, Format, DatePrinted, CustomCoverArtUrl, PublisherId, Condition)
+                SELECT e.BookId, e.Isbn, e.Format, e.DatePrinted, e.CoverUrl, e.PublisherId, c.Condition
+                FROM Copies c
+                INNER JOIN Editions e ON e.Id = c.EditionId;
+            ");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_BookCopies_BookId",
+                table: "BookCopies",
+                column: "BookId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_BookCopies_Isbn",
+                table: "BookCopies",
+                column: "Isbn");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_BookCopies_PublisherId",
+                table: "BookCopies",
+                column: "PublisherId");
+
+            // Drop new tables
+            migrationBuilder.DropTable(
+                name: "Copies");
+
+            migrationBuilder.DropTable(
+                name: "Editions");
+        }
+    }
+}

--- a/BookTracker.Data/Models/Book.cs
+++ b/BookTracker.Data/Models/Book.cs
@@ -44,7 +44,7 @@ public class Book
     [MaxLength(500)]
     public string? DefaultCoverArtUrl { get; set; }
 
-    public List<BookCopy> Copies { get; set; } = [];
+    public List<Edition> Editions { get; set; } = [];
 
     public List<Tag> Tags { get; set; } = [];
 

--- a/BookTracker.Data/Models/BookEnums.cs
+++ b/BookTracker.Data/Models/BookEnums.cs
@@ -1,0 +1,18 @@
+namespace BookTracker.Data.Models;
+
+public enum BookFormat
+{
+    Hardcopy,
+    Softcopy
+}
+
+// Standard used-book grading scale, best to worst.
+public enum BookCondition
+{
+    AsNew,
+    Fine,
+    VeryGood,
+    Good,
+    Fair,
+    Poor
+}

--- a/BookTracker.Data/Models/Copy.cs
+++ b/BookTracker.Data/Models/Copy.cs
@@ -1,0 +1,15 @@
+namespace BookTracker.Data.Models;
+
+public class Copy
+{
+    public int Id { get; set; }
+
+    public int EditionId { get; set; }
+    public Edition Edition { get; set; } = null!;
+
+    public BookCondition Condition { get; set; } = BookCondition.Good;
+
+    public DateTime? DateAcquired { get; set; }
+
+    public string? Notes { get; set; }
+}

--- a/BookTracker.Data/Models/Edition.cs
+++ b/BookTracker.Data/Models/Edition.cs
@@ -2,24 +2,7 @@ using System.ComponentModel.DataAnnotations;
 
 namespace BookTracker.Data.Models;
 
-public enum BookFormat
-{
-    Hardcopy,
-    Softcopy
-}
-
-// Standard used-book grading scale, best → worst.
-public enum BookCondition
-{
-    AsNew,
-    Fine,
-    VeryGood,
-    Good,
-    Fair,
-    Poor
-}
-
-public class BookCopy
+public class Edition
 {
     public int Id { get; set; }
 
@@ -33,11 +16,11 @@ public class BookCopy
 
     public DateOnly? DatePrinted { get; set; }
 
-    public BookCondition Condition { get; set; } = BookCondition.Good;
-
     [MaxLength(500)]
-    public string? CustomCoverArtUrl { get; set; }
+    public string? CoverUrl { get; set; }
 
     public int? PublisherId { get; set; }
     public Publisher? Publisher { get; set; }
+
+    public List<Copy> Copies { get; set; } = [];
 }

--- a/BookTracker.Data/Models/Publisher.cs
+++ b/BookTracker.Data/Models/Publisher.cs
@@ -3,7 +3,7 @@ using System.ComponentModel.DataAnnotations;
 namespace BookTracker.Data.Models;
 
 // TODO: add a "Manage publishers" feature — UI to rename/merge duplicates,
-// delete unused publishers, and see which copies each publisher covers.
+// delete unused publishers, and see which editions each publisher covers.
 // Right now Publishers are only created via find-or-create on the Add page.
 public class Publisher
 {
@@ -12,5 +12,5 @@ public class Publisher
     [Required, MaxLength(200)]
     public string Name { get; set; } = string.Empty;
 
-    public List<BookCopy> Copies { get; set; } = [];
+    public List<Edition> Editions { get; set; } = [];
 }

--- a/BookTracker.Tests/ViewModels/BulkAddViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/BulkAddViewModelTests.cs
@@ -60,7 +60,7 @@ public class BulkAddViewModelTests
             {
                 Title = "Existing",
                 Author = "Author",
-                Copies = [new BookCopy { Isbn = "9780345391803" }]
+                Editions = [new Edition { Isbn = "9780345391803", Copies = [new Copy { Condition = BookCondition.Good }] }]
             });
             await db.SaveChangesAsync();
         }

--- a/BookTracker.Web/Components/Pages/Books/Edit.razor
+++ b/BookTracker.Web/Components/Pages/Books/Edit.razor
@@ -116,11 +116,11 @@ else
             <div class="col-12">
                 <div class="card">
                     <div class="card-header bg-white d-flex justify-content-between align-items-center">
-                        <h2 class="h5 mb-0">Copies (@VM.Copies.Count)</h2>
+                        <h2 class="h5 mb-0">Copies (@VM.EditionCopies.Count)</h2>
                         <button type="button" class="btn btn-outline-primary btn-sm" @onclick="VM.ShowAddCopy">Add copy</button>
                     </div>
                     <div class="card-body">
-                        @if (VM.Copies.Count == 0 && !VM.ShowingNewCopy)
+                        @if (VM.EditionCopies.Count == 0 && !VM.ShowingNewCopy)
                         {
                             <p class="text-muted mb-0">No copies recorded.</p>
                         }
@@ -139,9 +139,9 @@ else
                                         </tr>
                                     </thead>
                                     <tbody>
-                                        @foreach (var copy in VM.Copies)
+                                        @foreach (var copy in VM.EditionCopies)
                                         {
-                                            @if (VM.EditingCopyId == copy.Id)
+                                            @if (VM.EditingCopyId == copy.CopyId)
                                             {
                                                 <tr>
                                                     <td><input type="text" class="form-control form-control-sm" @bind="VM.EditCopyInput.Isbn" /></td>
@@ -180,7 +180,7 @@ else
                                                     <td>@(copy.PublisherName ?? "—")</td>
                                                     <td>@(copy.DatePrinted?.ToString("yyyy-MM-dd") ?? "—")</td>
                                                     <td>
-                                                        @if (VM.ConfirmingDeleteCopyId == copy.Id)
+                                                        @if (VM.ConfirmingDeleteCopyId == copy.CopyId)
                                                         {
                                                             <div class="d-flex align-items-center gap-1">
                                                                 <span class="text-danger small">Delete?</span>
@@ -192,7 +192,7 @@ else
                                                         {
                                                             <div class="btn-group btn-group-sm">
                                                                 <button type="button" class="btn btn-outline-primary" @onclick="() => VM.StartEditCopy(copy)">Edit</button>
-                                                                <button type="button" class="btn btn-outline-danger" @onclick="() => VM.ConfirmingDeleteCopyId = copy.Id">Delete</button>
+                                                                <button type="button" class="btn btn-outline-danger" @onclick="() => VM.ConfirmingDeleteCopyId = copy.CopyId">Delete</button>
                                                             </div>
                                                         }
                                                     </td>

--- a/BookTracker.Web/ViewModels/BookAddViewModel.cs
+++ b/BookTracker.Web/ViewModels/BookAddViewModel.cs
@@ -98,16 +98,16 @@ public class BookAddViewModel(
                 Rating = BookInput.Rating,
                 DefaultCoverArtUrl = string.IsNullOrWhiteSpace(BookInput.DefaultCoverArtUrl) ? null : BookInput.DefaultCoverArtUrl.Trim(),
                 Genres = selectedGenres,
-                Copies =
+                Editions =
                 [
-                    new BookCopy
+                    new Edition
                     {
                         Isbn = CopyInput.Isbn!.Trim(),
                         Format = CopyInput.Format,
                         DatePrinted = CopyInput.DatePrinted,
-                        Condition = CopyInput.Condition,
                         Publisher = publisher,
-                        CustomCoverArtUrl = string.IsNullOrWhiteSpace(CopyInput.CustomCoverArtUrl) ? null : CopyInput.CustomCoverArtUrl.Trim()
+                        CoverUrl = string.IsNullOrWhiteSpace(CopyInput.CustomCoverArtUrl) ? null : CopyInput.CustomCoverArtUrl.Trim(),
+                        Copies = [new Copy { Condition = CopyInput.Condition }]
                     }
                 ]
             };

--- a/BookTracker.Web/ViewModels/BookEditViewModel.cs
+++ b/BookTracker.Web/ViewModels/BookEditViewModel.cs
@@ -17,12 +17,12 @@ public class BookEditViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
     public List<TagItem> AvailableTags { get; private set; } = [];
     public string NewTagName { get; set; } = "";
 
-    // Copies
-    public List<CopyRow> Copies { get; private set; } = [];
+    // Editions & Copies
+    public List<EditionCopyRow> EditionCopies { get; private set; } = [];
     public bool ShowingNewCopy { get; set; }
     public CopyFormViewModel.CopyFormInput NewCopyInput { get; set; } = new();
 
-    // Inline copy editing
+    // Inline edition/copy editing
     public int? EditingCopyId { get; set; }
     public CopyEditInput EditCopyInput { get; set; } = new();
     public int? ConfirmingDeleteCopyId { get; set; }
@@ -43,8 +43,10 @@ public class BookEditViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
         var book = await db.Books
             .Include(b => b.Genres)
             .Include(b => b.Tags)
-            .Include(b => b.Copies)
-                .ThenInclude(c => c.Publisher)
+            .Include(b => b.Editions)
+                .ThenInclude(e => e.Copies)
+            .Include(b => b.Editions)
+                .ThenInclude(e => e.Publisher)
             .FirstOrDefaultAsync(b => b.Id == bookId);
 
         if (book is null)
@@ -67,7 +69,12 @@ public class BookEditViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
 
         SelectedGenreIds = book.Genres.Select(g => g.Id).ToList();
         AssignedTags = book.Tags.Select(t => new TagItem(t.Id, t.Name)).ToList();
-        Copies = book.Copies.Select(c => new CopyRow(c.Id, c.Isbn, c.Format, c.Condition, c.Publisher?.Name, c.DatePrinted, c.CustomCoverArtUrl)).ToList();
+        EditionCopies = book.Editions
+            .SelectMany(e => e.Copies.Select(c => new EditionCopyRow(
+                e.Id, c.Id, e.Isbn, e.Format, c.Condition,
+                e.Publisher?.Name, e.DatePrinted, e.CoverUrl,
+                c.Notes, c.DateAcquired)))
+            .ToList();
 
         SelectedSeriesId = book.SeriesId;
         SeriesOrder = book.SeriesOrder;
@@ -153,34 +160,37 @@ public class BookEditViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
             }
         }
 
-        var copy = new BookCopy
+        var edition = new Edition
         {
             BookId = bookId,
             Isbn = NewCopyInput.Isbn.Trim(),
             Format = NewCopyInput.Format,
             DatePrinted = NewCopyInput.DatePrinted,
-            Condition = NewCopyInput.Condition,
             Publisher = publisher,
-            CustomCoverArtUrl = string.IsNullOrWhiteSpace(NewCopyInput.CustomCoverArtUrl) ? null : NewCopyInput.CustomCoverArtUrl.Trim()
+            CoverUrl = string.IsNullOrWhiteSpace(NewCopyInput.CustomCoverArtUrl) ? null : NewCopyInput.CustomCoverArtUrl.Trim(),
+            Copies = [new Copy { Condition = NewCopyInput.Condition }]
         };
 
-        db.BookCopies.Add(copy);
+        db.Editions.Add(edition);
         await db.SaveChangesAsync();
 
-        Copies.Add(new CopyRow(copy.Id, copy.Isbn, copy.Format, copy.Condition, publisher?.Name, copy.DatePrinted, copy.CustomCoverArtUrl));
+        var copy = edition.Copies[0];
+        EditionCopies.Add(new EditionCopyRow(
+            edition.Id, copy.Id, edition.Isbn, edition.Format, copy.Condition,
+            publisher?.Name, edition.DatePrinted, edition.CoverUrl, copy.Notes, copy.DateAcquired));
         ShowingNewCopy = false;
     }
 
-    public void StartEditCopy(CopyRow copy)
+    public void StartEditCopy(EditionCopyRow row)
     {
-        EditingCopyId = copy.Id;
+        EditingCopyId = row.CopyId;
         EditCopyInput = new CopyEditInput
         {
-            Isbn = copy.Isbn,
-            Format = copy.Format,
-            Condition = copy.Condition,
-            Publisher = copy.PublisherName,
-            DatePrinted = copy.DatePrinted
+            Isbn = row.Isbn,
+            Format = row.Format,
+            Condition = row.Condition,
+            Publisher = row.PublisherName,
+            DatePrinted = row.DatePrinted
         };
     }
 
@@ -191,13 +201,14 @@ public class BookEditViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
         if (EditingCopyId is not int copyId) return;
 
         await using var db = await dbFactory.CreateDbContextAsync();
-        var copy = await db.BookCopies.Include(c => c.Publisher).FirstOrDefaultAsync(c => c.Id == copyId);
+        var copy = await db.Copies.Include(c => c.Edition).ThenInclude(e => e.Publisher).FirstOrDefaultAsync(c => c.Id == copyId);
         if (copy is null) { EditingCopyId = null; return; }
 
-        copy.Isbn = EditCopyInput.Isbn?.Trim() ?? copy.Isbn;
-        copy.Format = EditCopyInput.Format;
+        var edition = copy.Edition;
+        edition.Isbn = EditCopyInput.Isbn?.Trim() ?? edition.Isbn;
+        edition.Format = EditCopyInput.Format;
+        edition.DatePrinted = EditCopyInput.DatePrinted;
         copy.Condition = EditCopyInput.Condition;
-        copy.DatePrinted = EditCopyInput.DatePrinted;
 
         var pubName = EditCopyInput.Publisher?.Trim();
         if (!string.IsNullOrEmpty(pubName))
@@ -208,34 +219,44 @@ public class BookEditViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
                 publisher = new Publisher { Name = pubName };
                 db.Publishers.Add(publisher);
             }
-            copy.Publisher = publisher;
+            edition.Publisher = publisher;
         }
         else
         {
-            copy.Publisher = null;
-            copy.PublisherId = null;
+            edition.Publisher = null;
+            edition.PublisherId = null;
         }
 
         await db.SaveChangesAsync();
 
-        var idx = Copies.FindIndex(c => c.Id == copyId);
+        var idx = EditionCopies.FindIndex(c => c.CopyId == copyId);
         if (idx >= 0)
         {
-            Copies[idx] = new CopyRow(copy.Id, copy.Isbn, copy.Format, copy.Condition, pubName, copy.DatePrinted, copy.CustomCoverArtUrl);
+            EditionCopies[idx] = new EditionCopyRow(
+                edition.Id, copy.Id, edition.Isbn, edition.Format, copy.Condition,
+                pubName, edition.DatePrinted, edition.CoverUrl, copy.Notes, copy.DateAcquired);
         }
         EditingCopyId = null;
     }
 
-    public async Task DeleteCopyAsync(CopyRow copy)
+    public async Task DeleteCopyAsync(EditionCopyRow row)
     {
         await using var db = await dbFactory.CreateDbContextAsync();
-        var entity = await db.BookCopies.FindAsync(copy.Id);
-        if (entity is not null)
+        var copy = await db.Copies.Include(c => c.Edition).ThenInclude(e => e.Copies).FirstOrDefaultAsync(c => c.Id == row.CopyId);
+        if (copy is not null)
         {
-            db.BookCopies.Remove(entity);
+            var edition = copy.Edition;
+            db.Copies.Remove(copy);
+
+            // If this was the last copy on the edition, remove the edition too
+            if (edition.Copies.Count <= 1)
+            {
+                db.Editions.Remove(edition);
+            }
+
             await db.SaveChangesAsync();
         }
-        Copies.RemoveAll(c => c.Id == copy.Id);
+        EditionCopies.RemoveAll(c => c.CopyId == row.CopyId);
         ConfirmingDeleteCopyId = null;
     }
 
@@ -309,7 +330,7 @@ public class BookEditViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
 
     public record SeriesOption(int Id, string Name, SeriesType Type);
     public record TagItem(int Id, string Name);
-    public record CopyRow(int Id, string Isbn, BookFormat Format, BookCondition Condition, string? PublisherName, DateOnly? DatePrinted, string? CustomCoverArtUrl);
+    public record EditionCopyRow(int EditionId, int CopyId, string Isbn, BookFormat Format, BookCondition Condition, string? PublisherName, DateOnly? DatePrinted, string? CoverUrl, string? CopyNotes, DateTime? DateAcquired);
 
     public class CopyEditInput
     {

--- a/BookTracker.Web/ViewModels/BulkAddViewModel.cs
+++ b/BookTracker.Web/ViewModels/BulkAddViewModel.cs
@@ -44,7 +44,7 @@ public class BulkAddViewModel(
     private async Task CheckDuplicateAsync(DiscoveryRow row)
     {
         await using var db = await dbFactory.CreateDbContextAsync();
-        row.IsDuplicate = await db.BookCopies.AnyAsync(c => c.Isbn == row.Isbn);
+        row.IsDuplicate = await db.Editions.AnyAsync(e => e.Isbn == row.Isbn);
     }
 
     private async Task LookupRowAsync(DiscoveryRow row)
@@ -119,24 +119,22 @@ public class BulkAddViewModel(
 
         if (row.IsDuplicate)
         {
-            var existingCopy = await db.BookCopies
-                .Include(c => c.Book)
-                .FirstOrDefaultAsync(c => c.Isbn == row.Isbn);
+            var existingEdition = await db.Editions
+                .Include(e => e.Book)
+                .FirstOrDefaultAsync(e => e.Isbn == row.Isbn);
 
-            if (existingCopy is not null)
+            if (existingEdition is not null)
             {
-                var newCopy = new BookCopy
+                var newCopy = new Copy
                 {
-                    BookId = existingCopy.BookId,
-                    Isbn = row.Isbn,
-                    Format = BookFormat.Softcopy,
+                    EditionId = existingEdition.Id,
                     Condition = BookCondition.Good
                 };
-                db.BookCopies.Add(newCopy);
+                db.Copies.Add(newCopy);
 
                 if (followUp)
                 {
-                    var book = await db.Books.Include(b => b.Tags).FirstAsync(b => b.Id == existingCopy.BookId);
+                    var book = await db.Books.Include(b => b.Tags).FirstAsync(b => b.Id == existingEdition.BookId);
                     await EnsureFollowUpTagAsync(db, book);
                 }
 
@@ -163,15 +161,15 @@ public class BulkAddViewModel(
             Subtitle = row.Subtitle,
             Author = (row.Author ?? "Unknown").Trim(),
             DefaultCoverArtUrl = row.CoverUrl,
-            Copies =
+            Editions =
             [
-                new BookCopy
+                new Edition
                 {
                     Isbn = row.Isbn,
                     Format = BookFormat.Softcopy,
-                    Condition = BookCondition.Good,
                     DatePrinted = row.DatePrinted,
-                    Publisher = publisher
+                    Publisher = publisher,
+                    Copies = [new Copy { Condition = BookCondition.Good }]
                 }
             ]
         };

--- a/BookTracker.Web/ViewModels/ShoppingViewModel.cs
+++ b/BookTracker.Web/ViewModels/ShoppingViewModel.cs
@@ -75,22 +75,24 @@ public class ShoppingViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
             SearchTerm = "";
             await using var db = await dbFactory.CreateDbContextAsync();
 
-            var copies = await db.BookCopies
-                .Include(c => c.Book)
+            var editions = await db.Editions
+                .Include(e => e.Book)
                     .ThenInclude(b => b.Series)
-                .Where(c => c.Isbn == isbn)
+                .Include(e => e.Copies)
+                .Where(e => e.Isbn == isbn)
                 .ToListAsync();
 
-            if (copies.Count > 0)
+            if (editions.Count > 0)
             {
-                var book = copies[0].Book;
+                var book = editions[0].Book;
+                var copyCount = editions.SelectMany(e => e.Copies).Count();
                 var seriesInfo = await GetSeriesInfoAsync(db, book);
                 Result = new LookupResult(
                     Found: true,
                     BookId: book.Id,
                     Title: book.Title,
                     Author: book.Author,
-                    CopyCount: copies.Count,
+                    CopyCount: copyCount,
                     CoverUrl: book.DefaultCoverArtUrl,
                     SeriesInfo: seriesInfo);
             }
@@ -124,7 +126,8 @@ public class ShoppingViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
             await using var db = await dbFactory.CreateDbContextAsync();
 
             var books = await db.Books
-                .Include(b => b.Copies)
+                .Include(b => b.Editions)
+                    .ThenInclude(e => e.Copies)
                 .Include(b => b.Series)
                 .Where(b => b.Title.Contains(term) || b.Author.Contains(term))
                 .OrderBy(b => b.Title)
@@ -140,7 +143,7 @@ public class ShoppingViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
                     BookId: book.Id,
                     Title: book.Title,
                     Author: book.Author,
-                    CopyCount: book.Copies.Count,
+                    CopyCount: book.Editions.SelectMany(e => e.Copies).Count(),
                     CoverUrl: book.DefaultCoverArtUrl,
                     SeriesInfo: seriesInfo);
             }
@@ -155,7 +158,7 @@ public class ShoppingViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
                     CoverUrl: null,
                     SeriesInfo: null,
                     MultipleResults: books.Select(b => new SearchResultItem(
-                        b.Id, b.Title, b.Author, b.Copies.Count, b.DefaultCoverArtUrl
+                        b.Id, b.Title, b.Author, b.Editions.SelectMany(e => e.Copies).Count(), b.DefaultCoverArtUrl
                     )).ToList());
             }
             else
@@ -180,7 +183,8 @@ public class ShoppingViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
     {
         await using var db = await dbFactory.CreateDbContextAsync();
         var book = await db.Books
-            .Include(b => b.Copies)
+            .Include(b => b.Editions)
+                .ThenInclude(e => e.Copies)
             .Include(b => b.Series)
             .FirstOrDefaultAsync(b => b.Id == bookId);
 
@@ -192,7 +196,7 @@ public class ShoppingViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
             BookId: book.Id,
             Title: book.Title,
             Author: book.Author,
-            CopyCount: book.Copies.Count,
+            CopyCount: book.Editions.SelectMany(e => e.Copies).Count(),
             CoverUrl: book.DefaultCoverArtUrl,
             SeriesInfo: seriesInfo);
     }
@@ -311,16 +315,16 @@ public class ShoppingViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
             Title = item.Title,
             Author = item.Author,
             Tags = [followUpTag],
-            Copies = []
+            Editions = []
         };
 
         if (!string.IsNullOrWhiteSpace(item.Isbn))
         {
-            book.Copies.Add(new BookCopy
+            book.Editions.Add(new Edition
             {
                 Isbn = item.Isbn,
                 Format = BookFormat.Softcopy,
-                Condition = BookCondition.Good
+                Copies = [new Copy { Condition = BookCondition.Good }]
             });
         }
 


### PR DESCRIPTION
Splits the flat BookCopy entity into a proper hierarchy:
  Book → Edition (ISBN, Format, Publisher, DatePrinted, CoverUrl)
           → Copy (Condition, DateAcquired, Notes)

This correctly models that a book can have multiple editions (hardcover, softcover, different publishers) each with a unique ISBN, and each edition can have multiple physical copies.

Edition.Isbn has a unique index so ISBN lookup always finds the right edition. Duplicate detection now works at the Edition level.

Data migration preserves all existing BookCopy data: each BookCopy becomes one Edition + one Copy. BookCopies with the same ISBN are merged into a single Edition with multiple Copies.

All ViewModels updated to compile against the new model. Pages and shared components will get deeper UI reworks in follow-up PRs.