### PR TITLE
refactor: split form components for Edition + Copy model

### DIFF
--- a/BookTracker.Web/Components/Pages/Books/Add.razor
+++ b/BookTracker.Web/Components/Pages/Books/Add.razor
@@ -58,7 +58,7 @@
         </div>
 
         <div class="col-12">
-            <CopyForm Input="VM.CopyInput" Title="First copy" />
+            <EditionCopyForm EditionInput="VM.EditionInput" CopyInput="VM.CopyInput" Title="First edition & copy" />
         </div>
 
         <div class="col-12 d-flex gap-2">

--- a/BookTracker.Web/Components/Pages/Books/Edit.razor
+++ b/BookTracker.Web/Components/Pages/Books/Edit.razor
@@ -116,11 +116,11 @@ else
             <div class="col-12">
                 <div class="card">
                     <div class="card-header bg-white d-flex justify-content-between align-items-center">
-                        <h2 class="h5 mb-0">Copies (@VM.EditionCopies.Count)</h2>
-                        <button type="button" class="btn btn-outline-primary btn-sm" @onclick="VM.ShowAddCopy">Add copy</button>
+                        <h2 class="h5 mb-0">Editions & Copies (@VM.EditionCopies.Count)</h2>
+                        <button type="button" class="btn btn-outline-primary btn-sm" @onclick="VM.ShowAddEdition">Add edition</button>
                     </div>
                     <div class="card-body">
-                        @if (VM.EditionCopies.Count == 0 && !VM.ShowingNewCopy)
+                        @if (VM.EditionCopies.Count == 0 && !VM.ShowingNewEdition)
                         {
                             <p class="text-muted mb-0">No copies recorded.</p>
                         }
@@ -204,13 +204,13 @@ else
                             </div>
                         }
 
-                        @if (VM.ShowingNewCopy)
+                        @if (VM.ShowingNewEdition)
                         {
                             <div class="mt-3 pt-3 border-top">
-                                <CopyForm Input="VM.NewCopyInput" Title="New copy" />
+                                <EditionCopyForm EditionInput="VM.NewEditionInput" CopyInput="VM.NewCopyInput" Title="New edition & copy" />
                                 <div class="mt-2 d-flex gap-2">
-                                    <button type="button" class="btn btn-outline-success btn-sm" @onclick="() => VM.SaveNewCopyAsync(BookId)">Save copy</button>
-                                    <button type="button" class="btn btn-outline-secondary btn-sm" @onclick="() => VM.ShowingNewCopy = false">Cancel</button>
+                                    <button type="button" class="btn btn-outline-success btn-sm" @onclick="() => VM.SaveNewEditionAsync(BookId)">Save</button>
+                                    <button type="button" class="btn btn-outline-secondary btn-sm" @onclick="() => VM.ShowingNewEdition = false">Cancel</button>
                                 </div>
                             </div>
                         }

--- a/BookTracker.Web/Components/Shared/EditionCopyForm.razor
+++ b/BookTracker.Web/Components/Shared/EditionCopyForm.razor
@@ -1,4 +1,4 @@
-@inject CopyFormViewModel VM
+@inject EditionFormViewModel EditionVM
 
 <div class="card">
     <div class="card-header bg-white"><h2 class="h5 mb-0">@Title</h2></div>
@@ -6,12 +6,12 @@
         <div class="row g-3">
             <div class="col-md-4">
                 <label class="form-label">ISBN</label>
-                <InputText @bind-Value="Input.Isbn" class="form-control" />
-                <ValidationMessage For="() => Input.Isbn" class="text-danger small" />
+                <InputText @bind-Value="EditionInput.Isbn" class="form-control" />
+                <ValidationMessage For="() => EditionInput.Isbn" class="text-danger small" />
             </div>
             <div class="col-md-2">
                 <label class="form-label">Format</label>
