### PR TITLE
feat: add AI book advisor with suitability assessment

### DIFF
--- a/BookTracker.Web/Components/Pages/Assistant/Index.razor
+++ b/BookTracker.Web/Components/Pages/Assistant/Index.razor
@@ -9,6 +9,88 @@
 </div>
 
 <div class="card mb-4">
+    <div class="card-header bg-white"><h2 class="h5 mb-0">Book advisor</h2></div>
+    <div class="card-body">
+        <div class="input-group">
+            <input type="text" class="form-control" placeholder="e.g. &quot;Dune by Frank Herbert&quot; or &quot;anything by Brandon Sanderson&quot;"
+                   @bind="VM.BookAdvisorQuery" @bind:event="oninput" @onkeyup="HandleAdvisorKeyUp" />
+            <button type="button" class="btn btn-primary" @onclick="VM.AssessBookAsync" disabled="@(VM.Advising || string.IsNullOrWhiteSpace(VM.BookAdvisorQuery))">
+                @if (VM.Advising)
+                {
+                    <span class="spinner-border spinner-border-sm" role="status"></span>
+                }
+                else
+                {
+                    <span>Advise</span>
+                }
+            </button>
+        </div>
+        <div class="form-text">Ask about a book or author — the AI will assess how well it fits your reading taste. Uses Claude Opus for deeper analysis.</div>
+
+        @if (VM.AdvisorError is not null)
+        {
+            <div class="alert alert-warning mt-3 py-2 small">@VM.AdvisorError</div>
+        }
+
+        @if (VM.AdvisorResult is not null)
+        {
+            var result = VM.AdvisorResult;
+            var scoreClass = result.SuitabilityScore >= 7 ? "bg-success" : result.SuitabilityScore >= 4 ? "bg-warning text-dark" : "bg-danger";
+
+            <div class="mt-3 p-3 bg-light rounded">
+                <div class="d-flex justify-content-between align-items-center mb-2">
+                    <span class="fw-semibold fs-5">@result.Verdict</span>
+                    <span class="badge @scoreClass fs-6">@result.SuitabilityScore / 10</span>
+                </div>
+
+                <p class="mb-2">@result.Analysis</p>
+
+                @if (result.Pros.Count > 0)
+                {
+                    <div class="mb-2">
+                        <span class="small fw-semibold text-success">Pros:</span>
+                        <ul class="mb-0 small">
+                            @foreach (var pro in result.Pros)
+                            {
+                                <li>@pro</li>
+                            }
+                        </ul>
+                    </div>
+                }
+
+                @if (result.Cons.Count > 0)
+                {
+                    <div class="mb-2">
+                        <span class="small fw-semibold text-danger">Cons:</span>
+                        <ul class="mb-0 small">
+                            @foreach (var con in result.Cons)
+                            {
+                                <li>@con</li>
+                            }
+                        </ul>
+                    </div>
+                }
+
+                @if (result.SimilarInLibrary.Count > 0)
+                {
+                    <div class="mb-2">
+                        <span class="small fw-semibold">Similar in your library:</span>
+                        <div class="d-flex flex-wrap gap-1 mt-1">
+                            @foreach (var title in result.SimilarInLibrary)
+                            {
+                                <span class="badge bg-light text-dark border">@title</span>
+                            }
+                        </div>
+                    </div>
+                }
+
+                <button type="button" class="btn btn-outline-secondary btn-sm" @onclick="VM.ClearAdvisor">Clear</button>
+            </div>
+        }
+    </div>
+</div>
+
+<div class="card mb-4">
     <div class="card-header bg-white d-flex justify-content-between align-items-center">
         <h2 class="h5 mb-0">Genre cleanup</h2>
         @if (!VM.GenresLoaded)
@@ -252,3 +334,11 @@
         }
     </div>
 </div>
+
+@code {
+    private async Task HandleAdvisorKeyUp(KeyboardEventArgs e)
+    {
+        if (e.Key == "Enter" && !string.IsNullOrWhiteSpace(VM.BookAdvisorQuery))
+            await VM.AssessBookAsync();
+    }
+}

