### PR TITLE
fix: photo ISBN error handling, SignalR size limit, ISBN-10 X support

### DIFF
--- a/BookTracker.Web/Components/Pages/Books/BulkAdd.razor
+++ b/BookTracker.Web/Components/Pages/Books/BulkAdd.razor
@@ -277,7 +277,7 @@
         photoError = null;
         if (photoActive)
         {
-            await JS.InvokeVoidAsync("PhotoCapture.stop");
+            try { await JS.InvokeVoidAsync("PhotoCapture.stop"); } catch { }
             photoActive = false;
         }
         else
@@ -291,11 +291,20 @@
 
             photoActive = true;
             StateHasChanged();
-            await Task.Delay(100);
-            var started = await JS.InvokeAsync<bool>("PhotoCapture.start", "photo-video");
-            if (!started)
+            await Task.Delay(200);
+
+            try
             {
-                photoError = "Could not access camera.";
+                var started = await JS.InvokeAsync<bool>("PhotoCapture.start", "photo-video");
+                if (!started)
+                {
+                    photoError = "Could not access camera. Check permissions.";
+                    photoActive = false;
+                }
+            }
+            catch (Exception ex)
+            {
+                photoError = $"Camera error: {ex.Message}";
                 photoActive = false;
             }
         }
@@ -305,14 +314,13 @@
     {
         extractingIsbn = true;
         photoError = null;
-        StateHasChanged();
 
         try
         {
             var base64 = await JS.InvokeAsync<string?>("PhotoCapture.capture", "photo-video");
             if (string.IsNullOrEmpty(base64))
             {
-                photoError = "Failed to capture image.";
+                photoError = "Failed to capture image. Make sure the camera is active.";
                 return;
             }
 

--- a/BookTracker.Web/Program.cs
+++ b/BookTracker.Web/Program.cs
@@ -12,6 +12,12 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents();
 
+// Increase SignalR max message size for photo ISBN capture (base64 images).
+builder.Services.AddSignalR(options =>
+{
+    options.MaximumReceiveMessageSize = 512 * 1024; // 512KB
+});
+
 // Blazor Server circuits are long-lived while DbContext is scoped and not
 // thread-safe, so components take IDbContextFactory<T> and create a short-lived
 // context per operation rather than injecting DbContext directly.

--- a/BookTracker.Web/Services/AIAssistantService.cs
+++ b/BookTracker.Web/Services/AIAssistantService.cs
@@ -43,7 +43,7 @@ public class AIAssistantService(
                     },
                     new TextContent
                     {
-                        Text = "Extract the ISBN number from this image. Return ONLY the digits (10 or 13 digits), nothing else. If you cannot find an ISBN, return the word NONE."
+                        Text = "Extract the ISBN number from this image. Return ONLY the ISBN (10 or 13 characters). ISBN-10 may end with the letter X as a check digit — include it if present. Return nothing else. If you cannot find an ISBN, return the word NONE."
                     }
                 }
             }

--- a/BookTracker.Web/wwwroot/js/photo-capture.js
+++ b/BookTracker.Web/wwwroot/js/photo-capture.js
@@ -27,14 +27,17 @@ window.PhotoCapture = {
         const video = document.getElementById(videoElementId);
         if (!video || !video.srcObject) return null;
 
+        // Scale down for OCR — we only need enough resolution to read text
+        const maxWidth = 800;
+        const scale = Math.min(1, maxWidth / video.videoWidth);
         const canvas = document.createElement("canvas");
-        canvas.width = video.videoWidth;
-        canvas.height = video.videoHeight;
+        canvas.width = Math.round(video.videoWidth * scale);
+        canvas.height = Math.round(video.videoHeight * scale);
         const ctx = canvas.getContext("2d");
-        ctx.drawImage(video, 0, 0);
+        ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
 
-        // Return as base64 JPEG (strip the data URL prefix)
-        const dataUrl = canvas.toDataURL("image/jpeg", 0.85);
+        // Return as base64 JPEG at moderate quality (strip the data URL prefix)
+        const dataUrl = canvas.toDataURL("image/jpeg", 0.7);
         return dataUrl.replace(/^data:image\/jpeg;base64,/, "");
     },
 


### PR DESCRIPTION
Fixes unhandled error on mobile when using photo ISBN capture:

1. SignalR max message size increased to 512KB (default 32KB was too small for base64-encoded camera photos)
2. Photo resolution scaled down to max 800px width at 70% JPEG quality to reduce payload size while keeping text readable for OCR
3. Better error handling: try/catch around camera start, clearer error messages, proper state cleanup on failure
4. Updated OCR prompt to explicitly mention ISBN-10 X check digit
5. Increased delay before camera start (100ms -> 200ms) for mobile DOM readiness