### PR TITLE
feat(infra): add Azure OpenAI in eastus2, Key Vault PE, switch to KV …

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,6 +7,7 @@ Outstanding work items for BookTracker. This is the single source of truth — c
 - [ ] Replace migrate-on-startup with deploy-time migration step (`Program.cs:39`) — use `dotnet ef migrations bundle` from GitHub Actions once the app goes multi-instance
 - [ ] Proper error handling — structured logging, correlation IDs, user-friendly messages by category, separate 404 handling (`Program.cs:50`, `Error.razor`)
 - [ ] GitHub Environment with required reviewers for staging-to-production slot swap (`infra/README.md`)
+- [ ] Re-add Microsoft Foundry (Claude on Azure) once on an EA / MCA-E subscription — Sponsored subscriptions are not eligible. Brings back `claude-sonnet-4-6` + `claude-opus-4-7` deployments, the Foundry Private Endpoint, and the `cognitiveservices.azure.com` DNS zone. Direct Anthropic API works in the meantime.
 
 ## UI / UX
 

--- a/infra/deploy.ps1
+++ b/infra/deploy.ps1
@@ -15,7 +15,14 @@ param(
     # Optional public IPv4 to whitelist on the SQL firewall for ad-hoc access
     # (e.g. local EF migrations). Leave blank to keep SQL fully private; the
     # only path in is then the Private Endpoint from inside the VNet.
-    [string] $DevClientIp = ''
+    [string] $DevClientIp = '',
+    # Region for AI services (Foundry + OpenAI). Defaults to eastus2 because
+    # Claude on Foundry and a stable gpt-4o successor are not available in
+    # australiaeast.
+    [string] $SecondaryLocation = 'eastus2',
+    # Optional Anthropic public-API key. When supplied it's stored in Key
+    # Vault and exposed via a KV reference in App Settings.
+    [string] $AnthropicApiKey = ''
 )
 
 $ErrorActionPreference = 'Stop'
