### PR TITLE
feat: add AI collection cataloguing suggestions

### DIFF
--- a/BookTracker.Web/Components/Pages/Assistant/Index.razor
+++ b/BookTracker.Web/Components/Pages/Assistant/Index.razor
@@ -115,3 +115,73 @@
         }
     </div>
 </div>
+
+<div class="card mb-4">
+    <div class="card-header bg-white d-flex justify-content-between align-items-center">
+        <h2 class="h5 mb-0">Collection helper</h2>
+        @if (VM.CollectionSuggestion is null && !VM.SuggestingCollections)
+        {
+            <button type="button" class="btn btn-outline-primary btn-sm" @onclick="VM.SuggestCollectionsAsync">
+                Suggest groupings
+            </button>
+        }
+    </div>
+    <div class="card-body">
+        @if (VM.SuggestingCollections)
+        {
+            <div class="text-center py-3">
+                <div class="spinner-border spinner-border-sm" role="status"></div>
+                <span class="ms-2 text-muted small">Analysing your library...</span>
+            </div>
+        }
+        else if (VM.CollectionError is not null)
+        {
+            <div class="alert alert-warning py-2 small mb-0">@VM.CollectionError</div>
+        }
+        else if (VM.CollectionSuggestion is not null)
+        {
+            @if (!string.IsNullOrEmpty(VM.CollectionSuggestion.Summary))
+            {
+                <p class="text-muted small mb-3">@VM.CollectionSuggestion.Summary</p>
+            }
+
+            @if (VM.CollectionSuggestion.Groupings.Count == 0)
+            {
+                <p class="text-muted small mb-0">No groupings suggested — your uncategorised books don't form obvious collections.</p>
+            }
+            else
+            {
+                @foreach (var grouping in VM.CollectionSuggestion.Groupings)
+                {
+                    <div class="p-3 bg-light rounded mb-3">
+                        <div class="d-flex justify-content-between align-items-start mb-2">
+                            <div>
+                                <span class="fw-semibold">@grouping.SuggestedName</span>
+                                <span class="badge bg-light text-dark border ms-1">@grouping.Type</span>
+                            </div>
+                            <button type="button" class="btn btn-success btn-sm" @onclick="() => VM.CreateCollectionFromSuggestionAsync(grouping)">
+                                Create
+                            </button>
+                        </div>
+                        <div class="text-muted small mb-2">@grouping.Reasoning</div>
+                        <div class="d-flex flex-wrap gap-1">
+                            @foreach (var title in grouping.BookTitles)
+                            {
+                                <span class="badge bg-white text-dark border">@title</span>
+                            }
+                        </div>
+                    </div>
+                }
+            }
+
+            <div class="mt-2">
+                <button type="button" class="btn btn-outline-secondary btn-sm" @onclick="VM.DismissCollections">Dismiss</button>
+                <button type="button" class="btn btn-outline-primary btn-sm ms-1" @onclick="VM.SuggestCollectionsAsync">Refresh</button>
+            </div>
+        }
+        else
+        {
+            <p class="text-muted small mb-0">Tap "Suggest groupings" to have AI analyse uncategorised books and suggest series/collection groupings.</p>
+        }
+    </div>
+</div>

--- a/BookTracker.Web/Services/AIAssistantService.cs
+++ b/BookTracker.Web/Services/AIAssistantService.cs
@@ -95,18 +95,94 @@ Respond with JSON only.";
         return ParseGenreSuggestion(responseText, allGenres.Select(g => g.Name).ToHashSet());
     }
 
