### PR TITLE
feat: add AI shopping suggestions based on library patterns

### DIFF
--- a/BookTracker.Web/Components/Pages/Assistant/Index.razor
+++ b/BookTracker.Web/Components/Pages/Assistant/Index.razor
@@ -185,3 +185,70 @@
         }
     </div>
 </div>
+
+<div class="card mb-4">
+    <div class="card-header bg-white d-flex justify-content-between align-items-center">
+        <h2 class="h5 mb-0">Shopping suggestions</h2>
+        @if (VM.ShoppingSuggestion is null && !VM.SuggestingShopping)
+        {
+            <button type="button" class="btn btn-outline-primary btn-sm" @onclick="VM.SuggestShoppingListAsync">
+                What should I look for?
+            </button>
+        }
+    </div>
+    <div class="card-body">
+        @if (VM.SuggestingShopping)
+        {
+            <div class="text-center py-3">
+                <div class="spinner-border spinner-border-sm" role="status"></div>
+                <span class="ms-2 text-muted small">Analysing your reading patterns...</span>
+            </div>
+        }
+        else if (VM.ShoppingError is not null)
+        {
+            <div class="alert alert-warning py-2 small mb-0">@VM.ShoppingError</div>
+        }
+        else if (VM.ShoppingSuggestion is not null)
+        {
+            @if (!string.IsNullOrEmpty(VM.ShoppingSuggestion.Summary))
+            {
+                <p class="text-muted small mb-3">@VM.ShoppingSuggestion.Summary</p>
+            }
+
+            @if (VM.ShoppingSuggestion.Recommendations.Count == 0)
+            {
+                <p class="text-muted small mb-0">No suggestions at this time.</p>
+            }
+            else
+            {
+                @foreach (var rec in VM.ShoppingSuggestion.Recommendations)
+                {
+                    <div class="d-flex gap-3 align-items-start py-2 @(rec != VM.ShoppingSuggestion.Recommendations.Last() ? "border-bottom" : "")">
+                        <div class="flex-grow-1 min-width-0">
+                            <div class="fw-semibold">@rec.Title</div>
+                            <div class="text-muted small">@rec.Author</div>
+                            <div class="text-muted small mt-1">@rec.Reasoning</div>
+                            @if (rec.SeriesContext is not null)
+                            {
+                                <span class="badge bg-light text-dark border mt-1">@rec.SeriesContext</span>
+                            }
+                        </div>
+                        <button type="button" class="btn btn-outline-success btn-sm flex-shrink-0"
+                                @onclick="() => VM.AddRecommendationToWishlistAsync(rec)" title="Add to shopping list">
+                            + List
+                        </button>
+                    </div>
+                }
+            }
+
+            <div class="mt-2">
+                <button type="button" class="btn btn-outline-secondary btn-sm" @onclick="VM.DismissShoppingSuggestions">Dismiss</button>
+                <button type="button" class="btn btn-outline-primary btn-sm ms-1" @onclick="VM.SuggestShoppingListAsync">Refresh</button>
+            </div>
+        }
+        else
+        {
+            <p class="text-muted small mb-0">Tap "What should I look for?" to get book recommendations based on your library and reading patterns.</p>
+        }
+    </div>
+</div>

--- a/BookTracker.Web/Services/AIAssistantService.cs
+++ b/BookTracker.Web/Services/AIAssistantService.cs
@@ -178,6 +178,111 @@ Suggest how these could be grouped. Respond with JSON only.";
         return ParseCollectionSuggestion(responseText);
     }
 