@@ -112,6 +119,8 @@ $templateParams = @{
     sqlAadAdminLogin    = $me.UserPrincipalName
     customDomain        = $CustomDomain
     devClientIp         = $DevClientIp
+    secondaryLocation   = $SecondaryLocation
+    anthropicApiKey     = $AnthropicApiKey
 }
 
 $deployment = New-AzSubscriptionDeployment `

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -30,6 +30,13 @@ param customDomain string = ''
 @description('Optional public IPv4 address allowed through the SQL firewall for ad-hoc access (e.g. local EF migrations). Leave blank to keep SQL fully private.')
 param devClientIp string = ''
 
+@description('Region for Azure-hosted AI services (Azure OpenAI). Defaults to eastus2 because the gpt-4o deployment in australiaeast is being retired in June 2026.')
+param secondaryLocation string = 'eastus2'
+
+@description('Optional Anthropic public-API key. When supplied it is stored in Key Vault and exposed as the AI__Anthropic__ApiKey app setting via a KV reference.')
+@secure()
+param anthropicApiKey string = ''
+
 var tags = {
   Client: 'Drew'
   Environment: 'Production'
@@ -57,6 +64,8 @@ module resources './modules/resources.bicep' = {
     sqlAadAdminLogin: sqlAadAdminLogin
     customDomain: customDomain
     devClientIp: devClientIp
+    secondaryLocation: secondaryLocation
+    anthropicApiKey: anthropicApiKey
   }
 }
 
@@ -70,3 +79,5 @@ output stagingHostName string = resources.outputs.stagingHostName
 output stagingPrincipalId string = resources.outputs.stagingPrincipalId
 output sqlServerFqdn string = resources.outputs.sqlServerFqdn
 output sqlDatabaseName string = resources.outputs.sqlDatabaseName
+output keyVaultName string = resources.outputs.keyVaultName
+output openAIEndpoint string = resources.outputs.openAIEndpoint

--- a/infra/modules/ai-services.bicep
+++ b/infra/modules/ai-services.bicep
@@ -1,0 +1,98 @@
+// Azure OpenAI account (kind=OpenAI). Deployed in a region that hosts the
+// desired models — for this project that's eastus2 because the gpt-4o
+// deployment in australiaeast is being retired in June 2026.
+//
+// Microsoft Foundry / Claude is intentionally NOT deployed here: this
+// project's Azure subscription is Sponsored, which Microsoft excludes from
+// Claude eligibility on Foundry. Direct Anthropic API (public, non-Azure)
+// remains the AI provider of choice for Claude. See TODO.md for the
+// follow-up to add Foundry once on an EA / MCA-E subscription.
+//
+// Public network access is disabled — the App Service reaches OpenAI
+// through VNet integration + a Private Endpoint in a peered eastus2 VNet.
+//
+// API keys are written into Key Vault by this module (using listKeys + an
+// existing reference to KV) so the App Settings can use Key Vault references
+// instead of raw secrets.
+
+param location string
+param tags object
+param openAIAccountName string
+param keyVaultName string
+
+@description('Custom subdomain for the Azure OpenAI account. Required for AAD auth and used in the resource\'s endpoint URL.')
+param openAICustomSubDomain string
+
+@description('Principal IDs of the App Service slot identities to grant Cognitive Services User on the OpenAI account.')
+param appPrincipalIds array
+
+resource openAI 'Microsoft.CognitiveServices/accounts@2024-10-01' = {
+  name: openAIAccountName
+  location: location
+  tags: tags
+  kind: 'OpenAI'
+  sku: {
+    name: 'S0'
+  }
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    customSubDomainName: openAICustomSubDomain
+    publicNetworkAccess: 'Disabled'
+    disableLocalAuth: false
+    networkAcls: {
+      defaultAction: 'Deny'
+      virtualNetworkRules: []
+      ipRules: []
+    }
+  }
+}
+
+resource openAIDeployment 'Microsoft.CognitiveServices/accounts/deployments@2024-10-01' = {
+  parent: openAI
+  name: 'gpt-4o'
+  sku: {
+    name: 'Standard'
+    capacity: 10
+  }
+  properties: {
+    model: {
+      format: 'OpenAI'
+      name: 'gpt-4o'
+      version: '2024-11-20'
+    }
+  }
+}
+
+// Existing KV — we write the OpenAI API key into it so the App Service can
+// resolve it as a Key Vault reference in App Settings.
+resource kv 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
+  name: keyVaultName
+}
+
+resource secretOpenAIKey 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+  parent: kv
+  name: 'AIAzureOpenAIApiKey'
+  properties: {
+    value: openAI.listKeys().key1
+  }
+}
+
+// Cognitive Services User role for App Service identities. Lets a future
+// migration to managed-identity auth happen without an infra PR.
+var cognitiveServicesUserRoleId = 'a97b65f3-24c7-4388-baec-2e87135dc908'
+
+resource openAIRoleAssignments 'Microsoft.Authorization/roleAssignments@2022-04-01' = [for principalId in appPrincipalIds: {
+  name: guid(openAI.id, principalId, cognitiveServicesUserRoleId)
+  scope: openAI
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', cognitiveServicesUserRoleId)
+    principalId: principalId
+    principalType: 'ServicePrincipal'
+  }
+}]
+
+output openAIId string = openAI.id
+output openAIEndpoint string = openAI.properties.endpoint
+output openAIDeploymentName string = openAIDeployment.name

--- a/infra/modules/app-config.bicep
+++ b/infra/modules/app-config.bicep
@@ -1,0 +1,175 @@
+// App Service configuration: app settings, connection strings, Easy Auth.
+// Lives in its own module so it can be deployed AFTER Key Vault (so the KV
+// references resolve) and AFTER AI services (so AI endpoints are available).
+
+param appServiceName string
+param stagingSlotName string
+param tenantId string
+param authClientId string
+param sqlServerFqdn string
+param sqlDatabaseName string
+param appInsightsConnectionString string
+
+@description('Key Vault name. Used to build @Microsoft.KeyVault references for secret app settings.')
+param keyVaultName string
+
+@description('True if the optional Anthropic API key was supplied (and therefore stored in KV). When false the AI__Anthropic__ApiKey setting is omitted.')
+param hasAnthropicKey bool = false
+
+// AI provider config (non-secret values only — secrets resolve via KV refs).
+// MicrosoftFoundry settings are intentionally omitted: this subscription is
+// Sponsored, so Claude on Foundry isn't deployable; the MicrosoftFoundry
+// provider therefore won't appear in the app's picker. See TODO.md for the
+// follow-up to add Foundry once on an EA / MCA-E subscription.
+param aiAzureOpenAIEndpoint string = ''
+param aiAzureOpenAIDeployment string = ''
+param aiDefaultProvider string = 'Anthropic'
+
+// Key Vault reference helpers. App Service resolves these via its managed
+// identity (which has Key Vault Secrets User role) and caches the resolved
+// value for the lifetime of the worker. Omitting the secret version tells
+// Azure to pick up the latest secret version automatically.
+#disable-next-line no-hardcoded-env-urls
+var kvBase = 'https://${keyVaultName}.vault.azure.net/secrets'
+var authClientSecretRef = '@Microsoft.KeyVault(SecretUri=${kvBase}/AuthClientSecret/)'
+var openAIKeyRef = '@Microsoft.KeyVault(SecretUri=${kvBase}/AIAzureOpenAIApiKey/)'
+var anthropicKeyRef = '@Microsoft.KeyVault(SecretUri=${kvBase}/AIAnthropicApiKey/)'
+
+// Build app settings as a single object so prod and staging stay in sync.
+// Conditional members let us omit Anthropic when no key was provided.
+var baseAppSettings = {
+  ASPNETCORE_ENVIRONMENT: 'Production'
+  APPLICATIONINSIGHTS_CONNECTION_STRING: appInsightsConnectionString
+  MICROSOFT_PROVIDER_AUTHENTICATION_SECRET: authClientSecretRef
+  AI__DefaultProvider: aiDefaultProvider
+  AI__AzureOpenAI__Endpoint: aiAzureOpenAIEndpoint
+  AI__AzureOpenAI__ApiKey: openAIKeyRef
+  AI__AzureOpenAI__Deployment: aiAzureOpenAIDeployment
+}
+var appSettingsValues = hasAnthropicKey ? union(baseAppSettings, { AI__Anthropic__ApiKey: anthropicKeyRef }) : baseAppSettings
+
+resource app 'Microsoft.Web/sites@2023-12-01' existing = {
+  name: appServiceName
+}
+
+resource stagingSlot 'Microsoft.Web/sites/slots@2023-12-01' existing = {
+  parent: app
+  name: stagingSlotName
+}
+
+resource appSettings 'Microsoft.Web/sites/config@2023-12-01' = {
+  parent: app
+  name: 'appsettings'
+  properties: appSettingsValues
+}
+
+resource connStrings 'Microsoft.Web/sites/config@2023-12-01' = {
+  parent: app
+  name: 'connectionstrings'
+  properties: {
+    DefaultConnection: {
+      value: 'Server=tcp:${sqlServerFqdn},1433;Database=${sqlDatabaseName};Authentication=Active Directory Default;Encrypt=True;TrustServerCertificate=False;'
+      type: 'SQLAzure'
+    }
+  }
+}
+
+// Easy Auth v2: require sign-in, redirect to AAD. Combined with
+// appRoleAssignmentRequired=true on the service principal, only users assigned
+// to the "Library-Patrons" enterprise app can complete sign-in.
+resource authConfig 'Microsoft.Web/sites/config@2023-12-01' = {
+  parent: app
+  name: 'authsettingsV2'
+  properties: {
+    platform: {
+      enabled: true
+      runtimeVersion: '~2'
+    }
+    globalValidation: {
+      requireAuthentication: true
+      unauthenticatedClientAction: 'RedirectToLoginPage'
+      redirectToProvider: 'azureactivedirectory'
+    }
+    identityProviders: {
+      azureActiveDirectory: {
+        enabled: true
+        registration: {
+          openIdIssuer: 'https://sts.windows.net/${tenantId}/v2.0'
+          clientId: authClientId
+          clientSecretSettingName: 'MICROSOFT_PROVIDER_AUTHENTICATION_SECRET'
+        }
+        validation: {
+          allowedAudiences: [
+            'api://${authClientId}'
+            authClientId
+          ]
+        }
+      }
+    }
+    login: {
+      tokenStore: {
+        enabled: true
+      }
+    }
+  }
+  dependsOn: [
+    appSettings
+  ]
+}
+
+resource stagingAppSettings 'Microsoft.Web/sites/slots/config@2023-12-01' = {
+  parent: stagingSlot
+  name: 'appsettings'
+  properties: appSettingsValues
+}
+
+resource stagingConnStrings 'Microsoft.Web/sites/slots/config@2023-12-01' = {
+  parent: stagingSlot
+  name: 'connectionstrings'
+  properties: {
+    DefaultConnection: {
+      value: 'Server=tcp:${sqlServerFqdn},1433;Database=${sqlDatabaseName};Authentication=Active Directory Default;Encrypt=True;TrustServerCertificate=False;'
+      type: 'SQLAzure'
+    }
+  }
+}
+
+resource stagingAuthConfig 'Microsoft.Web/sites/slots/config@2023-12-01' = {
+  parent: stagingSlot
+  name: 'authsettingsV2'
+  properties: {
+    platform: {
+      enabled: true
+      runtimeVersion: '~2'
+    }
+    globalValidation: {
+      requireAuthentication: true
+      unauthenticatedClientAction: 'RedirectToLoginPage'
+      redirectToProvider: 'azureactivedirectory'
+    }
+    identityProviders: {
+      azureActiveDirectory: {
+        enabled: true
+        registration: {
+          openIdIssuer: 'https://sts.windows.net/${tenantId}/v2.0'
+          clientId: authClientId
+          clientSecretSettingName: 'MICROSOFT_PROVIDER_AUTHENTICATION_SECRET'
+        }
+        validation: {
+          allowedAudiences: [
+            'api://${authClientId}'
+            authClientId
+          ]
+        }
+      }
+    }
+    login: {
+      tokenStore: {
+        enabled: true
+      }
+    }
+  }
+  dependsOn: [
+    stagingAppSettings
+  ]
+}

--- a/infra/modules/appservice.bicep
+++ b/infra/modules/appservice.bicep
@@ -1,32 +1,15 @@
+// App Service plan, site, and staging slot only. Configuration (app settings,
+// connection string, Easy Auth) lives in app-config.bicep so it can run after
+// dependencies (Key Vault, AI services) are in place — otherwise we'd have a
+// reference cycle (AI services need the app's principal IDs; app settings
+// need the AI endpoints).
 param location string
 param tags object
 param appServiceName string
 param appServicePlanName string
-param tenantId string
-param authClientId string
-@secure()
-param authClientSecret string
-param sqlServerFqdn string
-param sqlDatabaseName string
-param appInsightsConnectionString string
 param appIntegrationSubnetId string
 
-// AI provider config — set via Azure Portal or CLI for secrets.
-// Only configure the providers you want to use.
-@secure()
-param aiAnthropicApiKey string = ''
-@secure()
-param aiMicrosoftFoundryApiKey string = ''
-param aiMicrosoftFoundryEndpoint string = ''
-param aiMicrosoftFoundryFastDeployment string = ''
-param aiMicrosoftFoundryDeepDeployment string = ''
-@secure()
-param aiAzureOpenAIApiKey string = ''
-param aiAzureOpenAIEndpoint string = ''
-param aiAzureOpenAIDeployment string = ''
-param aiDefaultProvider string = 'Anthropic'
-
-// App Service plan: Linux, S1 (AlwaysOn + slots available, suits Blazor Server).
+// Linux S1: AlwaysOn + slots available, suits Blazor Server.
 resource plan 'Microsoft.Web/serverfarms@2023-12-01' = {
   name: appServicePlanName
   location: location
@@ -67,83 +50,6 @@ resource app 'Microsoft.Web/sites@2023-12-01' = {
   }
 }
 
-// App settings. MICROSOFT_PROVIDER_AUTHENTICATION_SECRET is the conventional
-// setting name Easy Auth looks up for the AAD client secret.
-resource appSettings 'Microsoft.Web/sites/config@2023-12-01' = {
-  parent: app
-  name: 'appsettings'
-  properties: {
-    ASPNETCORE_ENVIRONMENT: 'Production'
-    APPLICATIONINSIGHTS_CONNECTION_STRING: appInsightsConnectionString
-    MICROSOFT_PROVIDER_AUTHENTICATION_SECRET: authClientSecret
-    AI__DefaultProvider: aiDefaultProvider
-    AI__Anthropic__ApiKey: aiAnthropicApiKey
-    AI__MicrosoftFoundry__Endpoint: aiMicrosoftFoundryEndpoint
-    AI__MicrosoftFoundry__ApiKey: aiMicrosoftFoundryApiKey
-    AI__MicrosoftFoundry__FastDeployment: aiMicrosoftFoundryFastDeployment
-    AI__MicrosoftFoundry__DeepDeployment: aiMicrosoftFoundryDeepDeployment
-    AI__AzureOpenAI__Endpoint: aiAzureOpenAIEndpoint
-    AI__AzureOpenAI__ApiKey: aiAzureOpenAIApiKey
-    AI__AzureOpenAI__Deployment: aiAzureOpenAIDeployment
-  }
-}
-
-// AAD-only SQL: Active Directory Default uses the system-assigned managed
-// identity when running in App Service. No password in the connection string.
-resource connStrings 'Microsoft.Web/sites/config@2023-12-01' = {
-  parent: app
-  name: 'connectionstrings'
-  properties: {
-    DefaultConnection: {
-      value: 'Server=tcp:${sqlServerFqdn},1433;Database=${sqlDatabaseName};Authentication=Active Directory Default;Encrypt=True;TrustServerCertificate=False;'
-      type: 'SQLAzure'
-    }
-  }
-}
-
-// Easy Auth v2: require sign-in, redirect to AAD. Combined with
-// appRoleAssignmentRequired=true on the service principal, only users assigned
-// to the "Library-Patrons" enterprise app can complete sign-in.
-resource authConfig 'Microsoft.Web/sites/config@2023-12-01' = {
-  parent: app
-  name: 'authsettingsV2'
-  properties: {
-    platform: {
-      enabled: true
-      runtimeVersion: '~2'
-    }
-    globalValidation: {
-      requireAuthentication: true
-      unauthenticatedClientAction: 'RedirectToLoginPage'
-      redirectToProvider: 'azureactivedirectory'
-    }
-    identityProviders: {
-      azureActiveDirectory: {
-        enabled: true
-        registration: {
-          openIdIssuer: 'https://sts.windows.net/${tenantId}/v2.0'
-          clientId: authClientId
-          clientSecretSettingName: 'MICROSOFT_PROVIDER_AUTHENTICATION_SECRET'
-        }
-        validation: {
-          allowedAudiences: [
-            'api://${authClientId}'
-            authClientId
-          ]
-        }
-      }
-    }
-    login: {
-      tokenStore: {
-        enabled: true
-      }
-    }
-  }
-  dependsOn: [
-    appSettings
-  ]
-}
-
 // Staging deployment slot — GitHub Actions deploys here; swap.yml promotes to prod.
 // Each slot gets its own system-assigned managed identity, so both need to be
 // granted on the SQL DB (deploy.ps1 handles both).
@@ -173,76 +79,6 @@ resource stagingSlot 'Microsoft.Web/sites/slots@2023-12-01' = {
   }
 }
 
-resource stagingAppSettings 'Microsoft.Web/sites/slots/config@2023-12-01' = {
-  parent: stagingSlot
-  name: 'appsettings'
-  properties: {
-    ASPNETCORE_ENVIRONMENT: 'Production'
-    APPLICATIONINSIGHTS_CONNECTION_STRING: appInsightsConnectionString
-    MICROSOFT_PROVIDER_AUTHENTICATION_SECRET: authClientSecret
-    AI__DefaultProvider: aiDefaultProvider
-    AI__Anthropic__ApiKey: aiAnthropicApiKey
-    AI__MicrosoftFoundry__Endpoint: aiMicrosoftFoundryEndpoint
-    AI__MicrosoftFoundry__ApiKey: aiMicrosoftFoundryApiKey
-    AI__MicrosoftFoundry__FastDeployment: aiMicrosoftFoundryFastDeployment
-    AI__MicrosoftFoundry__DeepDeployment: aiMicrosoftFoundryDeepDeployment
-    AI__AzureOpenAI__Endpoint: aiAzureOpenAIEndpoint
-    AI__AzureOpenAI__ApiKey: aiAzureOpenAIApiKey
-    AI__AzureOpenAI__Deployment: aiAzureOpenAIDeployment
-  }
-}
-
-resource stagingConnStrings 'Microsoft.Web/sites/slots/config@2023-12-01' = {
-  parent: stagingSlot
-  name: 'connectionstrings'
-  properties: {
-    DefaultConnection: {
-      value: 'Server=tcp:${sqlServerFqdn},1433;Database=${sqlDatabaseName};Authentication=Active Directory Default;Encrypt=True;TrustServerCertificate=False;'
-      type: 'SQLAzure'
-    }
-  }
-}
-
-resource stagingAuthConfig 'Microsoft.Web/sites/slots/config@2023-12-01' = {
-  parent: stagingSlot
-  name: 'authsettingsV2'
-  properties: {
-    platform: {
-      enabled: true
-      runtimeVersion: '~2'
-    }
-    globalValidation: {
-      requireAuthentication: true
-      unauthenticatedClientAction: 'RedirectToLoginPage'
-      redirectToProvider: 'azureactivedirectory'
-    }
-    identityProviders: {
-      azureActiveDirectory: {
-        enabled: true
-        registration: {
-          openIdIssuer: 'https://sts.windows.net/${tenantId}/v2.0'
-          clientId: authClientId
-          clientSecretSettingName: 'MICROSOFT_PROVIDER_AUTHENTICATION_SECRET'
-        }
-        validation: {
-          allowedAudiences: [
-            'api://${authClientId}'
-            authClientId
-          ]
-        }
-      }
-    }
-    login: {
-      tokenStore: {
-        enabled: true
-      }
-    }
-  }
-  dependsOn: [
-    stagingAppSettings
-  ]
-}
-
 output appServiceUrl string = 'https://${app.properties.defaultHostName}'
 output appServiceName string = app.name
 output defaultHostName string = app.properties.defaultHostName
@@ -250,3 +86,4 @@ output customDomainVerificationId string = app.properties.customDomainVerificati
 output principalId string = app.identity.principalId
 output stagingHostName string = stagingSlot.properties.defaultHostName
 output stagingPrincipalId string = stagingSlot.identity.principalId
+output stagingSlotName string = stagingSlot.name

--- a/infra/modules/keyvault.bicep
+++ b/infra/modules/keyvault.bicep
@@ -7,15 +7,13 @@ param tenantId string
 param appServicePrincipalId string
 param stagingSlotPrincipalId string
 
-// Secrets to store
+// Externally-supplied secrets. AI provider keys for Foundry/OpenAI are NOT
+// here — those are written by ai-services.bicep using listKeys() against the
+// resources it provisions, which keeps them out of deployment params/logs.
 @secure()
 param authClientSecret string
 @secure()
-param aiAnthropicApiKey string = ''
-@secure()
-param aiMicrosoftFoundryApiKey string = ''
-@secure()
-param aiAzureOpenAIApiKey string = ''
+param anthropicApiKey string = ''
 
 resource kv 'Microsoft.KeyVault/vaults@2023-07-01' = {
   name: keyVaultName
@@ -33,8 +31,12 @@ resource kv 'Microsoft.KeyVault/vaults@2023-07-01' = {
     enabledForDeployment: false
     enabledForDiskEncryption: false
     enabledForTemplateDeployment: false
+    // Public access is denied — App Service reaches KV via Private Endpoint
+    // through VNet integration. AzureServices bypass is left on so platform
+    // services (e.g. ARM during the deployment itself) can still write
+    // secrets while resources are being provisioned.
     networkAcls: {
-      defaultAction: 'Allow'  // Will be restricted to VNet once Private Endpoint is added
+      defaultAction: 'Deny'
       bypass: 'AzureServices'
     }
   }
@@ -62,7 +64,6 @@ resource stagingSecretsRole 'Microsoft.Authorization/roleAssignments@2022-04-01'
   }
 }
 
-// Secrets
 resource secretAuthClient 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
   parent: kv
   name: 'AuthClientSecret'
@@ -71,35 +72,14 @@ resource secretAuthClient 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
   }
 }
 
-resource secretAnthropicApiKey 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = if (!empty(aiAnthropicApiKey)) {
+resource secretAnthropicApiKey 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = if (!empty(anthropicApiKey)) {
   parent: kv
   name: 'AIAnthropicApiKey'
   properties: {
-    value: aiAnthropicApiKey
+    value: anthropicApiKey
   }
 }
 
-resource secretMicrosoftFoundryApiKey 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = if (!empty(aiMicrosoftFoundryApiKey)) {
-  parent: kv
-  name: 'AIMicrosoftFoundryApiKey'
-  properties: {
-    value: aiMicrosoftFoundryApiKey
-  }
-}
-
-resource secretAzureOpenAIApiKey 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = if (!empty(aiAzureOpenAIApiKey)) {
-  parent: kv
-  name: 'AIAzureOpenAIApiKey'
-  properties: {
-    value: aiAzureOpenAIApiKey
-  }
-}
-
+output keyVaultId string = kv.id
 output keyVaultName string = kv.name
 output keyVaultUri string = kv.properties.vaultUri
-
-// Key Vault references for App Settings (use these instead of raw secrets)
-output authClientSecretRef string = '@Microsoft.KeyVault(SecretUri=${secretAuthClient.properties.secretUri})'
-output aiAnthropicApiKeyRef string = !empty(aiAnthropicApiKey) ? '@Microsoft.KeyVault(SecretUri=${secretAnthropicApiKey.properties.secretUri})' : ''
-output aiMicrosoftFoundryApiKeyRef string = !empty(aiMicrosoftFoundryApiKey) ? '@Microsoft.KeyVault(SecretUri=${secretMicrosoftFoundryApiKey.properties.secretUri})' : ''
-output aiAzureOpenAIApiKeyRef string = !empty(aiAzureOpenAIApiKey) ? '@Microsoft.KeyVault(SecretUri=${secretAzureOpenAIApiKey.properties.secretUri})' : ''

--- a/infra/modules/network-secondary.bicep
+++ b/infra/modules/network-secondary.bicep
@@ -1,0 +1,31 @@
+param location string
+param tags object
+param vnetName string
+
+// Secondary VNet that hosts Private Endpoints for resources only available in
+// regions other than the primary (e.g. Microsoft Foundry / Azure OpenAI in
+// eastus2). Address space must not overlap with the primary VNet.
+resource vnet 'Microsoft.Network/virtualNetworks@2024-01-01' = {
+  name: vnetName
+  location: location
+  tags: tags
+  properties: {
+    addressSpace: {
+      addressPrefixes: [
+        '10.1.0.0/16'
+      ]
+    }
+    subnets: [
+      {
+        name: 'private-endpoints'
+        properties: {
+          addressPrefix: '10.1.2.0/24'
+        }
+      }
+    ]
+  }
+}
+
+output vnetId string = vnet.id
+output vnetName string = vnet.name
+output privateEndpointSubnetId string = vnet.properties.subnets[0].id

--- a/infra/modules/private-endpoint.bicep
+++ b/infra/modules/private-endpoint.bicep
@@ -1,0 +1,84 @@
+// Generic Private Endpoint module: creates the Private DNS Zone (if it
+// doesn't exist), links it to one or more VNets, creates the PE in the
+// supplied subnet, and registers the PE's IP into the zone via a DNS zone
+// group. Reused for Key Vault, Cognitive Services, Azure OpenAI, etc.
+
+param location string
+param tags object
+
+@description('Private DNS zone name, e.g. privatelink.vaultcore.azure.net')
+param privateDnsZoneName string
+
+@description('Resource IDs of the VNets that should be able to resolve names in this zone (typically the App Service\'s VNet).')
+param linkedVnetIds array
+
+@description('Subnet ID where the Private Endpoint NIC will be created.')
+param privateEndpointSubnetId string
+
+@description('Resource ID of the target service to expose privately.')
+param targetResourceId string
+
+@description('Private Link group ID for the target (e.g. sqlServer, vault, account).')
+param groupId string
+
+@description('Name to give the Private Endpoint resource.')
+param privateEndpointName string
+
+resource privateDnsZone 'Microsoft.Network/privateDnsZones@2024-06-01' = {
+  name: privateDnsZoneName
+  location: 'global'
+  tags: tags
+}
+
+resource dnsVnetLinks 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2024-06-01' = [for (vnetId, i) in linkedVnetIds: {
+  parent: privateDnsZone
+  name: 'vnet-link-${i}'
+  location: 'global'
+  tags: tags
+  properties: {
+    registrationEnabled: false
+    virtualNetwork: {
+      id: vnetId
+    }
+  }
+}]
+
+resource privateEndpoint 'Microsoft.Network/privateEndpoints@2024-01-01' = {
+  name: privateEndpointName
+  location: location
+  tags: tags
+  properties: {
+    subnet: {
+      id: privateEndpointSubnetId
+    }
+    privateLinkServiceConnections: [
+      {
+        name: 'connection'
+        properties: {
+          privateLinkServiceId: targetResourceId
+          groupIds: [
+            groupId
+          ]
+        }
+      }
+    ]
+  }
+}
+
+resource peDnsZoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2024-01-01' = {
+  parent: privateEndpoint
+  name: 'default'
+  properties: {
+    privateDnsZoneConfigs: [
+      {
+        name: replace(privateDnsZoneName, '.', '-')
+        properties: {
+          privateDnsZoneId: privateDnsZone.id
+        }
+      }
+    ]
+  }
+}
+
+output privateEndpointId string = privateEndpoint.id
+output privateDnsZoneId string = privateDnsZone.id

--- a/infra/modules/resources.bicep
+++ b/infra/modules/resources.bicep
@@ -15,6 +15,13 @@ param customDomain string = ''
 @description('Optional public IPv4 address allowed through the SQL firewall for ad-hoc access. Leave blank to keep SQL fully private.')
 param devClientIp string = ''
 
+@description('Region for Azure-hosted AI services (Azure OpenAI). Defaults to eastus2 because the gpt-4o deployment in australiaeast is being retired in June 2026.')
+param secondaryLocation string = 'eastus2'
+
+@description('Optional Anthropic public-API key. When supplied it is stored in Key Vault and exposed as the AI__Anthropic__ApiKey app setting via a KV reference.')
+@secure()
+param anthropicApiKey string = ''
+
 // Short suffix to keep globally-unique names (App Service hostname, SQL server
 // name) stable across re-deploys while still being unique per-subscription.
 var uniqueSuffix = substring(uniqueString(resourceGroup().id), 0, 6)
@@ -23,9 +30,11 @@ var appServicePlanName = '${appName}-plan'
 var sqlServerName = '${appName}-sql-${uniqueSuffix}'
 var sqlDatabaseName = appName
 var vnetName = '${appName}-vnet'
+var vnetSecondaryName = '${appName}-vnet-${secondaryLocation}'
 var keyVaultName = '${appName}-kv-${uniqueSuffix}'
 var logAnalyticsName = '${appName}-logs'
 var appInsightsName = '${appName}-ai'
+var openAIAccountName = '${appName}-openai-${uniqueSuffix}'
 
 module network './network.bicep' = {
   name: 'network'
@@ -33,6 +42,25 @@ module network './network.bicep' = {
     location: location
     tags: tags
     vnetName: vnetName
+  }
+}
+
+module networkSecondary './network-secondary.bicep' = {
+  name: 'networkSecondary'
+  params: {
+    location: secondaryLocation
+    tags: tags
+    vnetName: vnetSecondaryName
+  }
+}
+
+module peering './vnet-peering.bicep' = {
+  name: 'peering'
+  params: {
+    primaryVnetName: network.outputs.vnetName
+    secondaryVnetName: networkSecondary.outputs.vnetName
+    primaryVnetId: network.outputs.vnetId
+    secondaryVnetId: networkSecondary.outputs.vnetId
   }
 }
 
@@ -72,6 +100,12 @@ module sqlPe './sql-private-endpoint.bicep' = {
   }
 }
 
+// App Service is just plan + site + slot here so its identity exists for
+// downstream RBAC (KV, AI services). All actual configuration (app settings,
+// connection strings, Easy Auth) is applied later by app-config.bicep, after
+// KV and AI services are in place. This avoids a reference cycle where AI
+// services need the app's principal IDs while app settings need the AI
+// endpoints.
 module app './appservice.bicep' = {
   name: 'app'
   params: {
@@ -79,20 +113,10 @@ module app './appservice.bicep' = {
     tags: tags
     appServiceName: appServiceName
     appServicePlanName: appServicePlanName
-    tenantId: tenantId
-    authClientId: authClientId
-    authClientSecret: authClientSecret
-    sqlServerFqdn: sql.outputs.sqlServerFqdn
-    sqlDatabaseName: sqlDatabaseName
-    appInsightsConnectionString: obs.outputs.appInsightsConnectionString
     appIntegrationSubnetId: network.outputs.appIntegrationSubnetId
   }
 }
 
-// Key Vault stores secrets and grants access to App Service managed identities.
-// Secrets are stored alongside the raw values in App Settings — to switch to
-// Key Vault references, update the App Settings to use the KV reference outputs
-// (e.g. via a second deploy.ps1 run or manual portal update).
 module kv './keyvault.bicep' = {
   name: 'keyvault'
   params: {
@@ -103,7 +127,85 @@ module kv './keyvault.bicep' = {
     appServicePrincipalId: app.outputs.principalId
     stagingSlotPrincipalId: app.outputs.stagingPrincipalId
     authClientSecret: authClientSecret
+    anthropicApiKey: anthropicApiKey
   }
+}
+
+module kvPe './private-endpoint.bicep' = {
+  name: 'kvPe'
+  params: {
+    location: location
+    tags: tags
+    privateDnsZoneName: 'privatelink.vaultcore.azure.net'
+    linkedVnetIds: [
+      network.outputs.vnetId
+      networkSecondary.outputs.vnetId
+    ]
+    privateEndpointSubnetId: network.outputs.privateEndpointSubnetId
+    targetResourceId: kv.outputs.keyVaultId
+    groupId: 'vault'
+    privateEndpointName: '${keyVaultName}-pe'
+  }
+}
+
+// Azure OpenAI lives in the secondary region. The KV that holds its API key
+// is in the primary region — that's fine, KV cross-region writes work as long
+// as the deploying principal has RBAC.
+module ai './ai-services.bicep' = {
+  name: 'ai'
+  params: {
+    location: secondaryLocation
+    tags: tags
+    openAIAccountName: openAIAccountName
+    keyVaultName: keyVaultName
+    openAICustomSubDomain: openAIAccountName
+    appPrincipalIds: [
+      app.outputs.principalId
+      app.outputs.stagingPrincipalId
+    ]
+  }
+  // KV must exist before ai-services tries to write secrets into it.
+  dependsOn: [
+    kv
+  ]
+}
+
+module openAIPe './private-endpoint.bicep' = {
+  name: 'openAIPe'
+  params: {
+    location: secondaryLocation
+    tags: tags
+    privateDnsZoneName: 'privatelink.openai.azure.com'
+    linkedVnetIds: [
+      network.outputs.vnetId
+      networkSecondary.outputs.vnetId
+    ]
+    privateEndpointSubnetId: networkSecondary.outputs.privateEndpointSubnetId
+    targetResourceId: ai.outputs.openAIId
+    groupId: 'account'
+    privateEndpointName: '${openAIAccountName}-pe'
+  }
+}
+
+module appConfig './app-config.bicep' = {
+  name: 'appConfig'
+  params: {
+    appServiceName: app.outputs.appServiceName
+    stagingSlotName: app.outputs.stagingSlotName
+    tenantId: tenantId
+    authClientId: authClientId
+    sqlServerFqdn: sql.outputs.sqlServerFqdn
+    sqlDatabaseName: sqlDatabaseName
+    appInsightsConnectionString: obs.outputs.appInsightsConnectionString
+    keyVaultName: keyVaultName
+    hasAnthropicKey: !empty(anthropicApiKey)
+    aiAzureOpenAIEndpoint: ai.outputs.openAIEndpoint
+    aiAzureOpenAIDeployment: ai.outputs.openAIDeploymentName
+  }
+  // Wait for KV (so KV refs resolve) and AI deployments (so endpoints exist).
+  dependsOn: [
+    kv
+  ]
 }
 
 module customdomain './customdomain.bicep' = if (!empty(customDomain)) {
@@ -129,3 +231,5 @@ output keyVaultName string = kv.outputs.keyVaultName
 output keyVaultUri string = kv.outputs.keyVaultUri
 output vnetName string = network.outputs.vnetName
 output privateEndpointSubnetId string = network.outputs.privateEndpointSubnetId
+output secondaryVnetName string = networkSecondary.outputs.vnetName
+output openAIEndpoint string = ai.outputs.openAIEndpoint

--- a/infra/modules/vnet-peering.bicep
+++ b/infra/modules/vnet-peering.bicep
@@ -1,0 +1,43 @@
+// Creates the two halves of a VNet peering. Both VNets must already exist.
+// Each peering resource lives under its own VNet, so we declare them as nested
+// resources of an `existing` parent reference.
+param primaryVnetName string
+param secondaryVnetName string
+param secondaryVnetId string
+param primaryVnetId string
+
+resource primaryVnet 'Microsoft.Network/virtualNetworks@2024-01-01' existing = {
+  name: primaryVnetName
+}
+
+resource secondaryVnet 'Microsoft.Network/virtualNetworks@2024-01-01' existing = {
+  name: secondaryVnetName
+}
+
+resource primaryToSecondary 'Microsoft.Network/virtualNetworks/virtualNetworkPeerings@2024-01-01' = {
+  parent: primaryVnet
+  name: 'to-${secondaryVnetName}'
+  properties: {
+    allowVirtualNetworkAccess: true
+    allowForwardedTraffic: false
+    allowGatewayTransit: false
+    useRemoteGateways: false
+    remoteVirtualNetwork: {
+      id: secondaryVnetId
+    }
+  }
+}
+
+resource secondaryToPrimary 'Microsoft.Network/virtualNetworks/virtualNetworkPeerings@2024-01-01' = {
+  parent: secondaryVnet
+  name: 'to-${primaryVnetName}'
+  properties: {
+    allowVirtualNetworkAccess: true
+    allowForwardedTraffic: false
+    allowGatewayTransit: false
+    useRemoteGateways: false
+    remoteVirtualNetwork: {
+      id: primaryVnetId
+    }
+  }
+}


### PR DESCRIPTION
…refs

Provisions an Azure OpenAI account (gpt-4o 2024-11-20, Standard SKU, capacity 10) in eastus2 — the gpt-4o deployment in australiaeast is being retired in June 2026, so a new region is needed regardless. publicNetworkAccess is Disabled and network ACLs Deny by default; the App Service in australiaeast reaches OpenAI through VNet integration + a peered eastus2 VNet (10.1.0.0/16) + a Private Endpoint in that VNet's private-endpoints subnet.

Adds a generic private-endpoint.bicep module (zone + VNet links + PE + DNS zone group) used twice — Key Vault PE in australiaeast and OpenAI PE in eastus2. The Key Vault networkAcls.defaultAction is flipped to Deny in the same deploy.

App Service slot identities receive Cognitive Services User on the OpenAI account so a future managed-identity migration is just a code change.

Splits app-config.bicep out of appservice.bicep so app settings, conn strings, and Easy Auth can be applied AFTER Key Vault and AI services exist (avoids a reference cycle: AI services need the app's principal IDs while app settings need the AI endpoints).

Switches the secret app settings (AuthClientSecret + OpenAI + optional Anthropic) to @Microsoft.KeyVault references. The OpenAI key is written into KV by ai-services.bicep via listKeys() so the deploy script never sees it. Anthropic public-API key is an optional script param.

Microsoft Foundry / Claude is deliberately not deployed: this Azure subscription is Sponsored, which Microsoft excludes from Claude on Foundry. Direct Anthropic API works in the meantime; TODO.md tracks re-adding Foundry once on an EA / MCA-E subscription.

deploy.ps1 gains -SecondaryLocation (default eastus2) and -AnthropicApiKey (optional), threaded through to Bicep.