--- a/BookTracker.Web/Services/AIAssistantService.cs
+++ b/BookTracker.Web/Services/AIAssistantService.cs
@@ -358,6 +358,72 @@ Suggest 5-10 books to look for. Respond with JSON only.";
         }
     }
 
+    public async Task<BookAdvisorResult> AssessBookAsync(string query, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+
+        // Build library context — richer than shopping since Opus can handle more
+        var allBooks = await db.Books
+            .Include(b => b.Genres)
+            .OrderBy(b => b.Author)
+            .ThenBy(b => b.Title)
+            .Select(b => new { b.Title, b.Author, b.Rating, Genres = b.Genres.Select(g => g.Name).ToList() })
+            .ToListAsync(ct);
+
+        var booksText = allBooks.Count > 0
+            ? string.Join("\n", allBooks.Select(b =>
+                $"- \"{b.Title}\" by {b.Author} | {b.Rating}/5 | {string.Join(", ", b.Genres)}"))
+            : "Library is empty.";
+
+        var systemPrompt = $@"You are a knowledgeable book advisor for a personal library. The reader has the following collection:
+
+{booksText}
+
+Your job: when the reader asks about a specific book or author, assess how well it fits their reading taste based on their library.
+
+Rules:
+- Consider genre overlap, author familiarity, rating patterns, and reading breadth.
+- Be honest — if the book is outside their usual taste, say so, but note if that's a positive (broadening horizons).
+- Give a suitability score from 1 (poor fit) to 10 (perfect fit).
+- Mention similar books already in their library.
+- Respond with valid JSON in this exact format:
+{{
+  ""verdict"": ""One-sentence recommendation (Buy it / Consider it / Skip it / etc.)"",
+  ""suitability_score"": 8,
+  ""analysis"": ""2-3 sentence detailed analysis of fit."",
+  ""pros"": [""Reason this is a good fit""],
+  ""cons"": [""Reason this might not work""],
+  ""similar_in_library"": [""Title already in library that's similar""]
+}}";
+
+        var userMessage = $"I'm considering: {query}\n\nShould I get it? Respond with JSON only.";
+
+        var messages = new List<Message>
+        {
+            new(RoleType.User, userMessage)
+        };
+
+        var parameters = new MessageParameters
+        {
+            Messages = messages,
+            MaxTokens = 2048,
+            Model = _options.DeepModel,
+            Stream = false,
+            System = new List<SystemMessage>
+            {
+                new(systemPrompt, new CacheControl { Type = CacheControlType.ephemeral })
+            },
+            PromptCaching = PromptCacheType.FineGrained
+        };
+
+        var client = GetClient();
+        var response = await client.Messages.GetClaudeMessageAsync(parameters, ct);
+        CallCount++;
+
+        var responseText = response.Message?.ToString() ?? "";
+        return ParseBookAdvisor(responseText);
+    }
+
     private static ShoppingSuggestionResult ParseShoppingSuggestion(string responseText)
     {
         try
@@ -393,6 +459,47 @@ Suggest 5-10 books to look for. Respond with JSON only.";
         {
             return new ShoppingSuggestionResult([], $"Could not parse AI response: {responseText[..Math.Min(200, responseText.Length)]}");
         }
+    }
+
+    private static BookAdvisorResult ParseBookAdvisor(string responseText)
+    {
+        try
+        {
+            var json = StripCodeFences(responseText);
+
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+
+            var verdict = root.TryGetProperty("verdict", out var v) ? v.GetString() ?? "" : "";
+            var score = root.TryGetProperty("suitability_score", out var s) ? s.GetInt32() : 5;
+            var analysis = root.TryGetProperty("analysis", out var a) ? a.GetString() ?? "" : "";
+
+            var pros = ParseStringArray(root, "pros");
+            var cons = ParseStringArray(root, "cons");
+            var similar = ParseStringArray(root, "similar_in_library");
+
+            return new BookAdvisorResult(verdict, Math.Clamp(score, 1, 10), analysis, pros, cons, similar);
+        }
+        catch
+        {
+            return new BookAdvisorResult(
+                "Could not parse AI response", 5, responseText[..Math.Min(200, responseText.Length)],
+                [], [], []);
+        }
+    }
+
+    private static List<string> ParseStringArray(JsonElement root, string propertyName)
+    {
+        var list = new List<string>();
+        if (root.TryGetProperty(propertyName, out var element))
+        {
+            foreach (var item in element.EnumerateArray())
+            {
+                var val = item.GetString();
+                if (val is not null) list.Add(val);
+            }
+        }
+        return list;
     }
 
     private static string StripCodeFences(string text)

--- a/BookTracker.Web/Services/IAIAssistantService.cs
+++ b/BookTracker.Web/Services/IAIAssistantService.cs
@@ -18,6 +18,12 @@ public interface IAIAssistantService
     /// </summary>
     Task<ShoppingSuggestionResult> SuggestShoppingListAsync(CancellationToken ct = default);
 
+    /// <summary>
+    /// Assesses whether a specific book or author would be a good fit for the reader
+    /// based on their library, tastes, and reading patterns. Uses the deep model (Opus).
+    /// </summary>
+    Task<BookAdvisorResult> AssessBookAsync(string query, CancellationToken ct = default);
+
     /// <summary>Number of API calls made in this service instance's lifetime.</summary>
     int CallCount { get; }
 }