+    public async Task<ShoppingSuggestionResult> SuggestShoppingListAsync(CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+
+        // Build a compact library summary for the prompt
+        var topAuthors = await db.Books
+            .GroupBy(b => b.Author)
+            .Select(g => new { Author = g.Key, Count = g.Count(), AvgRating = g.Average(b => (double)b.Rating) })
+            .OrderByDescending(a => a.Count)
+            .Take(15)
+            .ToListAsync(ct);
+
+        var topGenres = await db.Genres
+            .Select(g => new { g.Name, Count = g.Books.Count })
+            .Where(g => g.Count > 0)
+            .OrderByDescending(g => g.Count)
+            .Take(10)
+            .ToListAsync(ct);
+
+        var highlyRated = await db.Books
+            .Where(b => b.Rating >= 4)
+            .OrderByDescending(b => b.Rating)
+            .ThenBy(b => b.Title)
+            .Take(20)
+            .Select(b => new { b.Title, b.Author, b.Rating })
+            .ToListAsync(ct);
+
+        var incompleteSeries = await db.Series
+            .Include(s => s.Books)
+            .Where(s => s.Type == SeriesType.Series && s.ExpectedCount != null)
+            .ToListAsync(ct);
+
+        var gapsText = incompleteSeries
+            .Where(s => s.Books.Count < s.ExpectedCount!.Value)
+            .Select(s => $"- {s.Name} by {s.Author ?? "various"}: have {s.Books.Count}/{s.ExpectedCount!.Value}, missing positions: {string.Join(", ", Enumerable.Range(1, s.ExpectedCount.Value).Where(i => !s.Books.Any(b => b.SeriesOrder == i)))}")
+            .ToList();
+
+        var authorsText = string.Join("\n", topAuthors.Select(a => $"- {a.Author}: {a.Count} books, avg rating {a.AvgRating:F1}/5"));
+        var genresText = string.Join("\n", topGenres.Select(g => $"- {g.Name}: {g.Count} books"));
+        var ratedText = string.Join("\n", highlyRated.Select(b => $"- \"{b.Title}\" by {b.Author} ({b.Rating}/5)"));
+        var seriesGapsText = gapsText.Count > 0 ? string.Join("\n", gapsText) : "No incomplete series.";
+
+        var systemPrompt = @"You are a book recommendation engine for a personal library. Based on the reader's collection, suggest books they should look for.
+
+Rules:
+- Prioritise filling gaps in incomplete series.
+- Suggest books by authors the reader already enjoys.
+- Suggest books in genres they read most.
+- Include a mix: some series completions, some new discoveries.
+- Suggest 5-10 books total.
+- Respond with valid JSON in this exact format:
+{
+  ""recommendations"": [
+    {
+      ""title"": ""Book Title"",
+      ""author"": ""Author Name"",
+      ""reasoning"": ""Why this book fits the reader's taste."",
+      ""series_context"": ""Part of [Series Name] #N"" or null
+    }
+  ],
+  ""summary"": ""Brief assessment of reading patterns and recommendation strategy.""
+}";
+
+        var userMessage = $@"Here's the reader's library profile:
+
+Top authors:
+{authorsText}
+
+Top genres:
+{genresText}
+
+Highly rated books (4-5 stars):
+{ratedText}
+
+Incomplete series (gaps to fill):
+{seriesGapsText}
+
+Suggest 5-10 books to look for. Respond with JSON only.";
+
+        var messages = new List<Message>
+        {
+            new(RoleType.User, userMessage)
+        };
+
+        var parameters = new MessageParameters
+        {
+            Messages = messages,
+            MaxTokens = 2048,
+            Model = _options.FastModel,
+            Stream = false,
+            System = new List<SystemMessage>
+            {
+                new(systemPrompt, new CacheControl { Type = CacheControlType.ephemeral })
+            },
+            PromptCaching = PromptCacheType.FineGrained
+        };
+
+        var client = GetClient();
+        var response = await client.Messages.GetClaudeMessageAsync(parameters, ct);
+        CallCount++;
+
+        var responseText = response.Message?.ToString() ?? "";
+        return ParseShoppingSuggestion(responseText);
+    }
+
     private static GenreSuggestionResult ParseGenreSuggestion(string responseText, HashSet<string> validGenres)
     {
         try
@@ -250,6 +355,43 @@ Suggest how these could be grouped. Respond with JSON only.";
         catch
         {
             return new CollectionSuggestionResult([], $"Could not parse AI response: {responseText[..Math.Min(200, responseText.Length)]}");
+        }
+    }
+
+    private static ShoppingSuggestionResult ParseShoppingSuggestion(string responseText)
+    {
+        try
+        {
+            var json = StripCodeFences(responseText);
+
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+
+            var recommendations = new List<BookRecommendation>();
+            if (root.TryGetProperty("recommendations", out var recsElement))
+            {
+                foreach (var r in recsElement.EnumerateArray())
+                {
+                    var title = r.TryGetProperty("title", out var t) ? t.GetString() ?? "" : "";
+                    var author = r.TryGetProperty("author", out var a) ? a.GetString() ?? "" : "";
+                    var reasoning = r.TryGetProperty("reasoning", out var re) ? re.GetString() ?? "" : "";
+                    var seriesContext = r.TryGetProperty("series_context", out var sc) && sc.ValueKind != JsonValueKind.Null
+                        ? sc.GetString() : null;
+
+                    if (!string.IsNullOrWhiteSpace(title))
+                        recommendations.Add(new BookRecommendation(title, author, reasoning, seriesContext));
+                }
+            }
+
+            var summary = root.TryGetProperty("summary", out var summaryElement)
+                ? summaryElement.GetString() ?? ""
+                : "";
+
+            return new ShoppingSuggestionResult(recommendations, summary);
+        }
+        catch
+        {
+            return new ShoppingSuggestionResult([], $"Could not parse AI response: {responseText[..Math.Min(200, responseText.Length)]}");
         }
     }
 