+    public async Task<CollectionSuggestionResult> SuggestCollectionsAsync(CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+
+        // Load books not in any series
+        var uncategorised = await db.Books
+            .Where(b => b.SeriesId == null)
+            .OrderBy(b => b.Author)
+            .ThenBy(b => b.Title)
+            .Select(b => new { b.Title, b.Author })
+            .ToListAsync(ct);
+
+        if (uncategorised.Count == 0)
+            return new CollectionSuggestionResult([], "All books are already in a series or collection.");
+
+        // Load existing series for context
+        var existingSeries = await db.Series
+            .OrderBy(s => s.Name)
+            .Select(s => new { s.Name, s.Type, BookCount = s.Books.Count })
+            .ToListAsync(ct);
+
+        var booksText = string.Join("\n", uncategorised.Select(b => $"- \"{b.Title}\" by {b.Author}"));
+        var seriesText = existingSeries.Count > 0
+            ? "Existing series/collections:\n" + string.Join("\n", existingSeries.Select(s => $"- {s.Name} ({s.Type}, {s.BookCount} books)"))
+            : "No existing series or collections.";
+
+        var systemPrompt = $@"You are a librarian helping organise a book collection into series and collections.
+
+A ""Series"" is a numbered sequence with a known order (e.g. Harry Potter 1-7).
+A ""Collection"" is a loose grouping by the same author or theme (e.g. all Agatha Christie's Poirot novels).
+
+{seriesText}
+
+Rules:
+- Only suggest groupings where 2+ books from the list below belong together.
+- Suggest whether each grouping is a ""Series"" or ""Collection"".
+- If books could belong to an existing series/collection listed above, mention that.
+- Don't suggest single-book groupings.
+- Respond with valid JSON in this exact format:
+{{
+  ""groupings"": [
+    {{
+      ""name"": ""Suggested Series/Collection Name"",
+      ""type"": ""Series"" or ""Collection"",
+      ""reasoning"": ""Why these books belong together."",
+      ""books"": [""Book Title 1"", ""Book Title 2""]
+    }}
+  ],
+  ""summary"": ""Brief overall assessment of the collection.""
+}}";
+
+        var userMessage = $@"Here are the books not currently in any series or collection:
+
+{booksText}
+
+Suggest how these could be grouped. Respond with JSON only.";
+
+        var messages = new List<Message>
+        {
+            new(RoleType.User, userMessage)
+        };
+
+        var parameters = new MessageParameters
+        {
+            Messages = messages,
+            MaxTokens = 2048,
+            Model = _options.FastModel,
+            Stream = false,
+            System = new List<SystemMessage>
+            {
+                new(systemPrompt, new CacheControl { Type = CacheControlType.ephemeral })
+            },
+            PromptCaching = PromptCacheType.FineGrained
+        };
+
+        var client = GetClient();
+        var response = await client.Messages.GetClaudeMessageAsync(parameters, ct);
+        CallCount++;
+
+        var responseText = response.Message?.ToString() ?? "";
+        return ParseCollectionSuggestion(responseText);
+    }
+
     private static GenreSuggestionResult ParseGenreSuggestion(string responseText, HashSet<string> validGenres)
     {
         try
         {
-            var json = responseText.Trim();
-            if (json.StartsWith("```"))
-            {
-                var firstNewline = json.IndexOf('\n');
-                var lastFence = json.LastIndexOf("```");
-                if (firstNewline > 0 && lastFence > firstNewline)
-                    json = json[(firstNewline + 1)..lastFence].Trim();
-            }
+            var json = StripCodeFences(responseText);
 
             using var doc = JsonDocument.Parse(json);
             var root = doc.RootElement;
@@ -132,5 +208,61 @@ Respond with JSON only.";
         {
             return new GenreSuggestionResult([], $"Could not parse AI response: {responseText[..Math.Min(200, responseText.Length)]}");
         }
+    }
+
+    private static CollectionSuggestionResult ParseCollectionSuggestion(string responseText)
+    {
+        try
+        {
+            var json = StripCodeFences(responseText);
+
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+
+            var groupings = new List<CollectionGrouping>();
+            if (root.TryGetProperty("groupings", out var groupingsElement))
+            {
+                foreach (var g in groupingsElement.EnumerateArray())
+                {
+                    var name = g.TryGetProperty("name", out var n) ? n.GetString() ?? "" : "";
+                    var type = g.TryGetProperty("type", out var t) ? t.GetString() ?? "Collection" : "Collection";
+                    var reasoning = g.TryGetProperty("reasoning", out var r) ? r.GetString() ?? "" : "";
+                    var books = new List<string>();
+                    if (g.TryGetProperty("books", out var booksElement))
+                    {
+                        foreach (var b in booksElement.EnumerateArray())
+                        {
+                            var title = b.GetString();
+                            if (title is not null) books.Add(title);
+                        }
+                    }
+                    if (books.Count >= 2)
+                        groupings.Add(new CollectionGrouping(name, type, reasoning, books));
+                }
+            }
+
+            var summary = root.TryGetProperty("summary", out var summaryElement)
+                ? summaryElement.GetString() ?? ""
+                : "";
+
+            return new CollectionSuggestionResult(groupings, summary);
+        }
+        catch
+        {
+            return new CollectionSuggestionResult([], $"Could not parse AI response: {responseText[..Math.Min(200, responseText.Length)]}");
+        }
+    }
+
+    private static string StripCodeFences(string text)
+    {
+        var json = text.Trim();
+        if (json.StartsWith("```"))
+        {
+            var firstNewline = json.IndexOf('\n');
+            var lastFence = json.LastIndexOf("```");
+            if (firstNewline > 0 && lastFence > firstNewline)
+                json = json[(firstNewline + 1)..lastFence].Trim();
+        }
+        return json;
     }
 }

--- a/BookTracker.Web/Services/IAIAssistantService.cs
+++ b/BookTracker.Web/Services/IAIAssistantService.cs
@@ -8,6 +8,11 @@ public interface IAIAssistantService
     /// </summary>
     Task<GenreSuggestionResult> SuggestGenresAsync(string title, string author, string? subtitle, IReadOnlyList<string> currentGenres, CancellationToken ct = default);
 
+    /// <summary>
+    /// Analyses uncategorised books and suggests series/collection groupings.
+    /// </summary>
+    Task<CollectionSuggestionResult> SuggestCollectionsAsync(CancellationToken ct = default);
+
     /// <summary>Number of API calls made in this service instance's lifetime.</summary>
     int CallCount { get; }
 }
