### PR TITLE
feat(infra): add Key Vault for secret management

### DIFF
--- a/infra/modules/keyvault.bicep
+++ b/infra/modules/keyvault.bicep
@@ -1,0 +1,105 @@
+param location string
+param tags object
+param keyVaultName string
+param tenantId string
+
+// Principal IDs that need Secrets User access (App Service + staging slot)
+param appServicePrincipalId string
+param stagingSlotPrincipalId string
+
+// Secrets to store
+@secure()
+param authClientSecret string
+@secure()
+param aiAnthropicApiKey string = ''
+@secure()
+param aiMicrosoftFoundryApiKey string = ''
+@secure()
+param aiAzureOpenAIApiKey string = ''
+
+resource kv 'Microsoft.KeyVault/vaults@2023-07-01' = {
+  name: keyVaultName
+  location: location
+  tags: tags
+  properties: {
+    sku: {
+      family: 'A'
+      name: 'standard'
+    }
+    tenantId: tenantId
+    enableRbacAuthorization: true
+    enableSoftDelete: true
+    softDeleteRetentionInDays: 7
+    enabledForDeployment: false
+    enabledForDiskEncryption: false
+    enabledForTemplateDeployment: false
+    networkAcls: {
+      defaultAction: 'Allow'  // Will be restricted to VNet once Private Endpoint is added
+      bypass: 'AzureServices'
+    }
+  }
+}
+
+// Key Vault Secrets User role for App Service managed identity
+resource appSecretsRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(kv.id, appServicePrincipalId, '4633458b-17de-408a-b874-0445c86b69e6')
+  scope: kv
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4633458b-17de-408a-b874-0445c86b69e6') // Key Vault Secrets User
+    principalId: appServicePrincipalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+// Key Vault Secrets User role for staging slot managed identity
+resource stagingSecretsRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(kv.id, stagingSlotPrincipalId, '4633458b-17de-408a-b874-0445c86b69e6')
+  scope: kv
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4633458b-17de-408a-b874-0445c86b69e6') // Key Vault Secrets User
+    principalId: stagingSlotPrincipalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+// Secrets
+resource secretAuthClient 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+  parent: kv
+  name: 'AuthClientSecret'
+  properties: {
+    value: authClientSecret
+  }
+}
+
+resource secretAnthropicApiKey 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = if (!empty(aiAnthropicApiKey)) {
+  parent: kv
+  name: 'AIAnthropicApiKey'
+  properties: {
+    value: aiAnthropicApiKey
+  }
+}
+
+resource secretMicrosoftFoundryApiKey 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = if (!empty(aiMicrosoftFoundryApiKey)) {
+  parent: kv
+  name: 'AIMicrosoftFoundryApiKey'
+  properties: {
+    value: aiMicrosoftFoundryApiKey
+  }
+}
+
+resource secretAzureOpenAIApiKey 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = if (!empty(aiAzureOpenAIApiKey)) {
+  parent: kv
+  name: 'AIAzureOpenAIApiKey'
+  properties: {
+    value: aiAzureOpenAIApiKey
+  }
+}
+
+output keyVaultName string = kv.name
+output keyVaultUri string = kv.properties.vaultUri
+
+// Key Vault references for App Settings (use these instead of raw secrets)
+output authClientSecretRef string = '@Microsoft.KeyVault(SecretUri=${secretAuthClient.properties.secretUri})'
+output aiAnthropicApiKeyRef string = !empty(aiAnthropicApiKey) ? '@Microsoft.KeyVault(SecretUri=${secretAnthropicApiKey.properties.secretUri})' : ''
+output aiMicrosoftFoundryApiKeyRef string = !empty(aiMicrosoftFoundryApiKey) ? '@Microsoft.KeyVault(SecretUri=${secretMicrosoftFoundryApiKey.properties.secretUri})' : ''
+output aiAzureOpenAIApiKeyRef string = !empty(aiAzureOpenAIApiKey) ? '@Microsoft.KeyVault(SecretUri=${secretAzureOpenAIApiKey.properties.secretUri})' : ''

--- a/infra/modules/resources.bicep
+++ b/infra/modules/resources.bicep
@@ -20,6 +20,7 @@ var appServicePlanName = '${appName}-plan'
 var sqlServerName = '${appName}-sql-${uniqueSuffix}'
 var sqlDatabaseName = appName
 var vnetName = '${appName}-vnet'
+var keyVaultName = '${appName}-kv-${uniqueSuffix}'
 var logAnalyticsName = '${appName}-logs'
 var appInsightsName = '${appName}-ai'
 
@@ -72,6 +73,23 @@ module app './appservice.bicep' = {
   }
 }
 
+// Key Vault stores secrets and grants access to App Service managed identities.
+// Secrets are stored alongside the raw values in App Settings — to switch to
+// Key Vault references, update the App Settings to use the KV reference outputs
+// (e.g. via a second deploy.ps1 run or manual portal update).
+module kv './keyvault.bicep' = {
+  name: 'keyvault'
+  params: {
+    location: location
+    tags: tags
+    keyVaultName: keyVaultName
+    tenantId: tenantId
+    appServicePrincipalId: app.outputs.principalId
+    stagingSlotPrincipalId: app.outputs.stagingPrincipalId
+    authClientSecret: authClientSecret
+  }
+}
+
 module customdomain './customdomain.bicep' = if (!empty(customDomain)) {
   name: 'customdomain'
   params: {
@@ -91,5 +109,7 @@ output stagingHostName string = app.outputs.stagingHostName
 output stagingPrincipalId string = app.outputs.stagingPrincipalId
 output sqlServerFqdn string = sql.outputs.sqlServerFqdn
 output sqlDatabaseName string = sqlDatabaseName
+output keyVaultName string = kv.outputs.keyVaultName
+output keyVaultUri string = kv.outputs.keyVaultUri
 output vnetName string = network.outputs.vnetName
 output privateEndpointSubnetId string = network.outputs.privateEndpointSubnetId


### PR DESCRIPTION
New keyvault.bicep module:
- Standard tier Key Vault with RBAC authorization and soft delete
- Key Vault Secrets User role assigned to both App Service and staging slot managed identities
- Stores: AuthClientSecret, AI API keys (Anthropic, Microsoft Foundry, Azure OpenAI) — conditional creation for AI keys based on whether values are provided
- Outputs Key Vault reference strings for future migration of App Settings from raw values to @Microsoft.KeyVault(SecretUri=...)

Currently App Settings still use raw secret values. To migrate to Key Vault references, update the App Settings in the portal to use the KV reference URIs output by the module. The RBAC grants are already in place so the App Service can read the secrets.

TODO: add Key Vault Private Endpoint (PR 3 or 4) to restrict access to VNet only.