### PR TITLE
feat: add AI provider toggle on Assistant and Bulk Add pages

### DIFF
--- a/BookTracker.Web/Components/Pages/Assistant/Index.razor
+++ b/BookTracker.Web/Components/Pages/Assistant/Index.razor
@@ -3,9 +3,9 @@
 
 <PageTitle>AI Assistant - BookTracker</PageTitle>
 
-<div class="d-flex justify-content-between align-items-center mb-3">
+<div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-3">
     <h1 class="mb-0">AI Assistant</h1>
-    <span class="badge bg-light text-dark border">AI calls: @VM.CallCount</span>
+    <AIProviderToggle />
 </div>
 
 <div class="card mb-4">

--- a/BookTracker.Web/Components/Pages/Books/BulkAdd.razor
+++ b/BookTracker.Web/Components/Pages/Books/BulkAdd.razor
@@ -69,6 +69,10 @@
             </button>
         </div>
 
+        <div class="mt-2">
+            <AIProviderToggle />
+        </div>
+
         @if (!string.IsNullOrEmpty(scannerError))
         {
             <div class="alert alert-warning mt-2 mb-0 py-2 small">@scannerError</div>

--- a/BookTracker.Web/Components/Shared/AIProviderToggle.razor
+++ b/BookTracker.Web/Components/Shared/AIProviderToggle.razor
@@ -1,0 +1,33 @@
+@inject AIProviderFactory ProviderFactory
+
+<div class="d-inline-flex align-items-center gap-2">
+    <select class="form-select form-select-sm" style="width: auto;" value="@ProviderFactory.ActiveProvider" @onchange="OnProviderChanged">
+        @foreach (var provider in ProviderFactory.AvailableProviders)
+        {
+            <option value="@provider">@FormatProvider(provider)</option>
+        }
+    </select>
+    <span class="badge bg-light text-dark border">@ProviderFactory.GetService().CallCount calls</span>
+</div>
+
+@code {
+    [Parameter]
+    public EventCallback OnChanged { get; set; }
+
+    private async Task OnProviderChanged(ChangeEventArgs e)
+    {
+        if (Enum.TryParse<AIProvider>(e.Value?.ToString(), out var provider))
+        {
+            ProviderFactory.SwitchProvider(provider);
+            await OnChanged.InvokeAsync();
+        }
+    }
+
+    private static string FormatProvider(AIProvider p) => p switch
+    {
+        AIProvider.Anthropic => "Anthropic (Claude)",
+        AIProvider.AzureFoundry => "Azure Foundry (Claude)",
+        AIProvider.AzureOpenAI => "Azure OpenAI (GPT-4o)",
+        _ => p.ToString()
+    };
+}

--- a/BookTracker.Web/ViewModels/AIAssistantViewModel.cs
+++ b/BookTracker.Web/ViewModels/AIAssistantViewModel.cs
@@ -7,8 +7,15 @@ namespace BookTracker.Web.ViewModels;
 
 public class AIAssistantViewModel(
     IDbContextFactory<BookTrackerDbContext> dbFactory,
-    IAIAssistantService aiService)
+    AIProviderFactory providerFactory)
 {
+    private IAIAssistantService AiService => providerFactory.GetService();
+
+    public AIProvider ActiveProvider => providerFactory.ActiveProvider;
+    public IReadOnlyList<AIProvider> AvailableProviders => providerFactory.AvailableProviders;
+
+    public void SwitchProvider(AIProvider provider) => providerFactory.SwitchProvider(provider);
+
     // Genre cleanup
     public List<BookGenreRow> BooksNeedingGenres { get; private set; } = [];
     public bool GenresLoaded { get; private set; }
@@ -17,7 +24,7 @@ public class AIAssistantViewModel(
     public GenreSuggestionResult? CurrentSuggestion { get; private set; }
     public string? GenreError { get; private set; }
 
-    public int CallCount => aiService.CallCount;
+    public int CallCount => AiService.CallCount;
 
     public async Task LoadBooksNeedingGenresAsync()
     {
@@ -51,7 +58,7 @@ public class AIAssistantViewModel(
 
         try
         {
-            CurrentSuggestion = await aiService.SuggestGenresAsync(
+            CurrentSuggestion = await AiService.SuggestGenresAsync(
                 book.Title, book.Author, book.Subtitle, book.CurrentGenres);
         }
         catch (Exception ex)
@@ -115,7 +122,7 @@ public class AIAssistantViewModel(
 
         try
         {
-            CollectionSuggestion = await aiService.SuggestCollectionsAsync();
+            CollectionSuggestion = await AiService.SuggestCollectionsAsync();
         }
         catch (Exception ex)
         {
@@ -190,7 +197,7 @@ public class AIAssistantViewModel(
 
         try
         {
-            ShoppingSuggestion = await aiService.SuggestShoppingListAsync();
+            ShoppingSuggestion = await AiService.SuggestShoppingListAsync();
         }
         catch (Exception ex)
         {
@@ -241,7 +248,7 @@ public class AIAssistantViewModel(
 
         try
         {
-            AdvisorResult = await aiService.AssessBookAsync(BookAdvisorQuery.Trim());
+            AdvisorResult = await AiService.AssessBookAsync(BookAdvisorQuery.Trim());
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
New AIProviderToggle shared component — dropdown showing available providers (auto-detected from config) with call counter badge. Switches the active provider at runtime via AIProviderFactory.

Provider names displayed as: "Anthropic (Claude)", "Azure Foundry (Claude)", "Azure OpenAI (GPT-4o)".

Placed on:
- AI Assistant page header (replaces static call counter)
- Bulk Add page below scanner buttons (for photo ISBN OCR provider)

AIAssistantViewModel updated to take AIProviderFactory directly, exposing ActiveProvider/AvailableProviders/SwitchProvider and resolving the service via factory.GetService() on each call.