--- a/BookTracker.Web/Services/IAIAssistantService.cs
+++ b/BookTracker.Web/Services/IAIAssistantService.cs
@@ -13,6 +13,11 @@ public interface IAIAssistantService
     /// </summary>
     Task<CollectionSuggestionResult> SuggestCollectionsAsync(CancellationToken ct = default);
 
+    /// <summary>
+    /// Suggests books to look for based on incomplete series, reading preferences, and library patterns.
+    /// </summary>
+    Task<ShoppingSuggestionResult> SuggestShoppingListAsync(CancellationToken ct = default);
+
     /// <summary>Number of API calls made in this service instance's lifetime.</summary>
     int CallCount { get; }
 }
@@ -30,3 +35,13 @@ public record CollectionGrouping(
     string Type,
     string Reasoning,
     IReadOnlyList<string> BookTitles);
+
+public record ShoppingSuggestionResult(
+    IReadOnlyList<BookRecommendation> Recommendations,
+    string Summary);
+
+public record BookRecommendation(
+    string Title,
+    string Author,
+    string Reasoning,
+    string? SeriesContext);

--- a/BookTracker.Web/ViewModels/AIAssistantViewModel.cs
+++ b/BookTracker.Web/ViewModels/AIAssistantViewModel.cs
@@ -177,6 +177,54 @@ public class AIAssistantViewModel(
         CollectionError = null;
     }
 
+    // Shopping suggestions
+    public ShoppingSuggestionResult? ShoppingSuggestion { get; private set; }
+    public bool SuggestingShopping { get; private set; }
+    public string? ShoppingError { get; private set; }
+
+    public async Task SuggestShoppingListAsync()
+    {
+        SuggestingShopping = true;
+        ShoppingSuggestion = null;
+        ShoppingError = null;
+
+        try
+        {
+            ShoppingSuggestion = await aiService.SuggestShoppingListAsync();
+        }
+        catch (Exception ex)
+        {
+            ShoppingError = $"AI request failed: {ex.Message}";
+        }
+        finally
+        {
+            SuggestingShopping = false;
+        }
+    }
+
+    public async Task AddRecommendationToWishlistAsync(BookRecommendation rec)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync();
+
+        // Check if already on wishlist
+        if (await db.WishlistItems.AnyAsync(w => w.Title == rec.Title && w.Author == rec.Author))
+            return;
+
+        db.WishlistItems.Add(new WishlistItem
+        {
+            Title = rec.Title,
+            Author = rec.Author,
+            Priority = WishlistPriority.Medium
+        });
+        await db.SaveChangesAsync();
+    }
+
+    public void DismissShoppingSuggestions()
+    {
+        ShoppingSuggestion = null;
+        ShoppingError = null;
+    }
+
     public record BookGenreRow(
         int Id, string Title, string? Subtitle, string Author,
         List<string> CurrentGenres);


### PR DESCRIPTION
New "Shopping suggestions" section on the AI Assistant page. Analyses the reader's library — top authors, favourite genres, highly-rated books, and incomplete series gaps — then recommends 5-10 books to look for.

Service: builds a compact library profile (top 15 authors with avg rating, top 10 genres, 20 highly-rated books, series gaps) and sends to Claude Sonnet. Prompt instructs prioritising series completions, favourite authors, and preferred genres.

UI: "What should I look for?" button, results as a list with title, author, reasoning, and series context badge. "+ List" button adds the recommendation to the wishlist (deduplicates by title+author). Dismiss/Refresh available.