### PR TITLE
feat: add Azure Foundry AI provider + shared parsers refactor

### DIFF
--- a/BookTracker.Web/Services/AIProviderFactory.cs
+++ b/BookTracker.Web/Services/AIProviderFactory.cs
@@ -43,7 +43,7 @@ public class AIProviderFactory(
     private IAIAssistantService CreateService(AIProvider provider) => provider switch
     {
         AIProvider.Anthropic => new AnthropicAIAssistantService(dbFactory, _options.Anthropic),
-        AIProvider.AzureFoundry => throw new NotImplementedException("Azure Foundry provider coming in a future PR."),
+        AIProvider.AzureFoundry => new AzureFoundryAIAssistantService(dbFactory, _options.AzureFoundry),
         AIProvider.AzureOpenAI => throw new NotImplementedException("Azure OpenAI provider coming in a future PR."),
         _ => throw new ArgumentOutOfRangeException(nameof(provider))
     };
@@ -63,6 +63,7 @@ public class AIProviderFactory(
     private static AIProvider? GetProviderForService(IAIAssistantService service) => service switch
     {
         AnthropicAIAssistantService => AIProvider.Anthropic,
+        AzureFoundryAIAssistantService => AIProvider.AzureFoundry,
         _ => null
     };
 }

--- a/BookTracker.Web/Services/AzureFoundryAIAssistantService.cs
+++ b/BookTracker.Web/Services/AzureFoundryAIAssistantService.cs
@@ -7,11 +7,12 @@ using Microsoft.EntityFrameworkCore;
 namespace BookTracker.Web.Services;
 
 /// <summary>
-/// AI assistant implementation using the Anthropic API directly.
+/// AI assistant implementation using Claude models hosted on Azure AI Foundry.
+/// Uses the Anthropic SDK with a custom HttpClient pointing at the Azure endpoint.
 /// </summary>
-public class AnthropicAIAssistantService(
+public class AzureFoundryAIAssistantService(
     IDbContextFactory<BookTrackerDbContext> dbFactory,
-    AnthropicOptions options) : IAIAssistantService
+    AzureFoundryOptions options) : IAIAssistantService
 {
     private AnthropicClient? _client;
 
@@ -19,7 +20,14 @@ public class AnthropicAIAssistantService(
 
     private AnthropicClient GetClient()
     {
-        _client ??= new AnthropicClient(options.ApiKey);
+        if (_client is null)
+        {
+            var httpClient = new HttpClient
+            {
+                BaseAddress = new Uri(options.Endpoint.TrimEnd('/') + "/")
+            };
+            _client = new AnthropicClient(options.ApiKey, httpClient);
+        }
         return _client;
     }
 
@@ -34,11 +42,7 @@ public class AnthropicAIAssistantService(
                 {
                     new ImageContent
                     {
-                        Source = new ImageSource
-                        {
-                            MediaType = "image/jpeg",
-                            Data = base64Jpeg
-                        }
+                        Source = new ImageSource { MediaType = "image/jpeg", Data = base64Jpeg }
                     },
                     new TextContent
                     {
@@ -48,7 +52,7 @@ public class AnthropicAIAssistantService(
             }
         };
 
-        var response = await CallAsync(messages, options.FastModel, 50, ct);
+        var response = await CallAsync(messages, options.FastDeployment, 50, ct);
         var responseText = (response.Message?.ToString() ?? "").Trim();
 
         if (responseText.Equals("NONE", StringComparison.OrdinalIgnoreCase))
@@ -93,7 +97,7 @@ Rules:
 
         var userMessage = $"Suggest genres for this book:\n{bookDescription}\n\n{currentGenresText}\n\nRespond with JSON only.";
 
-        var response = await CallWithSystemAsync(systemPrompt, userMessage, options.FastModel, options.MaxTokens, ct);
+        var response = await CallWithSystemAsync(systemPrompt, userMessage, options.FastDeployment, options.MaxTokens, ct);
         return SharedParsers.ParseGenreSuggestion(response.Message?.ToString() ?? "", allGenres.Select(g => g.Name).ToHashSet());
     }
 
@@ -101,29 +105,24 @@ Rules:
     {
         await using var db = await dbFactory.CreateDbContextAsync(ct);
 
-        var uncategorised = await db.Books
-            .Where(b => b.SeriesId == null)
+        var uncategorised = await db.Books.Where(b => b.SeriesId == null)
             .OrderBy(b => b.Author).ThenBy(b => b.Title)
-            .Select(b => new { b.Title, b.Author })
-            .ToListAsync(ct);
+            .Select(b => new { b.Title, b.Author }).ToListAsync(ct);
 
         if (uncategorised.Count == 0)
             return new CollectionSuggestionResult([], "All books are already in a series or collection.");
 
-        var existingSeries = await db.Series
-            .OrderBy(s => s.Name)
-            .Select(s => new { s.Name, s.Type, BookCount = s.Books.Count })
-            .ToListAsync(ct);
+        var existingSeries = await db.Series.OrderBy(s => s.Name)
+            .Select(s => new { s.Name, s.Type, BookCount = s.Books.Count }).ToListAsync(ct);
 
         var booksText = string.Join("\n", uncategorised.Select(b => $"- \"{b.Title}\" by {b.Author}"));
         var seriesText = existingSeries.Count > 0
             ? "Existing series/collections:\n" + string.Join("\n", existingSeries.Select(s => $"- {s.Name} ({s.Type}, {s.BookCount} books)"))
             : "No existing series or collections.";
 
-        var systemPrompt = SharedParsers.BuildCollectionSystemPrompt(seriesText);
-        var userMessage = $"Here are the books not currently in any series or collection:\n\n{booksText}\n\nSuggest how these could be grouped. Respond with JSON only.";
-
-        var response = await CallWithSystemAsync(systemPrompt, userMessage, options.FastModel, 2048, ct);
+        var response = await CallWithSystemAsync(SharedParsers.BuildCollectionSystemPrompt(seriesText),
+            $"Here are the books not in any series:\n\n{booksText}\n\nSuggest groupings. Respond with JSON only.",
+            options.FastDeployment, 2048, ct);
         return SharedParsers.ParseCollectionSuggestion(response.Message?.ToString() ?? "");
     }
 
@@ -132,7 +131,9 @@ Rules:
         await using var db = await dbFactory.CreateDbContextAsync(ct);
         var context = await SharedParsers.BuildLibraryContextAsync(db, ct);
 
-        var response = await CallWithSystemAsync(SharedParsers.ShoppingSystemPrompt, $"{context}\n\nSuggest 5-10 books to look for. Respond with JSON only.", options.FastModel, 2048, ct);
+        var response = await CallWithSystemAsync(SharedParsers.ShoppingSystemPrompt,
+            $"{context}\n\nSuggest 5-10 books to look for. Respond with JSON only.",
+            options.FastDeployment, 2048, ct);
         return SharedParsers.ParseShoppingSuggestion(response.Message?.ToString() ?? "");
     }
 
@@ -140,8 +141,7 @@ Rules:
     {
         await using var db = await dbFactory.CreateDbContextAsync(ct);
 
-        var allBooks = await db.Books
-            .Include(b => b.Genres)
+        var allBooks = await db.Books.Include(b => b.Genres)
             .OrderBy(b => b.Author).ThenBy(b => b.Title)
             .Select(b => new { b.Title, b.Author, b.Rating, Genres = b.Genres.Select(g => g.Name).ToList() })
             .ToListAsync(ct);
@@ -150,8 +150,9 @@ Rules:
             ? string.Join("\n", allBooks.Select(b => $"- \"{b.Title}\" by {b.Author} | {b.Rating}/5 | {string.Join(", ", b.Genres)}"))
             : "Library is empty.";
 
-        var systemPrompt = SharedParsers.BuildAdvisorSystemPrompt(booksText);
-        var response = await CallWithSystemAsync(systemPrompt, $"I'm considering: {query}\n\nShould I get it? Respond with JSON only.", options.DeepModel, 2048, ct);
+        var response = await CallWithSystemAsync(SharedParsers.BuildAdvisorSystemPrompt(booksText),
+            $"I'm considering: {query}\n\nShould I get it? Respond with JSON only.",
+            options.DeepDeployment, 2048, ct);
         return SharedParsers.ParseBookAdvisor(response.Message?.ToString() ?? "");
     }
 

--- a/BookTracker.Web/Services/SharedParsers.cs
+++ b/BookTracker.Web/Services/SharedParsers.cs
@@ -1,0 +1,241 @@
+using System.Text.Json;
+using BookTracker.Data;
+using BookTracker.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookTracker.Web.Services;
+
+/// <summary>
+/// Shared JSON parsing and prompt building used by all AI provider implementations.
+/// </summary>
+internal static class SharedParsers
+{
+    public static GenreSuggestionResult ParseGenreSuggestion(string responseText, HashSet<string> validGenres)
+    {
+        try
+        {
+            var json = StripCodeFences(responseText);
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+
+            var genres = new List<string>();
+            if (root.TryGetProperty("genres", out var genresElement))
+            {
+                foreach (var genre in genresElement.EnumerateArray())
+                {
+                    var name = genre.GetString();
+                    if (name is not null && validGenres.Contains(name))
+                        genres.Add(name);
+                }
+            }
+
+            var reasoning = root.TryGetProperty("reasoning", out var r) ? r.GetString() ?? "" : "";
+            return new GenreSuggestionResult(genres, reasoning);
+        }
+        catch
+        {
+            return new GenreSuggestionResult([], $"Could not parse AI response: {responseText[..Math.Min(200, responseText.Length)]}");
+        }
+    }
+
+    public static CollectionSuggestionResult ParseCollectionSuggestion(string responseText)
+    {
+        try
+        {
+            var json = StripCodeFences(responseText);
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+
+            var groupings = new List<CollectionGrouping>();
+            if (root.TryGetProperty("groupings", out var groupingsElement))
+            {
+                foreach (var g in groupingsElement.EnumerateArray())
+                {
+                    var name = g.TryGetProperty("name", out var n) ? n.GetString() ?? "" : "";
+                    var type = g.TryGetProperty("type", out var t) ? t.GetString() ?? "Collection" : "Collection";
+                    var reasoning = g.TryGetProperty("reasoning", out var r) ? r.GetString() ?? "" : "";
+                    var books = ParseStringArray(g, "books");
+                    if (books.Count >= 2)
+                        groupings.Add(new CollectionGrouping(name, type, reasoning, books));
+                }
+            }
+
+            var summary = root.TryGetProperty("summary", out var s) ? s.GetString() ?? "" : "";
+            return new CollectionSuggestionResult(groupings, summary);
+        }
+        catch
+        {
+            return new CollectionSuggestionResult([], $"Could not parse AI response: {responseText[..Math.Min(200, responseText.Length)]}");
+        }
+    }
+
+    public static ShoppingSuggestionResult ParseShoppingSuggestion(string responseText)
+    {
+        try
+        {
+            var json = StripCodeFences(responseText);
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+
+            var recommendations = new List<BookRecommendation>();
+            if (root.TryGetProperty("recommendations", out var recsElement))
+            {
+                foreach (var r in recsElement.EnumerateArray())
+                {
+                    var title = r.TryGetProperty("title", out var t) ? t.GetString() ?? "" : "";
+                    var author = r.TryGetProperty("author", out var a) ? a.GetString() ?? "" : "";
+                    var reasoning = r.TryGetProperty("reasoning", out var re) ? re.GetString() ?? "" : "";
+                    var seriesContext = r.TryGetProperty("series_context", out var sc) && sc.ValueKind != JsonValueKind.Null
+                        ? sc.GetString() : null;
+                    if (!string.IsNullOrWhiteSpace(title))
+                        recommendations.Add(new BookRecommendation(title, author, reasoning, seriesContext));
+                }
+            }
+
+            var summary = root.TryGetProperty("summary", out var s) ? s.GetString() ?? "" : "";
+            return new ShoppingSuggestionResult(recommendations, summary);
+        }
+        catch
+        {
+            return new ShoppingSuggestionResult([], $"Could not parse AI response: {responseText[..Math.Min(200, responseText.Length)]}");
+        }
+    }
+
+    public static BookAdvisorResult ParseBookAdvisor(string responseText)
+    {
+        try
+        {
+            var json = StripCodeFences(responseText);
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+
+            var verdict = root.TryGetProperty("verdict", out var v) ? v.GetString() ?? "" : "";
+            var score = root.TryGetProperty("suitability_score", out var s) ? s.GetInt32() : 5;
+            var analysis = root.TryGetProperty("analysis", out var a) ? a.GetString() ?? "" : "";
+            var pros = ParseStringArray(root, "pros");
+            var cons = ParseStringArray(root, "cons");
+            var similar = ParseStringArray(root, "similar_in_library");
+
+            return new BookAdvisorResult(verdict, Math.Clamp(score, 1, 10), analysis, pros, cons, similar);
+        }
+        catch
+        {
+            return new BookAdvisorResult("Could not parse AI response", 5,
+                responseText[..Math.Min(200, responseText.Length)], [], [], []);
+        }
+    }
+
+    public static string StripCodeFences(string text)
+    {
+        var json = text.Trim();
+        if (json.StartsWith("```"))
+        {
+            var firstNewline = json.IndexOf('\n');
+            var lastFence = json.LastIndexOf("```");
+            if (firstNewline > 0 && lastFence > firstNewline)
+                json = json[(firstNewline + 1)..lastFence].Trim();
+        }
+        return json;
+    }
+
+    public static List<string> ParseStringArray(JsonElement root, string propertyName)
+    {
+        var list = new List<string>();
+        if (root.TryGetProperty(propertyName, out var element))
+        {
+            foreach (var item in element.EnumerateArray())
+            {
+                var val = item.GetString();
+                if (val is not null) list.Add(val);
+            }
+        }
+        return list;
+    }
+
+    // Shared prompt templates
+
+    public static string BuildCollectionSystemPrompt(string seriesText) => $@"You are a librarian helping organise a book collection into series and collections.
+
+A ""Series"" is a numbered sequence with a known order (e.g. Harry Potter 1-7).
+A ""Collection"" is a loose grouping by the same author or theme (e.g. all Agatha Christie's Poirot novels).
+
+{seriesText}
+
+Rules:
+- Only suggest groupings where 2+ books from the list below belong together.
+- Suggest whether each grouping is a ""Series"" or ""Collection"".
+- If books could belong to an existing series/collection listed above, mention that.
+- Don't suggest single-book groupings.
+- Respond with valid JSON: {{""groupings"": [{{""name"": ""Name"", ""type"": ""Series"", ""reasoning"": ""Why."", ""books"": [""Title""]}}], ""summary"": ""Brief assessment.""}}";
+
+    public const string ShoppingSystemPrompt = @"You are a book recommendation engine for a personal library. Based on the reader's collection, suggest books they should look for.
+
+Rules:
+- Prioritise filling gaps in incomplete series.
+- Suggest books by authors the reader already enjoys.
+- Suggest books in genres they read most.
+- Include a mix: some series completions, some new discoveries.
+- Suggest 5-10 books total.
+- Respond with valid JSON: {""recommendations"": [{""title"": ""Title"", ""author"": ""Author"", ""reasoning"": ""Why."", ""series_context"": ""Part of [Series] #N"" or null}], ""summary"": ""Brief assessment.""}";
+
+    public static string BuildAdvisorSystemPrompt(string booksText) => $@"You are a knowledgeable book advisor for a personal library. The reader has the following collection:
+
+{booksText}
+
+Your job: when the reader asks about a specific book or author, assess how well it fits their reading taste based on their library.
+
+Rules:
+- Consider genre overlap, author familiarity, rating patterns, and reading breadth.
+- Be honest — if the book is outside their usual taste, say so, but note if that's a positive.
+- Give a suitability score from 1 (poor fit) to 10 (perfect fit).
+- Mention similar books already in their library.
+- Respond with valid JSON: {{""verdict"": ""One sentence."", ""suitability_score"": 8, ""analysis"": ""Details."", ""pros"": [""Reason""], ""cons"": [""Reason""], ""similar_in_library"": [""Title""]}}";
+
+    public static async Task<string> BuildLibraryContextAsync(BookTrackerDbContext db, CancellationToken ct)
+    {
+        var topAuthors = await db.Books
+            .GroupBy(b => b.Author)
+            .Select(g => new { Author = g.Key, Count = g.Count(), AvgRating = g.Average(b => (double)b.Rating) })
+            .OrderByDescending(a => a.Count)
+            .Take(15)
+            .ToListAsync(ct);
+
+        var topGenres = await db.Genres
+            .Select(g => new { g.Name, Count = g.Books.Count })
+            .Where(g => g.Count > 0)
+            .OrderByDescending(g => g.Count)
+            .Take(10)
+            .ToListAsync(ct);
+
+        var highlyRated = await db.Books
+            .Where(b => b.Rating >= 4)
+            .OrderByDescending(b => b.Rating).ThenBy(b => b.Title)
+            .Take(20)
+            .Select(b => new { b.Title, b.Author, b.Rating })
+            .ToListAsync(ct);
+
+        var incompleteSeries = await db.Series
+            .Include(s => s.Books)
+            .Where(s => s.Type == SeriesType.Series && s.ExpectedCount != null)
+            .ToListAsync(ct);
+
+        var gapsText = incompleteSeries
+            .Where(s => s.Books.Count < s.ExpectedCount!.Value)
+            .Select(s => $"- {s.Name} by {s.Author ?? "various"}: have {s.Books.Count}/{s.ExpectedCount!.Value}, missing: {string.Join(", ", Enumerable.Range(1, s.ExpectedCount.Value).Where(i => !s.Books.Any(b => b.SeriesOrder == i)))}")
+            .ToList();
+
+        return $@"Here's the reader's library profile:
+
+Top authors:
+{string.Join("\n", topAuthors.Select(a => $"- {a.Author}: {a.Count} books, avg rating {a.AvgRating:F1}/5"))}
+
+Top genres:
+{string.Join("\n", topGenres.Select(g => $"- {g.Name}: {g.Count} books"))}
+
+Highly rated books (4-5 stars):
+{string.Join("\n", highlyRated.Select(b => $"- \"{b.Title}\" by {b.Author} ({b.Rating}/5)"))}
+
+Incomplete series (gaps to fill):
+{(gapsText.Count > 0 ? string.Join("\n", gapsText) : "No incomplete series.")}";
+    }
+}


### PR DESCRIPTION
New AzureFoundryAIAssistantService for Claude models hosted on Azure AI Foundry. Uses the Anthropic SDK with a custom HttpClient pointing at the Azure endpoint — same API, different billing (Azure credits).

Extracts all JSON parsing and prompt building into SharedParsers so both Anthropic and Azure Foundry implementations share the same logic. Reduces code duplication significantly.

Both services implement the full IAIAssistantService interface: genre suggestions, collection cataloguing, shopping suggestions, book advisor, and photo ISBN OCR.

Azure Foundry config: AI:AzureFoundry:Endpoint, ApiKey, FastDeployment, DeepDeployment.