### PR TITLE
fix: model IDs from SDK constants, placeholder quotes, DI resilience

### DIFF
--- a/BookTracker.Web/Components/Pages/Assistant/Index.razor
+++ b/BookTracker.Web/Components/Pages/Assistant/Index.razor
@@ -12,7 +12,7 @@
     <div class="card-header bg-white"><h2 class="h5 mb-0">Book advisor</h2></div>
     <div class="card-body">
         <div class="input-group">
-            <input type="text" class="form-control" placeholder="e.g. &quot;Dune by Frank Herbert&quot; or &quot;anything by Brandon Sanderson&quot;"
+            <input type="text" class="form-control" placeholder='e.g. "Dune by Frank Herbert" or "anything by Brandon Sanderson"'
                    @bind="VM.BookAdvisorQuery" @bind:event="oninput" @onkeyup="HandleAdvisorKeyUp" />
             <button type="button" class="btn btn-primary" @onclick="VM.AssessBookAsync" disabled="@(VM.Advising || string.IsNullOrWhiteSpace(VM.BookAdvisorQuery))">
                 @if (VM.Advising)

--- a/BookTracker.Web/Components/Pages/Books/BulkAdd.razor
+++ b/BookTracker.Web/Components/Pages/Books/BulkAdd.razor
@@ -3,7 +3,7 @@
 @inject BulkAddViewModel VM
 @inject NavigationManager Nav
 @inject IJSRuntime JS
-@inject IAIAssistantService AI
+@inject AIProviderFactory AIFactory
 
 <PageTitle>Bulk add books - BookTracker</PageTitle>
 
@@ -328,7 +328,7 @@
                 return;
             }
 
-            var isbn = await AI.ExtractIsbnFromImageAsync(base64);
+            var isbn = await AIFactory.GetService().ExtractIsbnFromImageAsync(base64);
             if (isbn is null)
             {
                 photoError = "Could not find an ISBN in the photo. Try again with clearer framing.";

--- a/BookTracker.Web/Program.cs
+++ b/BookTracker.Web/Program.cs
@@ -3,6 +3,7 @@ using BookTracker.Web.Components;
 using BookTracker.Web.Services;
 using BookTracker.Web.ViewModels;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -34,13 +35,16 @@ builder.Services.AddTransient<SeriesMatchService>();
 
 builder.Services.Configure<AIOptions>(
     builder.Configuration.GetSection(AIOptions.SectionName));
-builder.Services.AddScoped<AIProviderFactory>();
-builder.Services.AddScoped<IAIAssistantService>(sp =>
+builder.Services.AddScoped<AIProviderFactory>(sp =>
 {
-    var factory = sp.GetRequiredService<AIProviderFactory>();
+    var factory = new AIProviderFactory(
+        sp.GetRequiredService<IDbContextFactory<BookTrackerDbContext>>(),
+        sp.GetRequiredService<IOptions<AIOptions>>());
     factory.Initialize();
-    return factory.GetService();
+    return factory;
 });
+builder.Services.AddScoped<IAIAssistantService>(sp =>
+    sp.GetRequiredService<AIProviderFactory>().GetService());
 
 // ViewModels — transient so each component instance gets its own VM.
 builder.Services.AddTransient<HomeViewModel>();

--- a/BookTracker.Web/Services/AIAssistantOptions.cs
+++ b/BookTracker.Web/Services/AIAssistantOptions.cs
@@ -1,3 +1,5 @@
+using Anthropic.SDK.Constants;
+
 namespace BookTracker.Web.Services;
 
 public enum AIProvider
@@ -21,8 +23,8 @@ public class AIOptions
 public class AnthropicOptions
 {
     public string ApiKey { get; set; } = "";
-    public string FastModel { get; set; } = "claude-sonnet-4-20250514";
-    public string DeepModel { get; set; } = "claude-opus-4-20250514";
+    public string FastModel { get; set; } = AnthropicModels.Claude46Sonnet;
+    public string DeepModel { get; set; } = AnthropicModels.Claude46Opus;
     public int MaxTokens { get; set; } = 1024;
 }
 


### PR DESCRIPTION
1. Model IDs: use AnthropicModels.Claude46Sonnet/Claude46Opus SDK constants instead of hardcoded strings. Previous IDs were not found by the API.

2. Book advisor placeholder: switched from &quot; HTML entities to single-quoted attribute with real double quotes so the placeholder renders correctly.

3. DI resilience: AIProviderFactory now initialized during registration to avoid unhandled errors on page load. BulkAdd page uses AIFactory.GetService() instead of direct IAIAssistantService injection so it respects the provider toggle.