### PR TITLE
feat: add photo ISBN capture using Claude vision OCR

### DIFF
--- a/BookTracker.Web/Components/App.razor
+++ b/BookTracker.Web/Components/App.razor
@@ -17,5 +17,6 @@
     <script src="_framework/blazor.web.js"></script>
     <script src="lib/html5-qrcode/html5-qrcode.min.js"></script>
     <script src="js/barcode-scanner.js"></script>
+    <script src="js/photo-capture.js"></script>
 </body>
 </html>

--- a/BookTracker.Web/Components/Pages/Books/BulkAdd.razor
+++ b/BookTracker.Web/Components/Pages/Books/BulkAdd.razor
@@ -3,6 +3,7 @@
 @inject BulkAddViewModel VM
 @inject NavigationManager Nav
 @inject IJSRuntime JS
+@inject IAIAssistantService AI
 
 <PageTitle>Bulk add books - BookTracker</PageTitle>
 
@@ -10,9 +11,9 @@
 
 <div class="card mb-4">
     <div class="card-body">
-        @* Mobile: scanner button first, full-width and prominent *@
-        <div class="d-md-none mb-3">
-            <button type="button" class="btn w-100 @(scannerActive ? "btn-danger" : "btn-primary")" @onclick="ToggleScannerAsync">
+        @* Mobile: scanner buttons first, full-width and prominent *@
+        <div class="d-md-none mb-3 d-flex gap-2">
+            <button type="button" class="btn flex-grow-1 @(scannerActive ? "btn-danger" : "btn-primary")" @onclick="ToggleScannerAsync">
                 @if (scannerActive)
                 {
                     <span>Stop scanner</span>
@@ -20,6 +21,16 @@
                 else
                 {
                     <span>Scan barcode</span>
+                }
+            </button>
+            <button type="button" class="btn flex-grow-1 @(photoActive ? "btn-danger" : "btn-outline-primary")" @onclick="TogglePhotoCaptureAsync">
+                @if (photoActive)
+                {
+                    <span>Cancel photo</span>
+                }
+                else
+                {
+                    <span>Photo ISBN</span>
                 }
             </button>
         </div>
@@ -34,8 +45,8 @@
         </div>
         <div class="form-text">Type or paste an ISBN and press Enter, or scan a barcode with your camera.</div>
 
-        @* Desktop: scanner button below input, secondary style *@
-        <div class="d-none d-md-block mt-3">
+        @* Desktop: scanner buttons below input *@
+        <div class="d-none d-md-flex mt-3 gap-2">
             <button type="button" class="btn @(scannerActive ? "btn-danger" : "btn-outline-secondary")" @onclick="ToggleScannerAsync">
                 @if (scannerActive)
                 {
@@ -44,6 +55,16 @@
                 else
                 {
                     <span>Scan barcode</span>
+                }
+            </button>
+            <button type="button" class="btn @(photoActive ? "btn-danger" : "btn-outline-secondary")" @onclick="TogglePhotoCaptureAsync">
+                @if (photoActive)
+                {
+                    <span>Cancel photo</span>
+                }
+                else
+                {
+                    <span>Photo ISBN</span>
                 }
             </button>
         </div>
@@ -61,6 +82,35 @@
         <div class="card-body text-center">
             <div id="barcode-reader" class="scanner-container"></div>
             <div class="form-text mt-2">Point your camera at the ISBN barcode on the back of the book.</div>
+        </div>
+    </div>
+}
+
+@if (photoActive)
+{
+    <div class="card mb-4">
+        <div class="card-body text-center">
+            <div class="scanner-container">
+                <video id="photo-video" autoplay playsinline muted style="width: 100%; border-radius: 0.25rem;"></video>
+            </div>
+            <div class="mt-2 d-flex justify-content-center gap-2">
+                <button type="button" class="btn btn-primary" @onclick="CapturePhotoAsync" disabled="@extractingIsbn">
+                    @if (extractingIsbn)
+                    {
+                        <span class="spinner-border spinner-border-sm me-1" role="status"></span>
+                        <span>Reading ISBN...</span>
+                    }
+                    else
+                    {
+                        <span>Capture</span>
+                    }
+                </button>
+            </div>
+            <div class="form-text mt-2">Frame the printed ISBN number and tap Capture.</div>
+            @if (photoError is not null)
+            {
+                <div class="alert alert-warning mt-2 py-2 small">@photoError</div>
+            }
         </div>
     </div>
 }
@@ -200,6 +250,11 @@
     private string? scannerError;
     private DotNetObjectReference<BulkAdd>? dotNetRef;
 
+    // Photo ISBN capture
+    private bool photoActive;
+    private bool extractingIsbn;
+    private string? photoError;
+
     protected override void OnInitialized()
     {
         VM.OnStateChanged = () => InvokeAsync(StateHasChanged);
@@ -217,6 +272,75 @@
         StateHasChanged();
     }
 
+    private async Task TogglePhotoCaptureAsync()
+    {
+        photoError = null;
+        if (photoActive)
+        {
+            await JS.InvokeVoidAsync("PhotoCapture.stop");
+            photoActive = false;
+        }
+        else
+        {
+            // Stop barcode scanner if active
+            if (scannerActive)
+            {
+                await JS.InvokeVoidAsync("BarcodeScanner.stop");
+                scannerActive = false;
+            }
+
+            photoActive = true;
+            StateHasChanged();
+            await Task.Delay(100);
+            var started = await JS.InvokeAsync<bool>("PhotoCapture.start", "photo-video");
+            if (!started)
+            {
+                photoError = "Could not access camera.";
+                photoActive = false;
+            }
+        }
+    }
+
+    private async Task CapturePhotoAsync()
+    {
+        extractingIsbn = true;
+        photoError = null;
+        StateHasChanged();
+
+        try
+        {
+            var base64 = await JS.InvokeAsync<string?>("PhotoCapture.capture", "photo-video");
+            if (string.IsNullOrEmpty(base64))
+            {
+                photoError = "Failed to capture image.";
+                return;
+            }
+
+            var isbn = await AI.ExtractIsbnFromImageAsync(base64);
+            if (isbn is null)
+            {
+                photoError = "Could not find an ISBN in the photo. Try again with clearer framing.";
+                return;
+            }
+
+            // Feed the extracted ISBN into the discovery grid
+            VM.IsbnInput = isbn;
+            await VM.AddIsbnAsync();
+
+            // Stop camera after successful capture
+            await JS.InvokeVoidAsync("PhotoCapture.stop");
+            photoActive = false;
+        }
+        catch (Exception ex)
+        {
+            photoError = $"Error: {ex.Message}";
+        }
+        finally
+        {
+            extractingIsbn = false;
+        }
+    }
+
     private async Task ToggleScannerAsync()
     {
         scannerError = null;
@@ -227,6 +351,13 @@
         }
         else
         {
+            // Stop photo capture if active
+            if (photoActive)
+            {
+                await JS.InvokeVoidAsync("PhotoCapture.stop");
+                photoActive = false;
+            }
+
             scannerActive = true;
             dotNetRef ??= DotNetObjectReference.Create(this);
             StateHasChanged();
@@ -268,6 +399,10 @@
         if (scannerActive)
         {
             try { await JS.InvokeVoidAsync("BarcodeScanner.stop"); } catch { }
+        }
+        if (photoActive)
+        {
+            try { await JS.InvokeVoidAsync("PhotoCapture.stop"); } catch { }
         }
         dotNetRef?.Dispose();
     }

--- a/BookTracker.Web/Services/AIAssistantService.cs
+++ b/BookTracker.Web/Services/AIAssistantService.cs
@@ -24,6 +24,54 @@ public class AIAssistantService(
         return _client;
     }
 
+    public async Task<string?> ExtractIsbnFromImageAsync(string base64Jpeg, CancellationToken ct = default)
+    {
+        var messages = new List<Message>
+        {
+            new()
+            {
+                Role = RoleType.User,
+                Content = new List<ContentBase>
+                {
+                    new ImageContent
+                    {
+                        Source = new ImageSource
+                        {
+                            MediaType = "image/jpeg",
+                            Data = base64Jpeg
+                        }
+                    },
+                    new TextContent
+                    {
+                        Text = "Extract the ISBN number from this image. Return ONLY the digits (10 or 13 digits), nothing else. If you cannot find an ISBN, return the word NONE."
+                    }
+                }
+            }
+        };
+
+        var parameters = new MessageParameters
+        {
+            Messages = messages,
+            MaxTokens = 50,
+            Model = _options.FastModel,
+            Stream = false
+        };
+
+        var client = GetClient();
+        var response = await client.Messages.GetClaudeMessageAsync(parameters, ct);
+        CallCount++;
+
+        var responseText = (response.Message?.ToString() ?? "").Trim();
+
+        if (responseText.Equals("NONE", StringComparison.OrdinalIgnoreCase))
+            return null;
+
+        // Clean: keep only digits and X (for ISBN-10)
+        var cleaned = new string(responseText.Where(c => char.IsDigit(c) || c == 'X' || c == 'x').ToArray());
+
+        return cleaned.Length is 10 or 13 ? cleaned : null;
+    }
+
     public async Task<GenreSuggestionResult> SuggestGenresAsync(
         string title, string author, string? subtitle,
         IReadOnlyList<string> currentGenres, CancellationToken ct = default)

--- a/BookTracker.Web/Services/IAIAssistantService.cs
+++ b/BookTracker.Web/Services/IAIAssistantService.cs
@@ -24,6 +24,12 @@ public interface IAIAssistantService
     /// </summary>
     Task<BookAdvisorResult> AssessBookAsync(string query, CancellationToken ct = default);
 
+    /// <summary>
+    /// Extracts an ISBN number from a photo using vision OCR.
+    /// Returns the extracted ISBN or null if not found.
+    /// </summary>
+    Task<string?> ExtractIsbnFromImageAsync(string base64Jpeg, CancellationToken ct = default);
+
     /// <summary>Number of API calls made in this service instance's lifetime.</summary>
     int CallCount { get; }
 }