@@ -15,3 +20,13 @@ public interface IAIAssistantService
 public record GenreSuggestionResult(
     IReadOnlyList<string> SuggestedGenres,
     string Reasoning);
+
+public record CollectionSuggestionResult(
+    IReadOnlyList<CollectionGrouping> Groupings,
+    string Summary);
+
+public record CollectionGrouping(
+    string SuggestedName,
+    string Type,
+    string Reasoning,
+    IReadOnlyList<string> BookTitles);

--- a/BookTracker.Web/ViewModels/AIAssistantViewModel.cs
+++ b/BookTracker.Web/ViewModels/AIAssistantViewModel.cs
@@ -102,6 +102,81 @@ public class AIAssistantViewModel(
         GenreError = null;
     }
 
+    // Collection cataloguing
+    public CollectionSuggestionResult? CollectionSuggestion { get; private set; }
+    public bool SuggestingCollections { get; private set; }
+    public string? CollectionError { get; private set; }
+
+    public async Task SuggestCollectionsAsync()
+    {
+        SuggestingCollections = true;
+        CollectionSuggestion = null;
+        CollectionError = null;
+
+        try
+        {
+            CollectionSuggestion = await aiService.SuggestCollectionsAsync();
+        }
+        catch (Exception ex)
+        {
+            CollectionError = $"AI request failed: {ex.Message}";
+        }
+        finally
+        {
+            SuggestingCollections = false;
+        }
+    }
+
+    public async Task CreateCollectionFromSuggestionAsync(CollectionGrouping grouping)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync();
+
+        var seriesType = grouping.Type.Equals("Series", StringComparison.OrdinalIgnoreCase)
+            ? SeriesType.Series
+            : SeriesType.Collection;
+
+        // Check if series already exists
+        var existing = await db.Series.FirstOrDefaultAsync(s => s.Name == grouping.SuggestedName);
+        if (existing is not null) return;
+
+        var series = new Series
+        {
+            Name = grouping.SuggestedName,
+            Type = seriesType,
+            Description = grouping.Reasoning
+        };
+
+        // Try to set the author if all books share the same one
+        var matchedBooks = await db.Books
+            .Where(b => grouping.BookTitles.Contains(b.Title))
+            .ToListAsync();
+
+        var authors = matchedBooks.Select(b => b.Author).Distinct().ToList();
+        if (authors.Count == 1)
+            series.Author = authors[0];
+
+        db.Series.Add(series);
+        await db.SaveChangesAsync();
+
+        // Assign books to the series
+        var order = 1;
+        foreach (var book in matchedBooks)
+        {
+            if (book.SeriesId is null)
+            {
+                book.SeriesId = series.Id;
+                book.SeriesOrder = order++;
+            }
+        }
+        await db.SaveChangesAsync();
+    }
+
+    public void DismissCollections()
+    {
+        CollectionSuggestion = null;
+        CollectionError = null;
+    }
+
     public record BookGenreRow(
         int Id, string Title, string? Subtitle, string Author,
         List<string> CurrentGenres);


### PR DESCRIPTION
New "Collection helper" section on the AI Assistant page. Analyses uncategorised books (not in any series) and suggests groupings.

Service: sends book list + existing series context to Claude Sonnet, gets back suggested groupings with names, types (Series/Collection), reasoning, and matched book titles. Prompt cached for efficiency.

UI: "Suggest groupings" button, results shown as cards with suggested name, type badge, reasoning, and book title chips. "Create" button creates the series, sets author if all books share one, and assigns books with order numbers. Dismiss/Refresh available.

Also refactors StripCodeFences into a shared helper method.