### PR TITLE
chore: add AI config to Bicep and update docs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4,7 +4,7 @@ This document describes the overall design and structure of BookTracker. It shou
 
 ## Overview
 
-BookTracker is an ASP.NET Core Blazor Web App for managing a personal book library. It runs in **Interactive Server** render mode (Blazor Server), backed by EF Core + SQL Server. It includes AI-powered features via the Anthropic API (Claude).
+BookTracker is an ASP.NET Core Blazor Web App for managing a personal book library. It runs in **Interactive Server** render mode (Blazor Server), backed by EF Core + SQL Server. It includes AI-powered features via multiple providers: Anthropic (Claude), Azure AI Foundry (Claude), and Azure OpenAI (GPT-4o).
 
 Target deployment: Azure App Service + Azure SQL (Basic tier) via GitHub Actions.
 
@@ -115,6 +115,7 @@ A short-lived context is created per operation. Never inject `DbContext` directl
 | `BookForm.razor` | Book metadata fields (title, author, category, status, rating, notes, cover URL) + cover preview |
 | `GenrePicker.razor` | Hierarchical genre checkbox grid with fuzzy matching from ISBN lookup |
 | `EditionCopyForm.razor` | Edition fields (ISBN, format, publisher, date, cover) + copy condition |
+| `AIProviderToggle.razor` | Dropdown to switch AI provider at runtime + call counter badge |
 
 ## Services
 
