### PR TITLE
feat(infra): add SQL Private Endpoint and disable public access

### DIFF
--- a/infra/deploy.ps1
+++ b/infra/deploy.ps1
@@ -11,7 +11,11 @@ param(
     [string] $EnterpriseAppName = 'Library-Patrons',
     # Optional custom hostname (e.g. books.silly.ninja). DNS records must be in
     # place first — the script prints them at the end of every run.
-    [string] $CustomDomain = ''
+    [string] $CustomDomain = '',
+    # Optional public IPv4 to whitelist on the SQL firewall for ad-hoc access
+    # (e.g. local EF migrations). Leave blank to keep SQL fully private; the
+    # only path in is then the Private Endpoint from inside the VNet.
+    [string] $DevClientIp = ''
 )
 
 $ErrorActionPreference = 'Stop'
@@ -107,6 +111,7 @@ $templateParams = @{
     sqlAadAdminObjectId = $me.Id
     sqlAadAdminLogin    = $me.UserPrincipalName
     customDomain        = $CustomDomain
+    devClientIp         = $DevClientIp
 }
 
 $deployment = New-AzSubscriptionDeployment `
@@ -158,10 +163,20 @@ if ($missing) {
 # With AAD-only SQL, this is the only way the app can reach the database.
 Write-Host "Granting App Service managed identity access to SQL..."
 
-# The "Allow Azure services" firewall rule lets the App Service in but not this
-# machine, so punch a temporary hole for the script's public IP.
+# SQL is reachable only via Private Endpoint by default, so we temporarily
+# enable public access + add a firewall rule for this machine's IP, run the
+# AAD grant, then revert. If the user passed -DevClientIp the deployment
+# already left public access on, so we skip the toggle.
 $sqlServerResourceName = ($sqlFqdn -split '\.')[0]
 $rgName = $deployment.Outputs.resourceGroupName.Value
+
+$sqlServer = Get-AzSqlServer -ResourceGroupName $rgName -ServerName $sqlServerResourceName
+$publicAccessWas = $sqlServer.PublicNetworkAccess
+if ($publicAccessWas -ne 'Enabled') {
+    Write-Host "  Temporarily enabling SQL public network access..."
+    Set-AzSqlServer -ResourceGroupName $rgName -ServerName $sqlServerResourceName -PublicNetworkAccess 'Enabled' | Out-Null
+}
+
 $myIp = (Invoke-RestMethod -Uri 'https://api.ipify.org' -TimeoutSec 10).Trim()
 $tempRuleName = "deploy-script-$([guid]::NewGuid().ToString('N').Substring(0,8))"
 Write-Host "  Adding temporary SQL firewall rule for $myIp ($tempRuleName)..."
@@ -205,6 +220,11 @@ finally {
         -ServerName $sqlServerResourceName `
         -FirewallRuleName $tempRuleName `
         -Force -ErrorAction SilentlyContinue | Out-Null
+
+    if ($publicAccessWas -ne 'Enabled') {
+        Write-Host "  Restoring SQL public network access to '$publicAccessWas'..."
+        Set-AzSqlServer -ResourceGroupName $rgName -ServerName $sqlServerResourceName -PublicNetworkAccess $publicAccessWas -ErrorAction SilentlyContinue | Out-Null
+    }
 }
 
 Write-Host ""

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -27,6 +27,9 @@ param sqlAadAdminLogin string
 @description('Optional custom hostname to bind to the production slot (e.g. books.silly.ninja). Leave blank to skip.')
 param customDomain string = ''
 
+@description('Optional public IPv4 address allowed through the SQL firewall for ad-hoc access (e.g. local EF migrations). Leave blank to keep SQL fully private.')
+param devClientIp string = ''
+
 var tags = {
   Client: 'Drew'
   Environment: 'Production'
@@ -53,6 +56,7 @@ module resources './modules/resources.bicep' = {
     sqlAadAdminObjectId: sqlAadAdminObjectId
     sqlAadAdminLogin: sqlAadAdminLogin
     customDomain: customDomain
+    devClientIp: devClientIp
   }
 }
 

--- a/infra/modules/resources.bicep
+++ b/infra/modules/resources.bicep
@@ -12,6 +12,9 @@ param sqlAadAdminLogin string
 @description('Optional custom hostname to bind to the production slot (e.g. books.silly.ninja). Leave blank to skip.')
 param customDomain string = ''
 
+@description('Optional public IPv4 address allowed through the SQL firewall for ad-hoc access. Leave blank to keep SQL fully private.')
+param devClientIp string = ''
+
 // Short suffix to keep globally-unique names (App Service hostname, SQL server
 // name) stable across re-deploys while still being unique per-subscription.
 var uniqueSuffix = substring(uniqueString(resourceGroup().id), 0, 6)
@@ -53,6 +56,19 @@ module sql './sql.bicep' = {
     aadAdminObjectId: sqlAadAdminObjectId
     aadAdminLogin: sqlAadAdminLogin
     tenantId: tenantId
+    devClientIp: devClientIp
+  }
+}
+
+module sqlPe './sql-private-endpoint.bicep' = {
+  name: 'sqlPe'
+  params: {
+    location: location
+    tags: tags
+    vnetId: network.outputs.vnetId
+    privateEndpointSubnetId: network.outputs.privateEndpointSubnetId
+    sqlServerId: sql.outputs.sqlServerId
+    privateEndpointName: '${sqlServerName}-pe'
   }
 }
 

--- a/infra/modules/sql-private-endpoint.bicep
+++ b/infra/modules/sql-private-endpoint.bicep
@@ -1,0 +1,80 @@
+param location string
+param tags object
+
+@description('Resource ID of the VNet hosting the private endpoint subnet. Used to link the Private DNS Zone.')
+param vnetId string
+
+@description('Resource ID of the subnet in which the Private Endpoint NIC will be created.')
+param privateEndpointSubnetId string
+
+@description('Resource ID of the SQL server to expose privately.')
+param sqlServerId string
+
+@description('Name to give the Private Endpoint resource.')
+param privateEndpointName string
+
+// Private Link DNS zone name is fixed per-cloud; this project targets Azure
+// Public, so the literal is correct.
+#disable-next-line no-hardcoded-env-urls
+var privateDnsZoneName = 'privatelink.database.windows.net'
+
+resource privateDnsZone 'Microsoft.Network/privateDnsZones@2024-06-01' = {
+  name: privateDnsZoneName
+  location: 'global'
+  tags: tags
+}
+
+resource dnsVnetLink 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2024-06-01' = {
+  parent: privateDnsZone
+  name: 'vnet-link'
+  location: 'global'
+  tags: tags
+  properties: {
+    registrationEnabled: false
+    virtualNetwork: {
+      id: vnetId
+    }
+  }
+}
+
+resource privateEndpoint 'Microsoft.Network/privateEndpoints@2024-01-01' = {
+  name: privateEndpointName
+  location: location
+  tags: tags
+  properties: {
+    subnet: {
+      id: privateEndpointSubnetId
+    }
+    privateLinkServiceConnections: [
+      {
+        name: 'sql'
+        properties: {
+          privateLinkServiceId: sqlServerId
+          groupIds: [
+            'sqlServer'
+          ]
+        }
+      }
+    ]
+  }
+}
+
+// Auto-register the PE's IP into the Private DNS Zone so the SQL FQDN resolves
+// privately from the VNet without manual A-record management.
+resource peDnsZoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2024-01-01' = {
+  parent: privateEndpoint
+  name: 'default'
+  properties: {
+    privateDnsZoneConfigs: [
+      {
+        name: 'database-windows-net'
+        properties: {
+          privateDnsZoneId: privateDnsZone.id
+        }
+      }
+    ]
+  }
+}
+
+output privateEndpointId string = privateEndpoint.id
+output privateDnsZoneId string = privateDnsZone.id

--- a/infra/modules/sql.bicep
+++ b/infra/modules/sql.bicep
@@ -10,8 +10,14 @@ param aadAdminObjectId string
 @description('Display name shown in the portal for the AAD admin. Cosmetic only.')
 param aadAdminLogin string
 
+@description('Optional public IPv4 address allowed through the SQL firewall for ad-hoc access (e.g. local EF migrations). Leave blank to keep SQL fully private.')
+param devClientIp string = ''
+
 // AAD-only auth: no SQL logins exist. The admin above is the only way in until
 // deploy.ps1 provisions the App Service managed identity as a SQL user.
+// Public network access is disabled — App Service reaches SQL via VNet
+// integration + Private Endpoint. An optional firewall rule still applies to
+// the public endpoint when re-enabled, which is why we expose devClientIp.
 resource sqlServer 'Microsoft.Sql/servers@2023-08-01-preview' = {
   name: sqlServerName
   location: location
@@ -19,7 +25,7 @@ resource sqlServer 'Microsoft.Sql/servers@2023-08-01-preview' = {
   properties: {
     version: '12.0'
     minimalTlsVersion: '1.2'
-    publicNetworkAccess: 'Enabled'
+    publicNetworkAccess: empty(devClientIp) ? 'Disabled' : 'Enabled'
     administrators: {
       administratorType: 'ActiveDirectory'
       principalType: 'User'
@@ -47,16 +53,18 @@ resource sqlDb 'Microsoft.Sql/servers/databases@2023-08-01-preview' = {
   }
 }
 
-// Allow other Azure services (incl. the App Service) to reach the SQL server.
-// Suitable for this small app; swap to Private Endpoint / VNet integration for stricter isolation.
-resource allowAzureServices 'Microsoft.Sql/servers/firewallRules@2023-08-01-preview' = {
+// Optional pinhole for local development (EF migrations from a laptop).
+// Only created when devClientIp is supplied; deploys without it leave SQL
+// reachable solely through the Private Endpoint.
+resource devClientFirewallRule 'Microsoft.Sql/servers/firewallRules@2023-08-01-preview' = if (!empty(devClientIp)) {
   parent: sqlServer
-  name: 'AllowAllWindowsAzureIps'
+  name: 'DevClient'
   properties: {
-    startIpAddress: '0.0.0.0'
-    endIpAddress: '0.0.0.0'
+    startIpAddress: devClientIp
+    endIpAddress: devClientIp
   }
 }
 
 output sqlServerFqdn string = sqlServer.properties.fullyQualifiedDomainName
 output sqlServerName string = sqlServer.name
+output sqlServerId string = sqlServer.id


### PR DESCRIPTION
Adds infra/modules/sql-private-endpoint.bicep (Private DNS Zone for privatelink.database.windows.net + VNet link + Private Endpoint with DNS zone group). The App Service reaches SQL through the existing VNet integration; SQL no longer needs the public endpoint.

sql.bicep: publicNetworkAccess defaults to Disabled. Added an optional devClientIp parameter; supplying it re-enables public access and creates a single firewall rule for that IP, intended for ad-hoc local EF migrations from a developer laptop.

deploy.ps1: threads -DevClientIp through to Bicep, and around the AAD SQL grant temporarily flips public access on (then back to its prior state) so the script can run Invoke-Sqlcmd from the operator's machine even when SQL is private-endpoint-only.