--- a/BookTracker.Web/wwwroot/js/photo-capture.js
+++ b/BookTracker.Web/wwwroot/js/photo-capture.js
@@ -1,0 +1,51 @@
+// JS interop for capturing a photo from the device camera.
+// Returns a base64-encoded JPEG image to Blazor.
+
+let stream = null;
+let videoElement = null;
+
+window.PhotoCapture = {
+    start: async function (videoElementId) {
+        const video = document.getElementById(videoElementId);
+        if (!video) return false;
+
+        try {
+            stream = await navigator.mediaDevices.getUserMedia({
+                video: { facingMode: "environment", width: { ideal: 1280 }, height: { ideal: 720 } }
+            });
+            video.srcObject = stream;
+            await video.play();
+            videoElement = video;
+            return true;
+        } catch (err) {
+            console.error("Camera access failed:", err);
+            return false;
+        }
+    },
+
+    capture: function (videoElementId) {
+        const video = document.getElementById(videoElementId);
+        if (!video || !video.srcObject) return null;
+
+        const canvas = document.createElement("canvas");
+        canvas.width = video.videoWidth;
+        canvas.height = video.videoHeight;
+        const ctx = canvas.getContext("2d");
+        ctx.drawImage(video, 0, 0);
+
+        // Return as base64 JPEG (strip the data URL prefix)
+        const dataUrl = canvas.toDataURL("image/jpeg", 0.85);
+        return dataUrl.replace(/^data:image\/jpeg;base64,/, "");
+    },
+
+    stop: function () {
+        if (stream) {
+            stream.getTracks().forEach(t => t.stop());
+            stream = null;
+        }
+        if (videoElement) {
+            videoElement.srcObject = null;
+            videoElement = null;
+        }
+    }
+};


### PR DESCRIPTION
For older books without barcodes, users can now photograph the printed ISBN number and have it extracted via Claude Sonnet's vision API.

New "Photo ISBN" button alongside "Scan barcode" on the Bulk Add page (both mobile and desktop). Opens camera, user frames the ISBN text, taps Capture. The photo is sent to Claude as a base64 JPEG with a focused prompt to extract only the ISBN digits. Extracted ISBN feeds into the discovery grid like a scan or manual entry.

- photo-capture.js: getUserMedia camera interop (rear-facing, 1280x720) with start/capture/stop lifecycle
- AIAssistantService.ExtractIsbnFromImageAsync: sends image to Sonnet vision, extracts and validates 10 or 13 digit ISBN
- BulkAdd.razor: photo capture UI with spinner during OCR, error handling, mutual exclusion with barcode scanner, cleanup on dispose