-                <InputSelect @bind-Value="Input.Format" class="form-select">
+                <InputSelect @bind-Value="EditionInput.Format" class="form-select">
                     @foreach (var f in Enum.GetValues<BookFormat>())
                     {
                         <option value="@f">@f</option>
@@ -20,11 +20,11 @@
             </div>
             <div class="col-md-3">
                 <label class="form-label">Date printed</label>
-                <InputDate @bind-Value="Input.DatePrinted" class="form-control" />
+                <InputDate @bind-Value="EditionInput.DatePrinted" class="form-control" />
             </div>
             <div class="col-md-3">
                 <label class="form-label">Condition</label>
-                <InputSelect @bind-Value="Input.Condition" class="form-select">
+                <InputSelect @bind-Value="CopyInput.Condition" class="form-select">
                     @foreach (var c in Enum.GetValues<BookCondition>())
                     {
                         <option value="@c">@CopyFormViewModel.FormatCondition(c)</option>
@@ -33,17 +33,17 @@
             </div>
             <div class="col-md-6">
                 <label class="form-label">Publisher</label>
-                <InputText @bind-Value="Input.Publisher" class="form-control" list="@publisherDatalistId" placeholder="Penguin Books" />
+                <InputText @bind-Value="EditionInput.Publisher" class="form-control" list="@publisherDatalistId" placeholder="Penguin Books" />
                 <datalist id="@publisherDatalistId">
-                    @foreach (var p in VM.ExistingPublishers)
+                    @foreach (var p in EditionVM.ExistingPublishers)
                     {
                         <option value="@p.Name"></option>
                     }
                 </datalist>
             </div>
-            <div class="col-12">
-                <label class="form-label">Custom cover for this copy (optional)</label>
-                <InputText @bind-Value="Input.CustomCoverArtUrl" class="form-control" placeholder="Overrides the book's default cover" />
+            <div class="col-md-6">
+                <label class="form-label">Edition cover URL (optional)</label>
+                <InputText @bind-Value="EditionInput.CoverUrl" class="form-control" placeholder="Overrides the book's default cover" />
             </div>
         </div>
     </div>
@@ -51,15 +51,18 @@
 
 @code {
     [Parameter, EditorRequired]
-    public CopyFormViewModel.CopyFormInput Input { get; set; } = default!;
+    public EditionFormViewModel.EditionFormInput EditionInput { get; set; } = default!;
+
+    [Parameter, EditorRequired]
+    public CopyFormViewModel.CopyFormInput CopyInput { get; set; } = default!;
 
     [Parameter]
-    public string Title { get; set; } = "Copy";
+    public string Title { get; set; } = "Edition & Copy";
 
     private string publisherDatalistId = $"publisher-options-{Guid.NewGuid():N}";
 
     protected override async Task OnInitializedAsync()
     {
-        await VM.InitializeAsync();
+        await EditionVM.InitializeAsync();
     }
 }

--- a/BookTracker.Web/Program.cs
+++ b/BookTracker.Web/Program.cs
@@ -29,6 +29,7 @@ builder.Services.AddTransient<SeriesMatchService>();
 // ViewModels — transient so each component instance gets its own VM.
 builder.Services.AddTransient<HomeViewModel>();
 builder.Services.AddTransient<BookFormViewModel>();
+builder.Services.AddTransient<EditionFormViewModel>();
 builder.Services.AddTransient<CopyFormViewModel>();
 builder.Services.AddTransient<GenrePickerViewModel>();
 builder.Services.AddTransient<BookListViewModel>();

--- a/BookTracker.Web/ViewModels/BookAddViewModel.cs
+++ b/BookTracker.Web/ViewModels/BookAddViewModel.cs
@@ -11,6 +11,7 @@ public class BookAddViewModel(
     SeriesMatchService seriesMatch)
 {
     public BookFormViewModel.BookFormInput BookInput { get; set; } = new();
+    public EditionFormViewModel.EditionFormInput EditionInput { get; set; } = new();
     public CopyFormViewModel.CopyFormInput CopyInput { get; set; } = new();
     public List<string> LookupCandidates { get; private set; } = [];
 
@@ -45,9 +46,9 @@ public class BookAddViewModel(
             if (string.IsNullOrWhiteSpace(BookInput.Subtitle)) BookInput.Subtitle = result.Subtitle;
             if (string.IsNullOrWhiteSpace(BookInput.Author)) BookInput.Author = result.Author ?? "";
             if (string.IsNullOrWhiteSpace(BookInput.DefaultCoverArtUrl)) BookInput.DefaultCoverArtUrl = result.CoverUrl;
-            if (string.IsNullOrWhiteSpace(CopyInput.Isbn)) CopyInput.Isbn = result.Isbn;
-            if (string.IsNullOrWhiteSpace(CopyInput.Publisher)) CopyInput.Publisher = result.Publisher;
-            CopyInput.DatePrinted ??= result.DatePrinted;
+            if (string.IsNullOrWhiteSpace(EditionInput.Isbn)) EditionInput.Isbn = result.Isbn;
+            if (string.IsNullOrWhiteSpace(EditionInput.Publisher)) EditionInput.Publisher = result.Publisher;
+            EditionInput.DatePrinted ??= result.DatePrinted;
 
             LookupCandidates = result.GenreCandidates.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
             genrePicker.LookupCandidates = LookupCandidates;
@@ -76,7 +77,7 @@ public class BookAddViewModel(
                 .ToListAsync();
 
             Publisher? publisher = null;
-            var publisherName = CopyInput.Publisher?.Trim();
+            var publisherName = EditionInput.Publisher?.Trim();
             if (!string.IsNullOrEmpty(publisherName))
             {
                 publisher = await db.Publishers.FirstOrDefaultAsync(p => p.Name == publisherName);
@@ -102,11 +103,11 @@ public class BookAddViewModel(
                 [
                     new Edition
                     {
-                        Isbn = CopyInput.Isbn!.Trim(),
-                        Format = CopyInput.Format,
-                        DatePrinted = CopyInput.DatePrinted,
+                        Isbn = EditionInput.Isbn!.Trim(),
+                        Format = EditionInput.Format,
+                        DatePrinted = EditionInput.DatePrinted,
                         Publisher = publisher,
-                        CoverUrl = string.IsNullOrWhiteSpace(CopyInput.CustomCoverArtUrl) ? null : CopyInput.CustomCoverArtUrl.Trim(),
+                        CoverUrl = string.IsNullOrWhiteSpace(EditionInput.CoverUrl) ? null : EditionInput.CoverUrl.Trim(),
                         Copies = [new Copy { Condition = CopyInput.Condition }]
                     }
                 ]

--- a/BookTracker.Web/ViewModels/BookEditViewModel.cs
+++ b/BookTracker.Web/ViewModels/BookEditViewModel.cs
@@ -19,7 +19,8 @@ public class BookEditViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
 
     // Editions & Copies
     public List<EditionCopyRow> EditionCopies { get; private set; } = [];
-    public bool ShowingNewCopy { get; set; }
+    public bool ShowingNewEdition { get; set; }
+    public EditionFormViewModel.EditionFormInput NewEditionInput { get; set; } = new();
     public CopyFormViewModel.CopyFormInput NewCopyInput { get; set; } = new();
 
     // Inline edition/copy editing
@@ -136,20 +137,21 @@ public class BookEditViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
         }
     }
 
-    public void ShowAddCopy()
+    public void ShowAddEdition()
     {
+        NewEditionInput = new EditionFormViewModel.EditionFormInput();
         NewCopyInput = new CopyFormViewModel.CopyFormInput();
-        ShowingNewCopy = true;
+        ShowingNewEdition = true;
     }
 
-    public async Task SaveNewCopyAsync(int bookId)
+    public async Task SaveNewEditionAsync(int bookId)
     {
-        if (string.IsNullOrWhiteSpace(NewCopyInput.Isbn)) return;
+        if (string.IsNullOrWhiteSpace(NewEditionInput.Isbn)) return;
 
         await using var db = await dbFactory.CreateDbContextAsync();
 
         Publisher? publisher = null;
-        var pubName = NewCopyInput.Publisher?.Trim();
+        var pubName = NewEditionInput.Publisher?.Trim();
         if (!string.IsNullOrEmpty(pubName))
         {
             publisher = await db.Publishers.FirstOrDefaultAsync(p => p.Name == pubName);
@@ -163,11 +165,11 @@ public class BookEditViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
         var edition = new Edition
         {
             BookId = bookId,
-            Isbn = NewCopyInput.Isbn.Trim(),
-            Format = NewCopyInput.Format,
-            DatePrinted = NewCopyInput.DatePrinted,
+            Isbn = NewEditionInput.Isbn.Trim(),
+            Format = NewEditionInput.Format,
+            DatePrinted = NewEditionInput.DatePrinted,
             Publisher = publisher,
-            CoverUrl = string.IsNullOrWhiteSpace(NewCopyInput.CustomCoverArtUrl) ? null : NewCopyInput.CustomCoverArtUrl.Trim(),
+            CoverUrl = string.IsNullOrWhiteSpace(NewEditionInput.CoverUrl) ? null : NewEditionInput.CoverUrl.Trim(),
             Copies = [new Copy { Condition = NewCopyInput.Condition }]
         };
 
@@ -178,7 +180,7 @@ public class BookEditViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
         EditionCopies.Add(new EditionCopyRow(
             edition.Id, copy.Id, edition.Isbn, edition.Format, copy.Condition,
             publisher?.Name, edition.DatePrinted, edition.CoverUrl, copy.Notes, copy.DateAcquired));
-        ShowingNewCopy = false;
+        ShowingNewEdition = false;
     }
 
     public void StartEditCopy(EditionCopyRow row)

--- a/BookTracker.Web/ViewModels/CopyFormViewModel.cs
+++ b/BookTracker.Web/ViewModels/CopyFormViewModel.cs
@@ -1,23 +1,9 @@
-using System.ComponentModel.DataAnnotations;
-using BookTracker.Data;
 using BookTracker.Data.Models;
-using Microsoft.EntityFrameworkCore;
 
 namespace BookTracker.Web.ViewModels;
 
-public class CopyFormViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory)
+public class CopyFormViewModel
 {
-    public List<PublisherOption> ExistingPublishers { get; private set; } = [];
-
-    public async Task InitializeAsync()
-    {
-        await using var db = await dbFactory.CreateDbContextAsync();
-        ExistingPublishers = await db.Publishers
-            .OrderBy(p => p.Name)
-            .Select(p => new PublisherOption(p.Id, p.Name))
-            .ToListAsync();
-    }
-
     public static string FormatCondition(BookCondition c) => c switch
     {
         BookCondition.AsNew => "As New",
@@ -25,24 +11,12 @@ public class CopyFormViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
         _ => c.ToString()
     };
 
-    public record PublisherOption(int Id, string Name);
-
     public class CopyFormInput
     {
-        [Required, StringLength(20)]
-        [RegularExpression(@"^(97(8|9))?\d{9}(\d|X|x)$", ErrorMessage = "Enter a valid 10- or 13-digit ISBN.")]
-        public string? Isbn { get; set; }
-
-        public BookFormat Format { get; set; } = BookFormat.Softcopy;
-
-        public DateOnly? DatePrinted { get; set; }
-
         public BookCondition Condition { get; set; } = BookCondition.Good;
 
-        [StringLength(200)]
-        public string? Publisher { get; set; }
+        public DateTime? DateAcquired { get; set; }
 
-        [StringLength(500)]
-        public string? CustomCoverArtUrl { get; set; }
+        public string? Notes { get; set; }
     }
 }

--- a/BookTracker.Web/ViewModels/EditionFormViewModel.cs
+++ b/BookTracker.Web/ViewModels/EditionFormViewModel.cs
@@ -1,0 +1,39 @@
+using System.ComponentModel.DataAnnotations;
+using BookTracker.Data;
+using BookTracker.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookTracker.Web.ViewModels;
+
+public class EditionFormViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory)
+{
+    public List<PublisherOption> ExistingPublishers { get; private set; } = [];
+
+    public async Task InitializeAsync()
+    {
+        await using var db = await dbFactory.CreateDbContextAsync();
+        ExistingPublishers = await db.Publishers
+            .OrderBy(p => p.Name)
+            .Select(p => new PublisherOption(p.Id, p.Name))
+            .ToListAsync();
+    }
+
+    public record PublisherOption(int Id, string Name);
+
+    public class EditionFormInput
+    {
+        [Required, StringLength(20)]
+        [RegularExpression(@"^(97(8|9))?\d{9}(\d|X|x)$", ErrorMessage = "Enter a valid 10- or 13-digit ISBN.")]
+        public string? Isbn { get; set; }
+
+        public BookFormat Format { get; set; } = BookFormat.Softcopy;
+
+        public DateOnly? DatePrinted { get; set; }
+
+        [StringLength(200)]
+        public string? Publisher { get; set; }
+
+        [StringLength(500)]
+        public string? CoverUrl { get; set; }
+    }
+}


### PR DESCRIPTION
Replaces the combined CopyForm/CopyFormInput with properly split types:
- EditionFormViewModel: EditionFormInput (ISBN, Format, DatePrinted, Publisher, CoverUrl) + publisher autocomplete loading
- CopyFormViewModel: CopyFormInput (Condition, DateAcquired, Notes)
  + FormatCondition helper
- EditionCopyForm.razor: combined component for creating an edition with its first copy (used by Add and Edit pages)

BookAddViewModel now uses separate EditionInput + CopyInput. BookEditViewModel updated: ShowAddEdition/SaveNewEditionAsync use the split inputs. Edit page updated to use EditionCopyForm.

Old CopyForm.razor removed (replaced by EditionCopyForm).