### PR TITLE
refactor: rename AzureFoundry to MicrosoftFoundry throughout

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4,7 +4,7 @@ This document describes the overall design and structure of BookTracker. It shou
 
 ## Overview
 
-BookTracker is an ASP.NET Core Blazor Web App for managing a personal book library. It runs in **Interactive Server** render mode (Blazor Server), backed by EF Core + SQL Server. It includes AI-powered features via multiple providers: Anthropic (Claude), Azure AI Foundry (Claude), and Azure OpenAI (GPT-4o).
+BookTracker is an ASP.NET Core Blazor Web App for managing a personal book library. It runs in **Interactive Server** render mode (Blazor Server), backed by EF Core + SQL Server. It includes AI-powered features via multiple providers: Anthropic (Claude), Microsoft Foundry (Claude), and Azure OpenAI (GPT-4o).
 
 Target deployment: Azure App Service + Azure SQL (Basic tier) via GitHub Actions.
 
@@ -134,7 +134,7 @@ Multi-provider architecture with runtime switching via `AIProviderFactory`.
 
 **Providers:**
 - `AnthropicAIAssistantService` — Anthropic API direct. Sonnet for fast ops, Opus for deep analysis. Prompt caching via `CacheControlEphemeral`.
-- `AzureFoundryAIAssistantService` — Claude via Azure AI Foundry. Same Anthropic SDK with custom endpoint. Uses Azure credits.
+- `MicrosoftFoundryAIAssistantService` — Claude via Microsoft Foundry. Same Anthropic SDK with custom endpoint. Uses Azure credits.
 - `AzureOpenAIAssistantService` — GPT-4o via Azure OpenAI SDK. Single deployment for all operations.
 
 **Shared logic:** `SharedParsers` provides JSON parsing and prompt building used by all providers.
@@ -178,14 +178,14 @@ CI runs `dotnet test` on all PRs to main.
 | Setting | Source | Purpose |
 |---------|--------|---------|
 | `ConnectionStrings:DefaultConnection` | appsettings / Azure config | SQL Server connection |
-| `AI:DefaultProvider` | appsettings / Azure config | `Anthropic`, `AzureFoundry`, or `AzureOpenAI` |
+| `AI:DefaultProvider` | appsettings / Azure config | `Anthropic`, `MicrosoftFoundry`, or `AzureOpenAI` |
 | `AI:Anthropic:ApiKey` | appsettings / Azure config | Anthropic API key |
 | `AI:Anthropic:FastModel` | appsettings (default: SDK constant) | Model for fast AI ops |
 | `AI:Anthropic:DeepModel` | appsettings (default: SDK constant) | Model for deep analysis |
-| `AI:AzureFoundry:Endpoint` | appsettings / Azure config | Azure AI Foundry endpoint URL |
-| `AI:AzureFoundry:ApiKey` | appsettings / Azure config | Azure AI Foundry key |
-| `AI:AzureFoundry:FastDeployment` | appsettings / Azure config | Deployment for fast ops |
-| `AI:AzureFoundry:DeepDeployment` | appsettings / Azure config | Deployment for deep analysis |
+| `AI:MicrosoftFoundry:Endpoint` | appsettings / Azure config | Microsoft Foundry endpoint URL |
+| `AI:MicrosoftFoundry:ApiKey` | appsettings / Azure config | Microsoft Foundry key |
+| `AI:MicrosoftFoundry:FastDeployment` | appsettings / Azure config | Deployment for fast ops |
+| `AI:MicrosoftFoundry:DeepDeployment` | appsettings / Azure config | Deployment for deep analysis |
 | `AI:AzureOpenAI:Endpoint` | appsettings / Azure config | Azure OpenAI endpoint URL |
 | `AI:AzureOpenAI:ApiKey` | appsettings / Azure config | Azure OpenAI key |
 | `AI:AzureOpenAI:Deployment` | appsettings / Azure config | GPT-4o deployment name |

--- a/BookTracker.Web/Components/Shared/AIProviderToggle.razor
+++ b/BookTracker.Web/Components/Shared/AIProviderToggle.razor
@@ -26,7 +26,7 @@
     private static string FormatProvider(AIProvider p) => p switch
     {
         AIProvider.Anthropic => "Anthropic (Claude)",
-        AIProvider.AzureFoundry => "Azure Foundry (Claude)",
+        AIProvider.MicrosoftFoundry => "Microsoft Foundry (Claude)",
         AIProvider.AzureOpenAI => "Azure OpenAI (GPT-4o)",
         _ => p.ToString()
     };

