### PR TITLE
fix: remove missing styles.css reference and correct model IDs

### DIFF
--- a/BookTracker.Web/Components/App.razor
+++ b/BookTracker.Web/Components/App.razor
@@ -7,7 +7,7 @@
     <base href="/" />
     <link rel="stylesheet" href="@Assets["lib/bootstrap/dist/css/bootstrap.min.css"]" />
     <link rel="stylesheet" href="@Assets["css/site.css"]" />
-    <link rel="stylesheet" href="@Assets["BookTracker.Web.styles.css"]" />
+    @* Only include scoped styles bundle if scoped .razor.css files exist *@
     <ImportMap />
     <HeadOutlet @rendermode="InteractiveServer" />
 </head>

--- a/BookTracker.Web/Services/AIAssistantOptions.cs
+++ b/BookTracker.Web/Services/AIAssistantOptions.cs
@@ -21,8 +21,8 @@ public class AIOptions
 public class AnthropicOptions
 {
     public string ApiKey { get; set; } = "";
-    public string FastModel { get; set; } = "claude-sonnet-4-5-20250514";
-    public string DeepModel { get; set; } = "claude-opus-4-5-20250514";
+    public string FastModel { get; set; } = "claude-sonnet-4-20250514";
+    public string DeepModel { get; set; } = "claude-opus-4-20250514";
     public int MaxTokens { get; set; } = 1024;
 }
 


### PR DESCRIPTION
1. Removed BookTracker.Web.styles.css link from App.razor — no scoped .razor.css files exist so the bundle is never generated, causing a 404 in production.

2. Fixed default Anthropic model IDs:
   - claude-sonnet-4-5-20250514 -> claude-sonnet-4-20250514
   - claude-opus-4-5-20250514 -> claude-opus-4-20250514 The "-5" suffix was incorrect and caused not_found_error from the API.