### PR TITLE
refactor: multi-provider AI architecture with provider factory

### DIFF
--- a/BookTracker.Web/Program.cs
+++ b/BookTracker.Web/Program.cs
@@ -32,9 +32,15 @@ builder.Services.AddHttpClient<IBookLookupService, BookLookupService>(client =>
 
 builder.Services.AddTransient<SeriesMatchService>();
 
-builder.Services.Configure<AIAssistantOptions>(
-    builder.Configuration.GetSection(AIAssistantOptions.SectionName));
-builder.Services.AddScoped<IAIAssistantService, AIAssistantService>();
+builder.Services.Configure<AIOptions>(
+    builder.Configuration.GetSection(AIOptions.SectionName));
+builder.Services.AddScoped<AIProviderFactory>();
+builder.Services.AddScoped<IAIAssistantService>(sp =>
+{
+    var factory = sp.GetRequiredService<AIProviderFactory>();
+    factory.Initialize();
+    return factory.GetService();
+});
 
 // ViewModels — transient so each component instance gets its own VM.
 builder.Services.AddTransient<HomeViewModel>();

--- a/BookTracker.Web/Services/AIAssistantOptions.cs
+++ b/BookTracker.Web/Services/AIAssistantOptions.cs
@@ -1,16 +1,44 @@
 namespace BookTracker.Web.Services;
 
-public class AIAssistantOptions
+public enum AIProvider
 {
-    public const string SectionName = "Anthropic";
+    Anthropic,
+    AzureFoundry,
+    AzureOpenAI
+}
 
+public class AIOptions
+{
+    public const string SectionName = "AI";
+
+    public AIProvider DefaultProvider { get; set; } = AIProvider.Anthropic;
+
+    public AnthropicOptions Anthropic { get; set; } = new();
+    public AzureFoundryOptions AzureFoundry { get; set; } = new();
+    public AzureOpenAIOptions AzureOpenAI { get; set; } = new();
+}
+
+public class AnthropicOptions
+{
     public string ApiKey { get; set; } = "";
-
-    /// <summary>Model for fast/cheap operations (genre suggestions, collection cataloguing).</summary>
     public string FastModel { get; set; } = "claude-sonnet-4-5-20250514";
-
-    /// <summary>Model for deeper analysis (book recommendations, suitability assessment).</summary>
     public string DeepModel { get; set; } = "claude-opus-4-5-20250514";
+    public int MaxTokens { get; set; } = 1024;
+}
 
+public class AzureFoundryOptions
+{
+    public string Endpoint { get; set; } = "";
+    public string ApiKey { get; set; } = "";
+    public string FastDeployment { get; set; } = "";
+    public string DeepDeployment { get; set; } = "";
+    public int MaxTokens { get; set; } = 1024;
+}
+
+public class AzureOpenAIOptions
+{
+    public string Endpoint { get; set; } = "";
+    public string ApiKey { get; set; } = "";
+    public string Deployment { get; set; } = "";
     public int MaxTokens { get; set; } = 1024;
 }

--- a/BookTracker.Web/Services/AIAssistantService.cs
+++ b/BookTracker.Web/Services/AIAssistantService.cs
@@ -5,22 +5,19 @@ using Anthropic.SDK.Messaging;
 using BookTracker.Data;
 using BookTracker.Data.Models;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Options;
-
 namespace BookTracker.Web.Services;
 
-public class AIAssistantService(
+public class AnthropicAIAssistantService(
     IDbContextFactory<BookTrackerDbContext> dbFactory,
-    IOptions<AIAssistantOptions> options) : IAIAssistantService
+    AnthropicOptions options) : IAIAssistantService
 {
-    private readonly AIAssistantOptions _options = options.Value;
     private AnthropicClient? _client;
 
     public int CallCount { get; private set; }
 
     private AnthropicClient GetClient()
     {
-        _client ??= new AnthropicClient(_options.ApiKey);
+        _client ??= new AnthropicClient(options.ApiKey);
         return _client;
     }
 
@@ -53,7 +50,7 @@ public class AIAssistantService(
         {
             Messages = messages,
             MaxTokens = 50,
-            Model = _options.FastModel,
+            Model = options.FastModel,
             Stream = false
         };
 
@@ -124,8 +121,8 @@ Respond with JSON only.";
         var parameters = new MessageParameters
         {
             Messages = messages,
-            MaxTokens = _options.MaxTokens,
-            Model = _options.FastModel,
+            MaxTokens = options.MaxTokens,
+            Model = options.FastModel,
             Stream = false,
             System = new List<SystemMessage>
             {
@@ -209,7 +206,7 @@ Suggest how these could be grouped. Respond with JSON only.";
         {
             Messages = messages,
             MaxTokens = 2048,
-            Model = _options.FastModel,
+            Model = options.FastModel,
             Stream = false,
             System = new List<SystemMessage>
             {
@@ -314,7 +311,7 @@ Suggest 5-10 books to look for. Respond with JSON only.";
         {
             Messages = messages,
             MaxTokens = 2048,
-            Model = _options.FastModel,
+            Model = options.FastModel,
             Stream = false,
             System = new List<SystemMessage>
             {
@@ -455,7 +452,7 @@ Rules:
         {
             Messages = messages,
             MaxTokens = 2048,
-            Model = _options.DeepModel,
+            Model = options.DeepModel,
             Stream = false,
             System = new List<SystemMessage>
             {

--- a/BookTracker.Web/Services/AIProviderFactory.cs
+++ b/BookTracker.Web/Services/AIProviderFactory.cs
@@ -1,0 +1,68 @@
+using BookTracker.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+
+namespace BookTracker.Web.Services;
+
+/// <summary>
+/// Manages AI provider selection and creates the active service instance.
+/// Scoped lifetime — one per Blazor circuit. Allows runtime provider switching.
+/// </summary>
+public class AIProviderFactory(
+    IDbContextFactory<BookTrackerDbContext> dbFactory,
+    IOptions<AIOptions> options)
+{
+    private readonly AIOptions _options = options.Value;
+    private AIProvider _activeProvider;
+    private IAIAssistantService? _currentService;
+
+    public AIProvider ActiveProvider => _activeProvider;
+    public IReadOnlyList<AIProvider> AvailableProviders => GetAvailableProviders();
+
+    public void Initialize()
+    {
+        _activeProvider = _options.DefaultProvider;
+    }
+
+    public IAIAssistantService GetService()
+    {
+        if (_currentService is null || GetProviderForService(_currentService) != _activeProvider)
+        {
+            _currentService = CreateService(_activeProvider);
+        }
+        return _currentService;
+    }
+
+    public void SwitchProvider(AIProvider provider)
+    {
+        if (_activeProvider == provider) return;
+        _activeProvider = provider;
+        _currentService = null; // force recreation on next GetService()
+    }
+
+    private IAIAssistantService CreateService(AIProvider provider) => provider switch
+    {
+        AIProvider.Anthropic => new AnthropicAIAssistantService(dbFactory, _options.Anthropic),
+        AIProvider.AzureFoundry => throw new NotImplementedException("Azure Foundry provider coming in a future PR."),
+        AIProvider.AzureOpenAI => throw new NotImplementedException("Azure OpenAI provider coming in a future PR."),
+        _ => throw new ArgumentOutOfRangeException(nameof(provider))
+    };
+
+    private List<AIProvider> GetAvailableProviders()
+    {
+        var providers = new List<AIProvider>();
+        if (!string.IsNullOrEmpty(_options.Anthropic.ApiKey))
+            providers.Add(AIProvider.Anthropic);
+        if (!string.IsNullOrEmpty(_options.AzureFoundry.ApiKey) && !string.IsNullOrEmpty(_options.AzureFoundry.Endpoint))
+            providers.Add(AIProvider.AzureFoundry);
+        if (!string.IsNullOrEmpty(_options.AzureOpenAI.ApiKey) && !string.IsNullOrEmpty(_options.AzureOpenAI.Endpoint))
+            providers.Add(AIProvider.AzureOpenAI);
+        return providers;
+    }
+
+    private static AIProvider? GetProviderForService(IAIAssistantService service) => service switch
+    {
+        AnthropicAIAssistantService => AIProvider.Anthropic,
+        _ => null
+    };
+}

--- a/BookTracker.Web/appsettings.Example.json
+++ b/BookTracker.Web/appsettings.Example.json
@@ -2,8 +2,22 @@
   "ConnectionStrings": {
     "DefaultConnection": ""
   },
-  "Anthropic": {
-    "ApiKey": ""
+  "AI": {
+    "DefaultProvider": "Anthropic",
+    "Anthropic": {
+      "ApiKey": ""
+    },
+    "AzureFoundry": {
+      "Endpoint": "",
+      "ApiKey": "",
+      "FastDeployment": "",
+      "DeepDeployment": ""
+    },
+    "AzureOpenAI": {
+      "Endpoint": "",
+      "ApiKey": "",
+      "Deployment": ""
+    }
   },
   "Logging": {
     "LogLevel": {


### PR DESCRIPTION
Restructures AI service layer to support multiple providers: Anthropic (direct), Azure Foundry (Claude via Azure), Azure OpenAI.

- AIOptions: flat config with DefaultProvider enum and per-provider options (Anthropic, AzureFoundry, AzureOpenAI)
- AIProviderFactory: scoped factory that manages active provider, supports runtime switching, reports available providers based on which have API keys configured
- AnthropicAIAssistantService: renamed from AIAssistantService, now takes AnthropicOptions directly instead of IOptions wrapper
- Program.cs: registers factory + scoped IAIAssistantService via factory delegation
- Config path changed: Anthropic:ApiKey -> AI:Anthropic:ApiKey

Azure Foundry and OpenAI implementations throw NotImplementedException for now — will be added in follow-up PRs.

Breaking config change: update appsettings and Azure config to use
the new AI: section structure.