### PR TITLE
feat(infra): add VNet with App Service VNet Integration

### DIFF
--- a/infra/modules/appservice.bicep
+++ b/infra/modules/appservice.bicep
@@ -9,6 +9,7 @@ param authClientSecret string
 param sqlServerFqdn string
 param sqlDatabaseName string
 param appInsightsConnectionString string
+param appIntegrationSubnetId string
 
 // AI provider config — set via Azure Portal or CLI for secrets.
 // Only configure the providers you want to use.
@@ -53,6 +54,8 @@ resource app 'Microsoft.Web/sites@2023-12-01' = {
     serverFarmId: plan.id
     httpsOnly: true
     clientAffinityEnabled: true
+    virtualNetworkSubnetId: appIntegrationSubnetId
+    vnetRouteAllEnabled: true
     siteConfig: {
       linuxFxVersion: 'DOTNETCORE|10.0'
       alwaysOn: true
@@ -157,6 +160,8 @@ resource stagingSlot 'Microsoft.Web/sites/slots@2023-12-01' = {
     serverFarmId: plan.id
     httpsOnly: true
     clientAffinityEnabled: true
+    virtualNetworkSubnetId: appIntegrationSubnetId
+    vnetRouteAllEnabled: true
     siteConfig: {
       linuxFxVersion: 'DOTNETCORE|10.0'
       alwaysOn: true

--- a/infra/modules/network.bicep
+++ b/infra/modules/network.bicep
@@ -1,0 +1,46 @@
+param location string
+param tags object
+param vnetName string
+
+// VNet with two subnets:
+// - app-integration: delegated to App Service for VNet Integration (outbound)
+// - private-endpoints: for Private Endpoints (SQL, Key Vault, AI services)
+resource vnet 'Microsoft.Network/virtualNetworks@2024-01-01' = {
+  name: vnetName
+  location: location
+  tags: tags
+  properties: {
+    addressSpace: {
+      addressPrefixes: [
+        '10.0.0.0/16'
+      ]
+    }
+    subnets: [
+      {
+        name: 'app-integration'
+        properties: {
+          addressPrefix: '10.0.1.0/24'
+          delegations: [
+            {
+              name: 'appServiceDelegation'
+              properties: {
+                serviceName: 'Microsoft.Web/serverFarms'
+              }
+            }
+          ]
+        }
+      }
+      {
+        name: 'private-endpoints'
+        properties: {
+          addressPrefix: '10.0.2.0/24'
+        }
+      }
+    ]
+  }
+}
+
+output vnetId string = vnet.id
+output vnetName string = vnet.name
+output appIntegrationSubnetId string = vnet.properties.subnets[0].id
+output privateEndpointSubnetId string = vnet.properties.subnets[1].id

--- a/infra/modules/resources.bicep
+++ b/infra/modules/resources.bicep
@@ -19,8 +19,18 @@ var appServiceName = '${appName}-${uniqueSuffix}'
 var appServicePlanName = '${appName}-plan'
 var sqlServerName = '${appName}-sql-${uniqueSuffix}'
 var sqlDatabaseName = appName
+var vnetName = '${appName}-vnet'
 var logAnalyticsName = '${appName}-logs'
 var appInsightsName = '${appName}-ai'
+
+module network './network.bicep' = {
+  name: 'network'
+  params: {
+    location: location
+    tags: tags
+    vnetName: vnetName
+  }
+}
 
 module obs './observability.bicep' = {
   name: 'obs'
@@ -58,6 +68,7 @@ module app './appservice.bicep' = {
     sqlServerFqdn: sql.outputs.sqlServerFqdn
     sqlDatabaseName: sqlDatabaseName
     appInsightsConnectionString: obs.outputs.appInsightsConnectionString
+    appIntegrationSubnetId: network.outputs.appIntegrationSubnetId
   }
 }
 
@@ -80,3 +91,5 @@ output stagingHostName string = app.outputs.stagingHostName
 output stagingPrincipalId string = app.outputs.stagingPrincipalId
 output sqlServerFqdn string = sql.outputs.sqlServerFqdn
 output sqlDatabaseName string = sqlDatabaseName
+output vnetName string = network.outputs.vnetName
+output privateEndpointSubnetId string = network.outputs.privateEndpointSubnetId


### PR DESCRIPTION
New network.bicep module creating a VNet (10.0.0.0/16) with two subnets:
- app-integration (10.0.1.0/24): delegated to Microsoft.Web/serverFarms for App Service outbound VNet Integration
- private-endpoints (10.0.2.0/24): reserved for Private Endpoints (SQL, Key Vault, AI services in future PRs)

App Service and staging slot updated with:
- virtualNetworkSubnetId pointing to app-integration subnet
- vnetRouteAllEnabled: true (all outbound traffic routes through VNet)

This is the foundation for the security improvements. Private Endpoints for backend services will be added in follow-up PRs.

Deployment note: this adds a VNet and changes App Service networking. Existing public connectivity continues to work — VNet Integration is additive (outbound only). No downtime expected.