### PR TITLE
fix: mobile scanner UX tweaks

### DIFF
--- a/BookTracker.Web/Components/Pages/Books/BulkAdd.razor
+++ b/BookTracker.Web/Components/Pages/Books/BulkAdd.razor
@@ -26,7 +26,7 @@
 
         <label class="form-label fw-semibold">Add ISBN</label>
         <div class="input-group">
-            <input type="text" class="form-control" placeholder="9780345391803" @bind="VM.IsbnInput"
+            <input type="text" inputmode="numeric" autocomplete="off" class="form-control" placeholder="9780345391803" @bind="VM.IsbnInput"
                    @onkeyup="HandleIsbnKeyUp" />
             <button type="button" class="btn btn-outline-primary" @onclick="AddIsbnAsync" disabled="@string.IsNullOrWhiteSpace(VM.IsbnInput)">
                 Add

--- a/BookTracker.Web/wwwroot/css/site.css
+++ b/BookTracker.Web/wwwroot/css/site.css
@@ -77,11 +77,23 @@ body {
 /* Barcode scanner — responsive container */
 .scanner-container {
   max-width: 600px;
+  max-height: 250px;
   margin: 0 auto;
+  overflow: hidden;
+}
+
+.scanner-container video {
+  max-height: 220px;
+  object-fit: cover;
 }
 
 @media (max-width: 767.98px) {
   .scanner-container {
     max-width: 100%;
+    max-height: 200px;
+  }
+
+  .scanner-container video {
+    max-height: 170px;
   }
 }

--- a/BookTracker.Web/wwwroot/js/barcode-scanner.js
+++ b/BookTracker.Web/wwwroot/js/barcode-scanner.js
@@ -2,6 +2,9 @@
 // Called from Blazor via IJSRuntime.
 
 let scanner = null;
+let lastScannedCode = null;
+let lastScannedTime = 0;
+const DEBOUNCE_MS = 3000; // ignore duplicate scans within 3 seconds
 
 window.BarcodeScanner = {
     start: async function (elementId, dotNetRef) {
@@ -10,11 +13,15 @@ window.BarcodeScanner = {
             scanner = null;
         }
 
+        lastScannedCode = null;
+        lastScannedTime = 0;
+
         scanner = new Html5Qrcode(elementId);
 
         const config = {
             fps: 10,
             qrbox: { width: 280, height: 80 },
+            aspectRatio: 2.0, // wide and short — matches book barcode shape
             formatsToSupport: [
                 Html5QrcodeSupportedFormats.EAN_13,
                 Html5QrcodeSupportedFormats.EAN_8
@@ -26,6 +33,12 @@ window.BarcodeScanner = {
                 { facingMode: "environment" },
                 config,
                 async (decodedText) => {
+                    const now = Date.now();
+                    if (decodedText === lastScannedCode && (now - lastScannedTime) < DEBOUNCE_MS) {
+                        return; // debounce: same barcode scanned too quickly
+                    }
+                    lastScannedCode = decodedText;
+                    lastScannedTime = now;
                     await dotNetRef.invokeMethodAsync("OnBarcodeScanned", decodedText);
                 },
                 (_errorMessage) => {


### PR DESCRIPTION
1. Numeric keypad: ISBN input on Bulk Add page uses inputmode="numeric" so mobile devices show a number pad instead of full keyboard.

2. Smaller camera window: scanner container constrained to max-height 250px (200px on mobile) with overflow hidden. Video element capped separately. aspectRatio set to 2.0 in html5-qrcode config for a wider, shorter camera feed matching book barcode shape.

3. Scan debounce: 3-second cooldown on duplicate barcode scans in JS. If the same barcode is read within 3 seconds of the last scan, the callback is suppressed. Prevents accidental double-scans when the camera lingers on a barcode.