### PR TITLE
feat: add AI Assistant page with genre cleanup section

### DIFF
--- a/BookTracker.Web/Components/Layout/MainLayout.razor
+++ b/BookTracker.Web/Components/Layout/MainLayout.razor
@@ -29,6 +29,9 @@
                         <NavLink class="nav-link text-dark" href="shopping">Shopping</NavLink>
                     </li>
                     <li class="nav-item">
+                        <NavLink class="nav-link text-dark" href="assistant">AI Assistant</NavLink>
+                    </li>
+                    <li class="nav-item">
                         <NavLink class="nav-link text-dark" href="privacy">Privacy</NavLink>
                     </li>
                 </ul>

--- a/BookTracker.Web/Components/Pages/Assistant/Index.razor
+++ b/BookTracker.Web/Components/Pages/Assistant/Index.razor
@@ -1,0 +1,117 @@
+@page "/assistant"
+@inject AIAssistantViewModel VM
+
+<PageTitle>AI Assistant - BookTracker</PageTitle>
+
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <h1 class="mb-0">AI Assistant</h1>
+    <span class="badge bg-light text-dark border">AI calls: @VM.CallCount</span>
+</div>
+
+<div class="card mb-4">
+    <div class="card-header bg-white d-flex justify-content-between align-items-center">
+        <h2 class="h5 mb-0">Genre cleanup</h2>
+        @if (!VM.GenresLoaded)
+        {
+            <button type="button" class="btn btn-outline-primary btn-sm" @onclick="VM.LoadBooksNeedingGenresAsync">
+                Load books
+            </button>
+        }
+    </div>
+    <div class="card-body">
+        @if (!VM.GenresLoaded)
+        {
+            <p class="text-muted small mb-0">Tap "Load books" to see books that could use better genre classification.</p>
+        }
+        else if (VM.BooksNeedingGenres.Count == 0)
+        {
+            <p class="text-muted small mb-0">All books have genres assigned.</p>
+        }
+        else
+        {
+            @foreach (var book in VM.BooksNeedingGenres)
+            {
+                <div class="py-3 @(book != VM.BooksNeedingGenres.Last() ? "border-bottom" : "")">
+                    <div class="d-flex justify-content-between align-items-start">
+                        <div class="flex-grow-1 min-width-0">
+                            <div class="fw-semibold">@book.Title</div>
+                            <div class="text-muted small">@book.Author</div>
+                            <div class="mt-1 d-flex flex-wrap gap-1">
+                                @if (book.CurrentGenres.Count == 0)
+                                {
+                                    <span class="badge bg-danger">No genres</span>
+                                }
+                                else
+                                {
+                                    @foreach (var genre in book.CurrentGenres)
+                                    {
+                                        <span class="badge bg-light text-dark border">@genre</span>
+                                    }
+                                }
+                            </div>
+                        </div>
+                        <div class="flex-shrink-0 ms-2">
+                            @if (VM.SuggestingForBookId == book.Id)
+                            {
+                                <button type="button" class="btn btn-outline-primary btn-sm" disabled>
+                                    <span class="spinner-border spinner-border-sm" role="status"></span>
+                                </button>
+                            }
+                            else
+                            {
+                                <button type="button" class="btn btn-outline-primary btn-sm" @onclick="() => VM.SuggestGenresForBookAsync(book.Id)">
+                                    Suggest
+                                </button>
+                            }
+                        </div>
+                    </div>
+
+                    @if (VM.SuggestedBookId == book.Id && VM.CurrentSuggestion is not null)
+                    {
+                        <div class="mt-2 p-3 bg-light rounded">
+                            <div class="small fw-semibold mb-1">AI suggests:</div>
+                            <div class="d-flex flex-wrap gap-1 mb-2">
+                                @foreach (var genre in VM.CurrentSuggestion.SuggestedGenres)
+                                {
+                                    var isNew = !book.CurrentGenres.Contains(genre);
+                                    <span class="badge @(isNew ? "bg-success" : "bg-light text-dark border")">
+                                        @genre @(isNew ? "(new)" : "")
+                                    </span>
+                                }
+                            </div>
+                            @if (!string.IsNullOrEmpty(VM.CurrentSuggestion.Reasoning))
+                            {
+                                <div class="text-muted small mb-2">@VM.CurrentSuggestion.Reasoning</div>
+                            }
+                            <div class="d-flex gap-2">
+                                @{
+                                    var newGenres = VM.CurrentSuggestion.SuggestedGenres
+                                        .Where(g => !book.CurrentGenres.Contains(g)).ToList();
+                                }
+                                @if (newGenres.Count > 0)
+                                {
+                                    <button type="button" class="btn btn-success btn-sm"
+                                            @onclick="() => VM.AcceptGenreSuggestionsAsync(book.Id, newGenres)">
+                                        Accept @newGenres.Count new
+                                    </button>
+                                    <button type="button" class="btn btn-outline-success btn-sm"
+                                            @onclick="() => VM.AcceptGenreSuggestionsAsync(book.Id, VM.CurrentSuggestion.SuggestedGenres)">
+                                        Accept all
+                                    </button>
+                                }
+                                <button type="button" class="btn btn-outline-secondary btn-sm" @onclick="VM.DismissSuggestion">
+                                    Dismiss
+                                </button>
+                            </div>
+                        </div>
+                    }
+
+                    @if (VM.SuggestedBookId == book.Id && VM.GenreError is not null)
+                    {
+                        <div class="alert alert-warning mt-2 py-2 small mb-0">@VM.GenreError</div>
+                    }
+                </div>
+            }
+        }
+    </div>
+</div>