--- a/BookTracker.Web/Services/AIAssistantOptions.cs
+++ b/BookTracker.Web/Services/AIAssistantOptions.cs
@@ -5,7 +5,7 @@ namespace BookTracker.Web.Services;
 public enum AIProvider
 {
     Anthropic,
-    AzureFoundry,
+    MicrosoftFoundry,
     AzureOpenAI
 }
 
@@ -16,7 +16,7 @@ public class AIOptions
     public AIProvider DefaultProvider { get; set; } = AIProvider.Anthropic;
 
     public AnthropicOptions Anthropic { get; set; } = new();
-    public AzureFoundryOptions AzureFoundry { get; set; } = new();
+    public MicrosoftFoundryOptions MicrosoftFoundry { get; set; } = new();
     public AzureOpenAIOptions AzureOpenAI { get; set; } = new();
 }
 
@@ -28,7 +28,7 @@ public class AnthropicOptions
     public int MaxTokens { get; set; } = 1024;
 }
 
-public class AzureFoundryOptions
+public class MicrosoftFoundryOptions
 {
     public string Endpoint { get; set; } = "";
     public string ApiKey { get; set; } = "";

--- a/BookTracker.Web/Services/AIProviderFactory.cs
+++ b/BookTracker.Web/Services/AIProviderFactory.cs
@@ -43,7 +43,7 @@ public class AIProviderFactory(
     private IAIAssistantService CreateService(AIProvider provider) => provider switch
     {
         AIProvider.Anthropic => new AnthropicAIAssistantService(dbFactory, _options.Anthropic),
-        AIProvider.AzureFoundry => new AzureFoundryAIAssistantService(dbFactory, _options.AzureFoundry),
+        AIProvider.MicrosoftFoundry => new MicrosoftFoundryAIAssistantService(dbFactory, _options.MicrosoftFoundry),
         AIProvider.AzureOpenAI => new AzureOpenAIAssistantService(dbFactory, _options.AzureOpenAI),
         _ => throw new ArgumentOutOfRangeException(nameof(provider))
     };
@@ -53,8 +53,8 @@ public class AIProviderFactory(
         var providers = new List<AIProvider>();
         if (!string.IsNullOrEmpty(_options.Anthropic.ApiKey))
             providers.Add(AIProvider.Anthropic);
-        if (!string.IsNullOrEmpty(_options.AzureFoundry.ApiKey) && !string.IsNullOrEmpty(_options.AzureFoundry.Endpoint))
-            providers.Add(AIProvider.AzureFoundry);
+        if (!string.IsNullOrEmpty(_options.MicrosoftFoundry.ApiKey) && !string.IsNullOrEmpty(_options.MicrosoftFoundry.Endpoint))
+            providers.Add(AIProvider.MicrosoftFoundry);
         if (!string.IsNullOrEmpty(_options.AzureOpenAI.ApiKey) && !string.IsNullOrEmpty(_options.AzureOpenAI.Endpoint))
             providers.Add(AIProvider.AzureOpenAI);
         return providers;
@@ -63,7 +63,7 @@ public class AIProviderFactory(
     private static AIProvider? GetProviderForService(IAIAssistantService service) => service switch
     {
         AnthropicAIAssistantService => AIProvider.Anthropic,
-        AzureFoundryAIAssistantService => AIProvider.AzureFoundry,
+        MicrosoftFoundryAIAssistantService => AIProvider.MicrosoftFoundry,
         AzureOpenAIAssistantService => AIProvider.AzureOpenAI,
         _ => null
     };

--- a/BookTracker.Web/Services/MicrosoftFoundryAIAssistantService.cs
+++ b/BookTracker.Web/Services/MicrosoftFoundryAIAssistantService.cs
@@ -7,12 +7,12 @@ using Microsoft.EntityFrameworkCore;
 namespace BookTracker.Web.Services;
 
 /// <summary>
-/// AI assistant implementation using Claude models hosted on Azure AI Foundry.
+/// AI assistant implementation using Claude models hosted on Microsoft Foundry.
 /// Uses the Anthropic SDK with a custom HttpClient pointing at the Azure endpoint.
 /// </summary>
-public class AzureFoundryAIAssistantService(
+public class MicrosoftFoundryAIAssistantService(
     IDbContextFactory<BookTrackerDbContext> dbFactory,
-    AzureFoundryOptions options) : IAIAssistantService
+    MicrosoftFoundryOptions options) : IAIAssistantService
 {
     private AnthropicClient? _client;
 

--- a/BookTracker.Web/appsettings.Example.json
+++ b/BookTracker.Web/appsettings.Example.json
@@ -7,7 +7,7 @@
     "Anthropic": {
       "ApiKey": ""
     },
-    "AzureFoundry": {
+    "MicrosoftFoundry": {
       "Endpoint": "",
       "ApiKey": "",
       "FastDeployment": "",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ The app is used on both desktop and mobile (phones for barcode scanning and quic
 Three AI providers supported, selectable at runtime via toggle on the AI Assistant and Bulk Add pages:
 
 - **Anthropic** (direct API) — Claude Sonnet for fast ops, Opus for deep analysis
-- **Azure Foundry** — Claude via Azure endpoint (uses Azure credits)
+- **Microsoft Foundry** — Claude via Azure endpoint (uses Azure credits)
 - **Azure OpenAI** — GPT-4o
 
 Config under `AI:` section in appsettings. Only providers with API keys configured are available. See `appsettings.Example.json` for structure.

--- a/infra/README.md
+++ b/infra/README.md
@@ -101,9 +101,9 @@ The app supports three AI providers. Configure whichever ones you want to use �
 
 Model defaults (Sonnet for fast ops, Opus for deep analysis) are built into the app — no need to configure them unless you want to override.
 
-### Azure AI Foundry (Claude via Azure)
+### Microsoft Foundry (Claude via Azure)
 
-1. In the [Azure Portal](https://portal.azure.com), create an **Azure AI Foundry** resource (or use an existing one).
+1. In the [Azure Portal](https://portal.azure.com), create a **Microsoft Foundry** resource (or use an existing one).
 2. Deploy a Claude model (e.g. `claude-sonnet`) — note the deployment name.
 3. Optionally deploy a second model for deep analysis (e.g. `claude-opus`).
 4. From the resource's **Keys and Endpoint** page, copy the endpoint URL and a key.
@@ -111,16 +111,16 @@ Model defaults (Sonnet for fast ops, Opus for deep analysis) are built into the 
 
 | Setting | Value |
 |---------|-------|
-| `AI__DefaultProvider` | `AzureFoundry` (or keep `Anthropic` and switch at runtime) |
-| `AI__AzureFoundry__Endpoint` | `https://<resource>.services.ai.azure.com` |
-| `AI__AzureFoundry__ApiKey` | Your Azure AI Foundry key |
-| `AI__AzureFoundry__FastDeployment` | Deployment name for fast ops (e.g. `claude-sonnet`) |
-| `AI__AzureFoundry__DeepDeployment` | Deployment name for deep analysis (e.g. `claude-opus`) |
+| `AI__DefaultProvider` | `MicrosoftFoundry` (or keep `Anthropic` and switch at runtime) |
+| `AI__MicrosoftFoundry__Endpoint` | `https://<resource>.services.ai.azure.com` |
+| `AI__MicrosoftFoundry__ApiKey` | Your Microsoft Foundry key |
+| `AI__MicrosoftFoundry__FastDeployment` | Deployment name for fast ops (e.g. `claude-sonnet`) |
+| `AI__MicrosoftFoundry__DeepDeployment` | Deployment name for deep analysis (e.g. `claude-opus`) |
 
 ### Azure OpenAI (GPT-4o)
 
 1. In the [Azure Portal](https://portal.azure.com), create an **Azure OpenAI** resource.
-2. Go to **Azure AI Foundry** (linked from the resource) and deploy a model — e.g. `gpt-4o`. Note the deployment name.
+2. Go to **Microsoft Foundry** (linked from the resource) and deploy a model — e.g. `gpt-4o`. Note the deployment name.
 3. From the resource's **Keys and Endpoint** page, copy the endpoint URL and a key.
 4. Add the app settings:
 

--- a/infra/modules/appservice.bicep
+++ b/infra/modules/appservice.bicep
@@ -15,10 +15,10 @@ param appInsightsConnectionString string
 @secure()
 param aiAnthropicApiKey string = ''
 @secure()
-param aiAzureFoundryApiKey string = ''
-param aiAzureFoundryEndpoint string = ''
-param aiAzureFoundryFastDeployment string = ''
-param aiAzureFoundryDeepDeployment string = ''
+param aiMicrosoftFoundryApiKey string = ''
+param aiMicrosoftFoundryEndpoint string = ''
+param aiMicrosoftFoundryFastDeployment string = ''
+param aiMicrosoftFoundryDeepDeployment string = ''
 @secure()
 param aiAzureOpenAIApiKey string = ''
 param aiAzureOpenAIEndpoint string = ''
@@ -75,10 +75,10 @@ resource appSettings 'Microsoft.Web/sites/config@2023-12-01' = {
     MICROSOFT_PROVIDER_AUTHENTICATION_SECRET: authClientSecret
     AI__DefaultProvider: aiDefaultProvider
     AI__Anthropic__ApiKey: aiAnthropicApiKey
-    AI__AzureFoundry__Endpoint: aiAzureFoundryEndpoint
-    AI__AzureFoundry__ApiKey: aiAzureFoundryApiKey
-    AI__AzureFoundry__FastDeployment: aiAzureFoundryFastDeployment
-    AI__AzureFoundry__DeepDeployment: aiAzureFoundryDeepDeployment
+    AI__MicrosoftFoundry__Endpoint: aiMicrosoftFoundryEndpoint
+    AI__MicrosoftFoundry__ApiKey: aiMicrosoftFoundryApiKey
+    AI__MicrosoftFoundry__FastDeployment: aiMicrosoftFoundryFastDeployment
+    AI__MicrosoftFoundry__DeepDeployment: aiMicrosoftFoundryDeepDeployment
     AI__AzureOpenAI__Endpoint: aiAzureOpenAIEndpoint
     AI__AzureOpenAI__ApiKey: aiAzureOpenAIApiKey
     AI__AzureOpenAI__Deployment: aiAzureOpenAIDeployment
@@ -177,10 +177,10 @@ resource stagingAppSettings 'Microsoft.Web/sites/slots/config@2023-12-01' = {
     MICROSOFT_PROVIDER_AUTHENTICATION_SECRET: authClientSecret
     AI__DefaultProvider: aiDefaultProvider
     AI__Anthropic__ApiKey: aiAnthropicApiKey
-    AI__AzureFoundry__Endpoint: aiAzureFoundryEndpoint
-    AI__AzureFoundry__ApiKey: aiAzureFoundryApiKey
-    AI__AzureFoundry__FastDeployment: aiAzureFoundryFastDeployment
-    AI__AzureFoundry__DeepDeployment: aiAzureFoundryDeepDeployment
+    AI__MicrosoftFoundry__Endpoint: aiMicrosoftFoundryEndpoint
+    AI__MicrosoftFoundry__ApiKey: aiMicrosoftFoundryApiKey
+    AI__MicrosoftFoundry__FastDeployment: aiMicrosoftFoundryFastDeployment
+    AI__MicrosoftFoundry__DeepDeployment: aiMicrosoftFoundryDeepDeployment
     AI__AzureOpenAI__Endpoint: aiAzureOpenAIEndpoint
     AI__AzureOpenAI__ApiKey: aiAzureOpenAIApiKey
     AI__AzureOpenAI__Deployment: aiAzureOpenAIDeployment


### PR DESCRIPTION
Renames all references from "Azure Foundry" / "Azure AI Foundry" to "Microsoft Foundry" to match the current branding of the service.

- AIProvider enum: AzureFoundry -> MicrosoftFoundry
- AzureFoundryOptions -> MicrosoftFoundryOptions
- AzureFoundryAIAssistantService -> MicrosoftFoundryAIAssistantService
- Config keys: AI:AzureFoundry:* -> AI:MicrosoftFoundry:*
- Bicep params: aiAzureFoundry* -> aiMicrosoftFoundry*
- App settings: AI__AzureFoundry__* -> AI__MicrosoftFoundry__*
- All docs updated (ARCHITECTURE.md, CLAUDE.md, infra/README.md)
- Display text in AIProviderToggle updated

Breaking config change: any existing AI__AzureFoundry__* settings need to be renamed to AI__MicrosoftFoundry__*.