@@ -128,21 +129,34 @@ Local series detection after ISBN lookup. Strategies:
 3. Author has 2+ ungrouped books — suggests creating a collection
 4. Title contains series indicators (Book #, Vol., Part II)
 
-### AIAssistantService (IAIAssistantService)
-Wraps the Anthropic API. Scoped lifetime for prompt caching within a session.
+### AI Assistant (IAIAssistantService)
+Multi-provider architecture with runtime switching via `AIProviderFactory`.
 
-| Method | Model | Purpose |
+**Providers:**
+- `AnthropicAIAssistantService` — Anthropic API direct. Sonnet for fast ops, Opus for deep analysis. Prompt caching via `CacheControlEphemeral`.
+- `AzureFoundryAIAssistantService` — Claude via Azure AI Foundry. Same Anthropic SDK with custom endpoint. Uses Azure credits.
+- `AzureOpenAIAssistantService` — GPT-4o via Azure OpenAI SDK. Single deployment for all operations.
+
+**Shared logic:** `SharedParsers` provides JSON parsing and prompt building used by all providers.
+
+| Method | Speed | Purpose |
 |--------|-------|---------|
-| `SuggestGenresAsync` | Sonnet | Suggest genres from preset taxonomy |
-| `SuggestCollectionsAsync` | Sonnet | Suggest series/collection groupings for uncategorised books |
-| `SuggestShoppingListAsync` | Sonnet | Recommend books based on library patterns and series gaps |
-| `AssessBookAsync` | Opus | Suitability assessment for a specific book/author |
+| `ExtractIsbnFromImageAsync` | Fast | OCR ISBN from photo (vision API) |
+| `SuggestGenresAsync` | Fast | Suggest genres from preset taxonomy |
+| `SuggestCollectionsAsync` | Fast | Suggest series/collection groupings |
+| `SuggestShoppingListAsync` | Fast | Recommend books based on library patterns |
+| `AssessBookAsync` | Deep | Suitability assessment for a book/author |
 
-All prompts use `PromptCacheType.FineGrained` with `CacheControlEphemeral` on system messages.
+### AIProviderFactory
+Scoped factory managing provider lifecycle. Auto-detects available providers from config (checks for API keys). Supports runtime switching via `SwitchProvider()`.
 
-## Barcode scanning
+## ISBN capture
 
-ISBN barcodes (EAN-13/EAN-8) are scanned via the `html5-qrcode` library (v2.3.8, static JS under `wwwroot/lib/`). A JS interop wrapper (`barcode-scanner.js`) manages the scanner lifecycle. The scanning viewport is optimised for 1D barcodes (wide and short, not square). Used on Bulk Add and Shopping pages.
+### Barcode scanning
+ISBN barcodes (EAN-13/EAN-8) are scanned via the `html5-qrcode` library (v2.3.8, static JS under `wwwroot/lib/`). A JS interop wrapper (`barcode-scanner.js`) manages the scanner lifecycle with 3-second debounce on duplicate scans. The scanning viewport is optimised for 1D barcodes (wide and short, `aspectRatio: 2.0`). Used on Bulk Add and Shopping pages.
+
+### Photo ISBN OCR
+For older books without barcodes, `photo-capture.js` opens the camera for a still photo. The image is scaled to max 800px, compressed to 70% JPEG, and sent to the active AI provider's `ExtractIsbnFromImageAsync` for vision OCR. SignalR max message size increased to 512KB for image transfer.
 
 ## Mobile responsiveness
 
@@ -164,18 +178,26 @@ CI runs `dotnet test` on all PRs to main.
 | Setting | Source | Purpose |
 |---------|--------|---------|
 | `ConnectionStrings:DefaultConnection` | appsettings / Azure config | SQL Server connection |
-| `Anthropic:ApiKey` | appsettings / Azure config | Anthropic API key |
-| `Anthropic:FastModel` | appsettings (default: Sonnet 4.5) | Model for batch AI ops |
-| `Anthropic:DeepModel` | appsettings (default: Opus 4.5) | Model for deep analysis |
+| `AI:DefaultProvider` | appsettings / Azure config | `Anthropic`, `AzureFoundry`, or `AzureOpenAI` |
+| `AI:Anthropic:ApiKey` | appsettings / Azure config | Anthropic API key |
+| `AI:Anthropic:FastModel` | appsettings (default: SDK constant) | Model for fast AI ops |
+| `AI:Anthropic:DeepModel` | appsettings (default: SDK constant) | Model for deep analysis |
+| `AI:AzureFoundry:Endpoint` | appsettings / Azure config | Azure AI Foundry endpoint URL |
+| `AI:AzureFoundry:ApiKey` | appsettings / Azure config | Azure AI Foundry key |
+| `AI:AzureFoundry:FastDeployment` | appsettings / Azure config | Deployment for fast ops |
+| `AI:AzureFoundry:DeepDeployment` | appsettings / Azure config | Deployment for deep analysis |
+| `AI:AzureOpenAI:Endpoint` | appsettings / Azure config | Azure OpenAI endpoint URL |
+| `AI:AzureOpenAI:ApiKey` | appsettings / Azure config | Azure OpenAI key |
+| `AI:AzureOpenAI:Deployment` | appsettings / Azure config | GPT-4o deployment name |
 
-Dev config templates: `appsettings.Example.json`, `appsettings.Development.Example.json`. Copy and fill in secrets.
+Dev config templates: `appsettings.Example.json`, `appsettings.Development.Example.json`. Copy and fill in secrets. Only configure providers you want to use — the toggle auto-detects available providers.
 
 ## Infrastructure
 
 - Docker Compose for local SQL Server 2022 Developer
 - GitHub Actions CI (build + test on PR)
 - Dependabot for NuGet (EF Core grouped) and npm (html5-qrcode)
-- Azure Bicep templates under `infra/`
+- Azure Bicep templates under `infra/` (includes AI provider config parameters)
 - Auto-migration on startup (TODO: deploy-time migration bundle)
 
 ## Key conventions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ Two-project solution (`BookTracker.slnx`, the new XML solution format):
 
 **DbContext lifetime:** Blazor Server circuits are long-lived while `DbContext` is scoped and not thread-safe. `Program.cs` registers `AddDbContextFactory<BookTrackerDbContext>`; components inject `IDbContextFactory<T>` and create/dispose a context per operation (`await using var db = await DbFactory.CreateDbContextAsync();`). Do **not** switch back to `AddDbContext` + direct injection.
 
-Entity model: `Book` (Title, Author, many-to-many `Genres`, `BookStatus` enum Unread/Reading/Read, Rating 0–5, Notes, DateAdded, DefaultCoverArtUrl, one-to-many `Copies`), `BookCopy` (Isbn, `BookFormat`, DatePrinted, `BookCondition` default Good, optional CustomCoverArtUrl), `Genre` (unique Name), and `WishlistItem` (Title, Author, `WishlistPriority`, nullable Price `decimal(10,2)`, DateAdded).
+Entity model: `Book` (Title, Author, many-to-many `Genres`, `BookStatus` enum, Rating, Notes, DateAdded, DefaultCoverArtUrl, one-to-many `Editions`, optional `Series`), `Edition` (unique Isbn, `BookFormat`, DatePrinted, CoverUrl, Publisher, one-to-many `Copies`), `Copy` (Condition, DateAcquired, Notes), `Genre` (hierarchical with parent/child), `Series` (Name, Author, `SeriesType` Series/Collection, ExpectedCount), `Tag` (many-to-many with Book), `Publisher`, and `WishlistItem` (Title, Author, Priority, optional Isbn/Series link).
 
 Config convention: connection string name is **`DefaultConnection`**. Dev value lives in `appsettings.Development.json` and points at the Docker SQL container. Prod value comes from Azure App Service configuration. `appsettings*.json` is **gitignored**; committed templates live alongside them as `appsettings.Example.json` and `appsettings.Development.Example.json` — on a fresh clone, copy each `.Example.json` to the real filename and fill in secrets.
 
@@ -68,6 +68,16 @@ Typical first-run loop: `docker compose up -d` → `dotnet ef database update ..
 
 The app is used on both desktop and mobile (phones for barcode scanning and quick library checks). When planning new features, always clarify whether the feature should be **mobile-prioritised** (responsive-first, tested at small breakpoints) or **web-only** (desktop layout sufficient). Key mobile workflows: bulk ISBN scanning, library search.
 
-## Not yet in the repo
+## AI integration
 
-No Anthropic integration. When adding tests, add them to the existing `BookTracker.Tests\` project.
+Three AI providers supported, selectable at runtime via toggle on the AI Assistant and Bulk Add pages:
+
+- **Anthropic** (direct API) — Claude Sonnet for fast ops, Opus for deep analysis
+- **Azure Foundry** — Claude via Azure endpoint (uses Azure credits)
+- **Azure OpenAI** — GPT-4o
+
+Config under `AI:` section in appsettings. Only providers with API keys configured are available. See `appsettings.Example.json` for structure.
+
+## Tests
+
+Tests live in `BookTracker.Tests\` (xUnit + NSubstitute + EF InMemory). CI runs tests on all PRs to main.

--- a/infra/README.md
+++ b/infra/README.md
@@ -84,8 +84,62 @@ Bind a custom hostname (e.g. `books.silly.ninja`) to the production slot with a 
 
 Works for CNAME-pointed subdomains only. Apex domains (`silly.ninja`) need a different cert issuance path (A record + ALIAS or equivalent) — not covered here.
 
+## AI provider configuration
+
+The app supports three AI providers. Configure whichever ones you want to use — only providers with API keys will appear in the runtime toggle. Set these as App Settings in the Azure Portal (`Configuration > Application settings`) or pass them via Bicep parameters.
+
+### Anthropic (direct API)
+
+1. Create an account at [console.anthropic.com](https://console.anthropic.com).
+2. Go to **API Keys** and create a new key.
+3. Add the app setting:
+
+| Setting | Value |
+|---------|-------|
+| `AI__DefaultProvider` | `Anthropic` |
+| `AI__Anthropic__ApiKey` | `sk-ant-...` (your API key) |
+
+Model defaults (Sonnet for fast ops, Opus for deep analysis) are built into the app — no need to configure them unless you want to override.
+
+### Azure AI Foundry (Claude via Azure)
+
+1. In the [Azure Portal](https://portal.azure.com), create an **Azure AI Foundry** resource (or use an existing one).
+2. Deploy a Claude model (e.g. `claude-sonnet`) — note the deployment name.
+3. Optionally deploy a second model for deep analysis (e.g. `claude-opus`).
+4. From the resource's **Keys and Endpoint** page, copy the endpoint URL and a key.
+5. Add the app settings:
+
+| Setting | Value |
+|---------|-------|
+| `AI__DefaultProvider` | `AzureFoundry` (or keep `Anthropic` and switch at runtime) |
+| `AI__AzureFoundry__Endpoint` | `https://<resource>.services.ai.azure.com` |
+| `AI__AzureFoundry__ApiKey` | Your Azure AI Foundry key |
+| `AI__AzureFoundry__FastDeployment` | Deployment name for fast ops (e.g. `claude-sonnet`) |
+| `AI__AzureFoundry__DeepDeployment` | Deployment name for deep analysis (e.g. `claude-opus`) |
+
+### Azure OpenAI (GPT-4o)
+
+1. In the [Azure Portal](https://portal.azure.com), create an **Azure OpenAI** resource.
+2. Go to **Azure AI Foundry** (linked from the resource) and deploy a model — e.g. `gpt-4o`. Note the deployment name.
+3. From the resource's **Keys and Endpoint** page, copy the endpoint URL and a key.
+4. Add the app settings:
+
+| Setting | Value |
+|---------|-------|
+| `AI__DefaultProvider` | `AzureOpenAI` (or keep another default and switch at runtime) |
+| `AI__AzureOpenAI__Endpoint` | `https://<resource>.openai.azure.com` |
+| `AI__AzureOpenAI__ApiKey` | Your Azure OpenAI key |
+| `AI__AzureOpenAI__Deployment` | Deployment name (e.g. `gpt-4o`) |
+
+### Notes
+
+- You can configure multiple providers simultaneously. The app auto-detects which ones have valid keys and shows them in the provider toggle dropdown.
+- `AI__DefaultProvider` determines which provider is active on page load. Users can switch at runtime via the dropdown on the AI Assistant and Bulk Add pages.
+- For local development, add the same settings to `appsettings.Development.json` under the `AI` section (using `:` instead of `__` as the separator). See `appsettings.Example.json` for the structure.
+
 ## TODOs
 
 - Move the Easy Auth client secret from an app setting to a Key Vault reference and schedule rotation.
 - Consider Private Endpoint + VNet integration instead of the "Allow Azure services" SQL firewall rule.
 - Add a staging slot to the App Service once the deploy pipeline is in place.
+- Consider moving AI API keys to Key Vault references for better secret management.

--- a/infra/modules/appservice.bicep
+++ b/infra/modules/appservice.bicep
@@ -10,6 +10,21 @@ param sqlServerFqdn string
 param sqlDatabaseName string
 param appInsightsConnectionString string
 
+// AI provider config — set via Azure Portal or CLI for secrets.
+// Only configure the providers you want to use.
+@secure()
+param aiAnthropicApiKey string = ''
+@secure()
+param aiAzureFoundryApiKey string = ''
+param aiAzureFoundryEndpoint string = ''
+param aiAzureFoundryFastDeployment string = ''
+param aiAzureFoundryDeepDeployment string = ''
+@secure()
+param aiAzureOpenAIApiKey string = ''
+param aiAzureOpenAIEndpoint string = ''
+param aiAzureOpenAIDeployment string = ''
+param aiDefaultProvider string = 'Anthropic'
+
 // App Service plan: Linux, S1 (AlwaysOn + slots available, suits Blazor Server).
 resource plan 'Microsoft.Web/serverfarms@2023-12-01' = {
   name: appServicePlanName
@@ -58,6 +73,15 @@ resource appSettings 'Microsoft.Web/sites/config@2023-12-01' = {
     ASPNETCORE_ENVIRONMENT: 'Production'
     APPLICATIONINSIGHTS_CONNECTION_STRING: appInsightsConnectionString
     MICROSOFT_PROVIDER_AUTHENTICATION_SECRET: authClientSecret
+    AI__DefaultProvider: aiDefaultProvider
+    AI__Anthropic__ApiKey: aiAnthropicApiKey
+    AI__AzureFoundry__Endpoint: aiAzureFoundryEndpoint
+    AI__AzureFoundry__ApiKey: aiAzureFoundryApiKey
+    AI__AzureFoundry__FastDeployment: aiAzureFoundryFastDeployment
+    AI__AzureFoundry__DeepDeployment: aiAzureFoundryDeepDeployment
+    AI__AzureOpenAI__Endpoint: aiAzureOpenAIEndpoint
+    AI__AzureOpenAI__ApiKey: aiAzureOpenAIApiKey
+    AI__AzureOpenAI__Deployment: aiAzureOpenAIDeployment
   }
 }
 
@@ -151,6 +175,15 @@ resource stagingAppSettings 'Microsoft.Web/sites/slots/config@2023-12-01' = {
     ASPNETCORE_ENVIRONMENT: 'Production'
     APPLICATIONINSIGHTS_CONNECTION_STRING: appInsightsConnectionString
     MICROSOFT_PROVIDER_AUTHENTICATION_SECRET: authClientSecret
+    AI__DefaultProvider: aiDefaultProvider
+    AI__Anthropic__ApiKey: aiAnthropicApiKey
+    AI__AzureFoundry__Endpoint: aiAzureFoundryEndpoint
+    AI__AzureFoundry__ApiKey: aiAzureFoundryApiKey
+    AI__AzureFoundry__FastDeployment: aiAzureFoundryFastDeployment
+    AI__AzureFoundry__DeepDeployment: aiAzureFoundryDeepDeployment
+    AI__AzureOpenAI__Endpoint: aiAzureOpenAIEndpoint
+    AI__AzureOpenAI__ApiKey: aiAzureOpenAIApiKey
+    AI__AzureOpenAI__Deployment: aiAzureOpenAIDeployment
   }
 }
 


### PR DESCRIPTION
Bicep (appservice.bicep):
- Adds AI provider parameters (all defaulting to empty/Anthropic)
- App settings for all three providers on both production and staging slots: AI__DefaultProvider, AI__Anthropic__ApiKey, AI__AzureFoundry__*, AI__AzureOpenAI__*
- API keys marked @secure()

CLAUDE.md:
- Updated entity model description for Edition/Copy hierarchy
- Replaced stale "Not yet in the repo" with AI integration and Tests sections

ARCHITECTURE.md:
- Updated overview for multi-provider AI
- Added AIProviderToggle to shared components
- Replaced single AIAssistantService section with multi-provider architecture (3 implementations + SharedParsers + factory)
- Added ISBN capture section (barcode scanning + photo OCR)
- Updated config table with all AI provider settings
- Removed duplicate barcode scanning section