--- a/BookTracker.Web/Program.cs
+++ b/BookTracker.Web/Program.cs
@@ -43,6 +43,7 @@ builder.Services.AddTransient<BulkAddViewModel>();
 builder.Services.AddTransient<SeriesListViewModel>();
 builder.Services.AddTransient<SeriesEditViewModel>();
 builder.Services.AddTransient<ShoppingViewModel>();
+builder.Services.AddScoped<AIAssistantViewModel>();
 
 var app = builder.Build();
 

--- a/BookTracker.Web/ViewModels/AIAssistantViewModel.cs
+++ b/BookTracker.Web/ViewModels/AIAssistantViewModel.cs
@@ -1,0 +1,108 @@
+using BookTracker.Data;
+using BookTracker.Data.Models;
+using BookTracker.Web.Services;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookTracker.Web.ViewModels;
+
+public class AIAssistantViewModel(
+    IDbContextFactory<BookTrackerDbContext> dbFactory,
+    IAIAssistantService aiService)
+{
+    // Genre cleanup
+    public List<BookGenreRow> BooksNeedingGenres { get; private set; } = [];
+    public bool GenresLoaded { get; private set; }
+    public int? SuggestingForBookId { get; private set; }
+    public int? SuggestedBookId { get; private set; }
+    public GenreSuggestionResult? CurrentSuggestion { get; private set; }
+    public string? GenreError { get; private set; }
+
+    public int CallCount => aiService.CallCount;
+
+    public async Task LoadBooksNeedingGenresAsync()
+    {
+        await using var db = await dbFactory.CreateDbContextAsync();
+
+        BooksNeedingGenres = await db.Books
+            .Include(b => b.Genres)
+            .OrderBy(b => b.Genres.Count)
+            .ThenBy(b => b.Title)
+            .Take(50)
+            .Select(b => new BookGenreRow(
+                b.Id,
+                b.Title,
+                b.Subtitle,
+                b.Author,
+                b.Genres.Select(g => g.Name).ToList()))
+            .ToListAsync();
+
+        GenresLoaded = true;
+    }
+
+    public async Task SuggestGenresForBookAsync(int bookId)
+    {
+        var book = BooksNeedingGenres.FirstOrDefault(b => b.Id == bookId);
+        if (book is null) return;
+
+        SuggestingForBookId = bookId;
+        SuggestedBookId = bookId;
+        CurrentSuggestion = null;
+        GenreError = null;
+
+        try
+        {
+            CurrentSuggestion = await aiService.SuggestGenresAsync(
+                book.Title, book.Author, book.Subtitle, book.CurrentGenres);
+        }
+        catch (Exception ex)
+        {
+            GenreError = $"AI request failed: {ex.Message}";
+        }
+        finally
+        {
+            SuggestingForBookId = null;
+        }
+    }
+
+    public async Task AcceptGenreSuggestionsAsync(int bookId, IReadOnlyList<string> genreNames)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync();
+
+        var book = await db.Books.Include(b => b.Genres).FirstOrDefaultAsync(b => b.Id == bookId);
+        if (book is null) return;
+
+        var genresToAdd = await db.Genres
+            .Where(g => genreNames.Contains(g.Name))
+            .ToListAsync();
+
+        foreach (var genre in genresToAdd)
+        {
+            if (!book.Genres.Any(g => g.Id == genre.Id))
+                book.Genres.Add(genre);
+        }
+
+        await db.SaveChangesAsync();
+
+        // Update the local list
+        var row = BooksNeedingGenres.FirstOrDefault(b => b.Id == bookId);
+        if (row is not null)
+        {
+            var idx = BooksNeedingGenres.IndexOf(row);
+            var updatedGenres = book.Genres.Select(g => g.Name).ToList();
+            BooksNeedingGenres[idx] = row with { CurrentGenres = updatedGenres };
+        }
+
+        CurrentSuggestion = null;
+    }
+
+    public void DismissSuggestion()
+    {
+        CurrentSuggestion = null;
+        SuggestedBookId = null;
+        GenreError = null;
+    }
+
+    public record BookGenreRow(
+        int Id, string Title, string? Subtitle, string Author,
+        List<string> CurrentGenres);
+}


### PR DESCRIPTION
New /assistant page for AI-powered library data cleanup. First section: genre cleanup.

Genre cleanup:
- Loads books sorted by genre count (fewest first, up to 50)
- Per book: shows current genres, "Suggest" button calls Claude Sonnet via the AI service to recommend genres from the preset taxonomy
- Suggestion panel shows recommended genres (new ones highlighted in green), AI reasoning, accept new / accept all / dismiss actions
- Accepted genres are immediately saved to the book
- AI call counter shown in page header for cost visibility

AIAssistantViewModel (scoped): manages book list, suggestion state, tracks which book suggestion is displayed for, genre acceptance flow.

Nav link added ("AI Assistant").