@@ -45,3 +51,11 @@ public record BookRecommendation(
     string Author,
     string Reasoning,
     string? SeriesContext);
+
+public record BookAdvisorResult(
+    string Verdict,
+    int SuitabilityScore,
+    string Analysis,
+    IReadOnlyList<string> Pros,
+    IReadOnlyList<string> Cons,
+    IReadOnlyList<string> SimilarInLibrary);

--- a/BookTracker.Web/ViewModels/AIAssistantViewModel.cs
+++ b/BookTracker.Web/ViewModels/AIAssistantViewModel.cs
@@ -225,6 +225,41 @@ public class AIAssistantViewModel(
         ShoppingError = null;
     }
 
+    // Book advisor
+    public string BookAdvisorQuery { get; set; } = "";
+    public BookAdvisorResult? AdvisorResult { get; private set; }
+    public bool Advising { get; private set; }
+    public string? AdvisorError { get; private set; }
+
+    public async Task AssessBookAsync()
+    {
+        if (string.IsNullOrWhiteSpace(BookAdvisorQuery)) return;
+
+        Advising = true;
+        AdvisorResult = null;
+        AdvisorError = null;
+
+        try
+        {
+            AdvisorResult = await aiService.AssessBookAsync(BookAdvisorQuery.Trim());
+        }
+        catch (Exception ex)
+        {
+            AdvisorError = $"AI request failed: {ex.Message}";
+        }
+        finally
+        {
+            Advising = false;
+        }
+    }
+
+    public void ClearAdvisor()
+    {
+        AdvisorResult = null;
+        AdvisorError = null;
+        BookAdvisorQuery = "";
+    }
+
     public record BookGenreRow(
         int Id, string Title, string? Subtitle, string Author,
         List<string> CurrentGenres);

--- a/TODO.md
+++ b/TODO.md
@@ -25,5 +25,6 @@ Outstanding work items for BookTracker. This is the single source of truth — c
 
 ## Planned features
 
-- [ ] AI book recommendations via the Anthropic API
-- [ ] Wishlist UI (model exists, no pages yet)
+- [x] AI book recommendations via the Anthropic API — genre cleanup, collection cataloguing, shopping suggestions, book advisor
+- [x] Wishlist UI — integrated into Shopping page (shopping list section)
+- [ ] AI cost tracking — add persistent token/cost logging beyond the session counter


### PR DESCRIPTION
New "Book advisor" section at the top of the AI Assistant page — designed for the "I'm holding this book in a shop" mobile use case.

Type a book title or author, press Enter or tap Advise, and Claude Opus analyses whether it fits your reading taste based on your full library (all books with genres and ratings).

Response includes:
- Verdict (one-sentence recommendation)
- Suitability score (1-10) with colour-coded badge
- Detailed analysis
- Pros and cons
- Similar books already in your library

Uses the DeepModel (Opus) for richer analysis vs Sonnet for the other features. System prompt includes full library context and is cached for efficient sequential queries.

Also marks AI recommendations and Wishlist UI as done in TODO.md.