### PR TITLE
feat: auto-detect format from ISBN lookup; richer BookFormat enum

### DIFF
--- a/BookTracker.Data/BookTrackerDbContext.cs
+++ b/BookTracker.Data/BookTrackerDbContext.cs
@@ -13,6 +13,7 @@ public class BookTrackerDbContext(DbContextOptions<BookTrackerDbContext> options
     public DbSet<Series> Series => Set<Series>();
     public DbSet<Tag> Tags => Set<Tag>();
     public DbSet<WishlistItem> WishlistItems => Set<WishlistItem>();
+    public DbSet<MaintenanceLog> MaintenanceLogs => Set<MaintenanceLog>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -77,5 +78,9 @@ public class BookTrackerDbContext(DbContextOptions<BookTrackerDbContext> options
 
         modelBuilder.Entity<Tag>()
             .HasData(new Tag { Id = 1, Name = "follow-up" });
+
+        modelBuilder.Entity<MaintenanceLog>()
+            .HasIndex(m => m.Name)
+            .IsUnique();
     }
 }

--- a/BookTracker.Data/Migrations/20260419061201_AddMaintenanceLog.Designer.cs
+++ b/BookTracker.Data/Migrations/20260419061201_AddMaintenanceLog.Designer.cs
@@ -4,6 +4,7 @@ using BookTracker.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BookTracker.Data.Migrations
 {
     [DbContext(typeof(BookTrackerDbContext))]
-    partial class BookTrackerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260419061201_AddMaintenanceLog")]
+    partial class AddMaintenanceLog
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BookTracker.Data/Migrations/20260419061201_AddMaintenanceLog.cs
+++ b/BookTracker.Data/Migrations/20260419061201_AddMaintenanceLog.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BookTracker.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMaintenanceLog : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "MaintenanceLogs",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Name = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    CompletedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    Notes = table.Column<string>(type: "nvarchar(2000)", maxLength: 2000, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_MaintenanceLogs", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MaintenanceLogs_Name",
+                table: "MaintenanceLogs",
+                column: "Name",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "MaintenanceLogs");
+        }
+    }
+}

--- a/BookTracker.Data/Models/BookEnums.cs
+++ b/BookTracker.Data/Models/BookEnums.cs
@@ -1,9 +1,17 @@
 namespace BookTracker.Data.Models;
 
+// Ordinals are deliberately preserved across the v1 (Hardcopy/Softcopy) ->
+// v2 (richer) transition: Hardcopy(0) -> Hardcover(0), Softcopy(1) ->
+// TradePaperback(1). Existing rows therefore migrate without a SQL update;
+// previously-Softcopy rows land as TradePaperback (the most common case),
+// and can be re-classified manually or by the EditionFormatBackfillService
+// startup task.
 public enum BookFormat
 {
-    Hardcopy,
-    Softcopy
+    Hardcover = 0,
+    TradePaperback = 1,
+    MassMarketPaperback = 2,
+    LargePrint = 3,
 }
 
 // Standard used-book grading scale, best to worst.

--- a/BookTracker.Data/Models/Edition.cs
+++ b/BookTracker.Data/Models/Edition.cs
@@ -12,7 +12,7 @@ public class Edition
     [Required, MaxLength(20)]
     public string Isbn { get; set; } = string.Empty;
 
-    public BookFormat Format { get; set; } = BookFormat.Softcopy;
+    public BookFormat Format { get; set; } = BookFormat.TradePaperback;
 
     public DateOnly? DatePrinted { get; set; }
 

--- a/BookTracker.Data/Models/MaintenanceLog.cs
+++ b/BookTracker.Data/Models/MaintenanceLog.cs
@@ -1,0 +1,20 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace BookTracker.Data.Models;
+
+// Marker rows for one-shot data operations that should run at most once per
+// deployment (typically a hosted startup task that backfills data after a
+// schema/semantic change). The Name uniquely identifies the operation
+// (e.g. "BackfillEditionFormats-v1") so a duplicate startup is a no-op.
+public class MaintenanceLog
+{
+    public int Id { get; set; }
+
+    [Required, MaxLength(200)]
+    public string Name { get; set; } = string.Empty;
+
+    public DateTime CompletedAt { get; set; }
+
+    [MaxLength(2000)]
+    public string? Notes { get; set; }
+}

--- a/BookTracker.Tests/Services/BookFormatNormalizerTests.cs
+++ b/BookTracker.Tests/Services/BookFormatNormalizerTests.cs
@@ -1,0 +1,72 @@
+using BookTracker.Data.Models;
+using BookTracker.Web.Services;
+
+namespace BookTracker.Tests.Services;
+
+public class BookFormatNormalizerTests
+{
+    [Theory]
+    [InlineData("Hardcover", BookFormat.Hardcover)]
+    [InlineData("Hardback", BookFormat.Hardcover)]
+    [InlineData("Hard cover", BookFormat.Hardcover)]
+    [InlineData("Paperback", BookFormat.TradePaperback)]
+    [InlineData("Trade paperback", BookFormat.TradePaperback)]
+    [InlineData("Softcover", BookFormat.TradePaperback)]
+    [InlineData("Mass Market Paperback", BookFormat.MassMarketPaperback)]
+    [InlineData("MASS MARKET", BookFormat.MassMarketPaperback)]
+    [InlineData("Large Print", BookFormat.LargePrint)]
+    [InlineData("Large Type", BookFormat.LargePrint)]
+    public void Normalize_MapsPhysicalFormatString(string input, BookFormat expected)
+    {
+        Assert.Equal(expected, BookFormatNormalizer.Normalize(input, null));
+    }
+
+    [Fact]
+    public void Normalize_LargePrintWinsOverHardcoverWhenBothMentioned()
+    {
+        Assert.Equal(BookFormat.LargePrint, BookFormatNormalizer.Normalize("Large Print Hardcover", null));
+    }
+
+    [Fact]
+    public void Normalize_MassMarketWinsOverGenericPaperback()
+    {
+        Assert.Equal(BookFormat.MassMarketPaperback, BookFormatNormalizer.Normalize("Mass Market Paperback", null));
+    }
+
+    [Theory]
+    [InlineData("6.9 x 4.2 x 1 inches")]
+    [InlineData("17.5 x 10.6 x 2.5 cm")]
+    public void Normalize_DimensionsInferMassMarket(string dims)
+    {
+        // Both sets of dimensions are within the mass-market envelope.
+        Assert.Equal(BookFormat.MassMarketPaperback, BookFormatNormalizer.Normalize(null, dims));
+    }
+
+    [Fact]
+    public void Normalize_TradeSizedDimensionsReturnNull()
+    {
+        // Dimensions alone can't disambiguate trade paperback from hardcover,
+        // so we conservatively return null and let callers keep their default.
+        Assert.Null(BookFormatNormalizer.Normalize(null, "9.0 x 6.0 x 1.5 inches"));
+    }
+
+    [Fact]
+    public void Normalize_ReturnsNullWhenBothInputsAreEmpty()
+    {
+        Assert.Null(BookFormatNormalizer.Normalize(null, null));
+        Assert.Null(BookFormatNormalizer.Normalize("", "  "));
+    }
+
+    [Fact]
+    public void Normalize_ReturnsNullForUnrecognisedFormatString()
+    {
+        Assert.Null(BookFormatNormalizer.Normalize("Audiobook", null));
+    }
+
+    [Fact]
+    public void Normalize_PhysicalFormatStringTakesPrecedenceOverDimensions()
+    {
+        // String says hardcover, dims say mass-market — string wins.
+        Assert.Equal(BookFormat.Hardcover, BookFormatNormalizer.Normalize("Hardcover", "6.9 x 4.2 x 1 inches"));
+    }
+}

--- a/BookTracker.Tests/Services/EditionFormatBackfillServiceTests.cs
+++ b/BookTracker.Tests/Services/EditionFormatBackfillServiceTests.cs
@@ -1,0 +1,120 @@
+using BookTracker.Data.Models;
+using BookTracker.Web.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace BookTracker.Tests.Services;
+
+public class EditionFormatBackfillServiceTests
+{
+    private readonly TestDbContextFactory _factory = new();
+    private readonly IBookLookupService _lookup = Substitute.For<IBookLookupService>();
+
+    private EditionFormatBackfillService CreateService() =>
+        new(_factory, _lookup, NullLogger<EditionFormatBackfillService>.Instance)
+        {
+            ApiThrottle = TimeSpan.Zero
+        };
+
+    private static BookLookupResult ResultWith(string isbn, BookFormat? format) =>
+        new(isbn, "T", null, "A", null, [], null, null, "test", format);
+
+    [Fact]
+    public async Task RunBackfillAsync_UpdatesEditionsAndStampsMarker()
+    {
+        await SeedEditionsAsync(
+            ("9780000000001", BookFormat.TradePaperback),
+            ("9780000000002", BookFormat.TradePaperback));
+
+        _lookup.LookupByIsbnAsync("9780000000001", Arg.Any<CancellationToken>())
+            .Returns(ResultWith("9780000000001", BookFormat.MassMarketPaperback));
+        _lookup.LookupByIsbnAsync("9780000000002", Arg.Any<CancellationToken>())
+            .Returns(ResultWith("9780000000002", BookFormat.Hardcover));
+
+        await CreateService().RunBackfillAsync(CancellationToken.None);
+
+        using var db = _factory.CreateDbContext();
+        var byIsbn = db.Editions.ToDictionary(e => e.Isbn);
+        Assert.Equal(BookFormat.MassMarketPaperback, byIsbn["9780000000001"].Format);
+        Assert.Equal(BookFormat.Hardcover, byIsbn["9780000000002"].Format);
+
+        var marker = Assert.Single(db.MaintenanceLogs);
+        Assert.Equal("BackfillEditionFormats-v1", marker.Name);
+        Assert.Contains("Updated 2 of 2", marker.Notes);
+    }
+
+    [Fact]
+    public async Task RunBackfillAsync_SkipsWhenMarkerPresent()
+    {
+        await SeedEditionsAsync(("9780000000001", BookFormat.TradePaperback));
+        using (var db = _factory.CreateDbContext())
+        {
+            db.MaintenanceLogs.Add(new MaintenanceLog
+            {
+                Name = "BackfillEditionFormats-v1",
+                CompletedAt = DateTime.UtcNow,
+                Notes = "from a previous run"
+            });
+            await db.SaveChangesAsync();
+        }
+
+        await CreateService().RunBackfillAsync(CancellationToken.None);
+
+        await _lookup.DidNotReceiveWithAnyArgs().LookupByIsbnAsync(default!, default);
+    }
+
+    [Fact]
+    public async Task RunBackfillAsync_LeavesEditionUnchangedWhenLookupReturnsNullFormat()
+    {
+        await SeedEditionsAsync(("9780000000001", BookFormat.TradePaperback));
+        _lookup.LookupByIsbnAsync("9780000000001", Arg.Any<CancellationToken>())
+            .Returns(ResultWith("9780000000001", null));
+
+        await CreateService().RunBackfillAsync(CancellationToken.None);
+
+        using var db = _factory.CreateDbContext();
+        Assert.Equal(BookFormat.TradePaperback, db.Editions.Single().Format);
+
+        var marker = Assert.Single(db.MaintenanceLogs);
+        Assert.Contains("Updated 0 of 1", marker.Notes);
+    }
+
+    [Fact]
+    public async Task RunBackfillAsync_TreatsLookupExceptionsAsFailuresAndStillStampsMarker()
+    {
+        await SeedEditionsAsync(
+            ("9780000000001", BookFormat.TradePaperback),
+            ("9780000000002", BookFormat.TradePaperback));
+
+        _lookup.LookupByIsbnAsync("9780000000001", Arg.Any<CancellationToken>())
+            .Returns<Task<BookLookupResult?>>(_ => throw new HttpRequestException("boom"));
+        _lookup.LookupByIsbnAsync("9780000000002", Arg.Any<CancellationToken>())
+            .Returns(ResultWith("9780000000002", BookFormat.Hardcover));
+
+        await CreateService().RunBackfillAsync(CancellationToken.None);
+
+        using var db = _factory.CreateDbContext();
+        var byIsbn = db.Editions.ToDictionary(e => e.Isbn);
+        Assert.Equal(BookFormat.TradePaperback, byIsbn["9780000000001"].Format);
+        Assert.Equal(BookFormat.Hardcover, byIsbn["9780000000002"].Format);
+
+        var marker = Assert.Single(db.MaintenanceLogs);
+        Assert.Contains("Updated 1 of 2", marker.Notes);
+        Assert.Contains("1 lookup failures", marker.Notes);
+    }
+
+    private async Task SeedEditionsAsync(params (string Isbn, BookFormat Format)[] editions)
+    {
+        using var db = _factory.CreateDbContext();
+        foreach (var (isbn, format) in editions)
+        {
+            db.Books.Add(new Book
+            {
+                Title = "Test",
+                Author = "Test",
+                Editions = [new Edition { Isbn = isbn, Format = format, Copies = [new Copy { Condition = BookCondition.Good }] }]
+            });
+        }
+        await db.SaveChangesAsync();
+    }
+}

--- a/BookTracker.Web/BookFormatExtensions.cs
+++ b/BookTracker.Web/BookFormatExtensions.cs
@@ -1,0 +1,15 @@
+using BookTracker.Data.Models;
+
+namespace BookTracker.Web;
+
+public static class BookFormatExtensions
+{
+    public static string DisplayName(this BookFormat format) => format switch
+    {
+        BookFormat.Hardcover => "Hardcover",
+        BookFormat.TradePaperback => "Trade Paperback",
+        BookFormat.MassMarketPaperback => "Mass Market Paperback",
+        BookFormat.LargePrint => "Large Print",
+        _ => format.ToString(),
+    };
+}

--- a/BookTracker.Web/Components/Shared/EditionCopyForm.razor
+++ b/BookTracker.Web/Components/Shared/EditionCopyForm.razor
@@ -4,17 +4,17 @@
     <div class="card-header bg-white"><h2 class="h5 mb-0">@Title</h2></div>
     <div class="card-body">
         <div class="row g-3">
-            <div class="col-md-4">
+            <div class="col-md-3">
                 <label class="form-label">ISBN</label>
                 <InputText @bind-Value="EditionInput.Isbn" class="form-control" />
                 <ValidationMessage For="() => EditionInput.Isbn" class="text-danger small" />
             </div>
-            <div class="col-md-2">
+            <div class="col-md-3">
                 <label class="form-label">Format</label>
                 <InputSelect @bind-Value="EditionInput.Format" class="form-select">
                     @foreach (var f in Enum.GetValues<BookFormat>())
                     {
-                        <option value="@f">@f</option>
+                        <option value="@f">@f.DisplayName()</option>
                     }
                 </InputSelect>
             </div>

--- a/BookTracker.Web/Program.cs
+++ b/BookTracker.Web/Program.cs
@@ -33,6 +33,12 @@ builder.Services.AddHttpClient<IBookLookupService, BookLookupService>(client =>
 
 builder.Services.AddTransient<SeriesMatchService>();
 
+// One-shot startup task that re-classifies existing Editions using the
+// richer BookFormat enum (populated from upstream metadata). Idempotent via
+// a MaintenanceLog marker; safe to leave registered after the backfill has
+// run.
+builder.Services.AddHostedService<EditionFormatBackfillService>();
+
 builder.Services.Configure<AIOptions>(
     builder.Configuration.GetSection(AIOptions.SectionName));
 builder.Services.AddScoped<AIProviderFactory>(sp =>

--- a/BookTracker.Web/Services/BookFormatNormalizer.cs
+++ b/BookTracker.Web/Services/BookFormatNormalizer.cs
@@ -1,0 +1,79 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+using BookTracker.Data.Models;
+
+namespace BookTracker.Web.Services;
+
+// Normalises raw upstream metadata (Open Library's `physical_format` string,
+// Google Books-style dimensions) into one of the four BookFormat values.
+// Returns null when the inputs aren't confident enough to commit to a value
+// — callers should preserve their existing default in that case rather than
+// guessing.
+public static class BookFormatNormalizer
+{
+    public static BookFormat? Normalize(string? physicalFormat, string? physicalDimensions)
+    {
+        var fromString = FromPhysicalFormatString(physicalFormat);
+        if (fromString is not null) return fromString;
+
+        return FromDimensions(physicalDimensions);
+    }
+
+    private static BookFormat? FromPhysicalFormatString(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw)) return null;
+
+        var s = raw.ToLowerInvariant();
+
+        // Order matters: the more specific labels must win over the generic
+        // "paperback" / "hardcover" matches.
+        if (s.Contains("large print") || s.Contains("large type")) return BookFormat.LargePrint;
+        if (s.Contains("mass market")) return BookFormat.MassMarketPaperback;
+        if (s.Contains("hardcover") || s.Contains("hardback") || s.Contains("hard cover") || s.Contains("hard back")) return BookFormat.Hardcover;
+        if (s.Contains("paperback") || s.Contains("softcover") || s.Contains("soft cover") || s.Contains("trade pb")) return BookFormat.TradePaperback;
+
+        return null;
+    }
+
+    // Open Library's physical_dimensions field looks like "7.5 x 5 x 0.6
+    // inches" or "19.05 x 12.7 x 1.27 centimeters". Without a format string
+    // we can only reliably distinguish mass-market (small) from trade-or-
+    // larger — hardcover vs trade paperback isn't decidable from outer
+    // dimensions alone.
+    private static readonly Regex DimensionsRegex = new(
+        @"^\s*(?<a>[\d.]+)\s*x\s*(?<b>[\d.]+)(?:\s*x\s*(?<c>[\d.]+))?\s*(?<unit>inches?|in|centimeters?|centimetres?|cm)?\s*$",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    private static BookFormat? FromDimensions(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw)) return null;
+
+        var m = DimensionsRegex.Match(raw);
+        if (!m.Success) return null;
+
+        if (!double.TryParse(m.Groups["a"].Value, NumberStyles.Float, CultureInfo.InvariantCulture, out var a)) return null;
+        if (!double.TryParse(m.Groups["b"].Value, NumberStyles.Float, CultureInfo.InvariantCulture, out var b)) return null;
+
+        var unit = m.Groups["unit"].Value;
+        var inCm = unit.Length > 0 && unit.StartsWith("c", StringComparison.OrdinalIgnoreCase);
+        if (!inCm)
+        {
+            // Default to inches when unit is missing (Open Library frequently
+            // omits the unit; their data is overwhelmingly imperial).
+            a *= 2.54;
+            b *= 2.54;
+        }
+
+        // Mass-market paperback is roughly 17.8 x 10.5 cm. Allow a small
+        // tolerance — anything noticeably larger on either axis is a trade
+        // (or hardcover, which we can't tell apart from dimensions).
+        var height = Math.Max(a, b);
+        var width = Math.Min(a, b);
+        if (height <= 19.0 && width <= 11.5)
+        {
+            return BookFormat.MassMarketPaperback;
+        }
+
+        return null;
+    }
+}

--- a/BookTracker.Web/Services/BookLookupResult.cs
+++ b/BookTracker.Web/Services/BookLookupResult.cs
@@ -1,3 +1,5 @@
+using BookTracker.Data.Models;
+
 namespace BookTracker.Web.Services;
 
 public record BookLookupResult(
@@ -9,4 +11,5 @@ public record BookLookupResult(
     IReadOnlyList<string> GenreCandidates,
     DateOnly? DatePrinted,
     string? CoverUrl,
-    string Source);
+    string Source,
+    BookFormat? Format = null);

--- a/BookTracker.Web/Services/BookLookupService.cs
+++ b/BookTracker.Web/Services/BookLookupService.cs
@@ -48,7 +48,8 @@ public class BookLookupService(HttpClient http, ILogger<BookLookupService> logge
                 GenreCandidates: genres,
                 DatePrinted: ParseLooseDate(book.PublishDate),
                 CoverUrl: book.Cover?.Large ?? book.Cover?.Medium ?? $"https://covers.openlibrary.org/b/isbn/{isbn}-L.jpg",
-                Source: "Open Library");
+                Source: "Open Library",
+                Format: BookFormatNormalizer.Normalize(book.PhysicalFormat, book.PhysicalDimensions));
         }
         catch (Exception ex)
         {
@@ -135,6 +136,8 @@ public class BookLookupService(HttpClient http, ILogger<BookLookupService> logge
         [JsonPropertyName("subjects")] public List<OpenLibrarySubject>? Subjects { get; set; }
         [JsonPropertyName("publish_date")] public string? PublishDate { get; set; }
         [JsonPropertyName("cover")] public OpenLibraryCover? Cover { get; set; }
+        [JsonPropertyName("physical_format")] public string? PhysicalFormat { get; set; }
+        [JsonPropertyName("physical_dimensions")] public string? PhysicalDimensions { get; set; }
     }
     private sealed class OpenLibraryAuthor { [JsonPropertyName("name")] public string? Name { get; set; } }
     private sealed class OpenLibraryPublisher { [JsonPropertyName("name")] public string? Name { get; set; } }

--- a/BookTracker.Web/Services/EditionFormatBackfillService.cs
+++ b/BookTracker.Web/Services/EditionFormatBackfillService.cs
@@ -1,0 +1,102 @@
+using BookTracker.Data;
+using BookTracker.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookTracker.Web.Services;
+
+// One-shot startup task that re-classifies existing Editions using the
+// (now-richer) BookFormat enum populated from upstream metadata. The first
+// successful run records a MaintenanceLog row and subsequent startups
+// short-circuit to a no-op. Runs in the background so app startup isn't
+// blocked.
+public class EditionFormatBackfillService(
+    IDbContextFactory<BookTrackerDbContext> dbFactory,
+    IBookLookupService lookup,
+    ILogger<EditionFormatBackfillService> logger) : BackgroundService
+{
+    private const string MarkerName = "BackfillEditionFormats-v1";
+
+    // Polite delay between Open Library calls. Settable so unit tests can
+    // skip the wait; production never overrides it.
+    public TimeSpan ApiThrottle { get; init; } = TimeSpan.FromMilliseconds(200);
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        try
+        {
+            await RunBackfillAsync(stoppingToken);
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            // App shutting down before the backfill finished — leave the
+            // marker absent so it retries on next start.
+        }
+        catch (Exception ex)
+        {
+            // Never fail the host because of a backfill problem; log and move on.
+            logger.LogError(ex, "Edition format backfill failed unexpectedly");
+        }
+    }
+
+    // Exposed (rather than private) so tests can drive the backfill
+    // synchronously without the BackgroundService scaffolding.
+    public async Task RunBackfillAsync(CancellationToken ct)
+    {
+        await using (var probe = await dbFactory.CreateDbContextAsync(ct))
+        {
+            if (await probe.MaintenanceLogs.AnyAsync(m => m.Name == MarkerName, ct))
+            {
+                logger.LogDebug("Edition format backfill already completed; skipping");
+                return;
+            }
+        }
+
+        logger.LogInformation("Starting edition format backfill");
+
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var editions = await db.Editions.ToListAsync(ct);
+
+        var updated = 0;
+        var failures = 0;
+
+        foreach (var edition in editions)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            try
+            {
+                var result = await lookup.LookupByIsbnAsync(edition.Isbn, ct);
+                if (result?.Format is BookFormat resolved && resolved != edition.Format)
+                {
+                    edition.Format = resolved;
+                    updated++;
+                }
+            }
+            catch (Exception ex)
+            {
+                failures++;
+                logger.LogWarning(ex, "Backfill lookup failed for ISBN {Isbn}", edition.Isbn);
+            }
+
+            try
+            {
+                await Task.Delay(ApiThrottle, ct);
+            }
+            catch (OperationCanceledException) { throw; }
+        }
+
+        await db.SaveChangesAsync(ct);
+
+        db.MaintenanceLogs.Add(new MaintenanceLog
+        {
+            Name = MarkerName,
+            CompletedAt = DateTime.UtcNow,
+            Notes = $"Updated {updated} of {editions.Count} editions; {failures} lookup failures."
+        });
+        await db.SaveChangesAsync(ct);
+
+        logger.LogInformation(
+            "Edition format backfill complete: updated {Updated}/{Total}, {Failures} failures",
+            updated, editions.Count, failures);
+    }
+}

--- a/BookTracker.Web/ViewModels/BulkAddViewModel.cs
+++ b/BookTracker.Web/ViewModels/BulkAddViewModel.cs
@@ -62,6 +62,7 @@ public class BulkAddViewModel(
                 row.Subtitle = result.Subtitle;
                 row.DatePrinted = result.DatePrinted;
                 row.GenreCandidates = result.GenreCandidates.ToList();
+                row.Format = result.Format;
                 row.Status = RowStatus.Found;
 
                 row.SeriesSuggestion = await seriesMatch.FindMatchAsync(result.Title, result.Author);
@@ -166,7 +167,7 @@ public class BulkAddViewModel(
                 new Edition
                 {
                     Isbn = row.Isbn,
-                    Format = BookFormat.Softcopy,
+                    Format = row.Format ?? BookFormat.TradePaperback,
                     DatePrinted = row.DatePrinted,
                     Publisher = publisher,
                     Copies = [new Copy { Condition = BookCondition.Good }]
@@ -236,6 +237,10 @@ public class BulkAddViewModel(
         public string? Publisher { get; set; }
         public DateOnly? DatePrinted { get; set; }
         public List<string> GenreCandidates { get; set; } = [];
+        // Null when the lookup couldn't infer a confident format; the save
+        // path falls back to TradePaperback so manual override still wins
+        // pre-save.
+        public BookFormat? Format { get; set; }
         public RowStatus Status { get; set; }
         public RowAction Action { get; set; } = RowAction.Pending;
         public bool IsDuplicate { get; set; }

--- a/BookTracker.Web/ViewModels/EditionFormViewModel.cs
+++ b/BookTracker.Web/ViewModels/EditionFormViewModel.cs
@@ -26,7 +26,7 @@ public class EditionFormViewModel(IDbContextFactory<BookTrackerDbContext> dbFact
         [RegularExpression(@"^(97(8|9))?\d{9}(\d|X|x)$", ErrorMessage = "Enter a valid 10- or 13-digit ISBN.")]
         public string? Isbn { get; set; }
 
-        public BookFormat Format { get; set; } = BookFormat.Softcopy;
+        public BookFormat Format { get; set; } = BookFormat.TradePaperback;
 
         public DateOnly? DatePrinted { get; set; }
 

--- a/BookTracker.Web/ViewModels/ShoppingViewModel.cs
+++ b/BookTracker.Web/ViewModels/ShoppingViewModel.cs
@@ -323,7 +323,7 @@ public class ShoppingViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
             book.Editions.Add(new Edition
             {
                 Isbn = item.Isbn,
-                Format = BookFormat.Softcopy,
+                Format = BookFormat.TradePaperback,
                 Copies = [new Copy { Condition = BookCondition.Good }]
             });
         }


### PR DESCRIPTION
Expands BookFormat from {Hardcopy, Softcopy} to {Hardcover, TradePaperback, MassMarketPaperback, LargePrint}. Existing rows carry across without a SQL update because the new ordinals match the old ones (Hardcopy=0 -> Hardcover=0, Softcopy=1 -> TradePaperback=1).

BookLookupService now reads Open Library's physical_format and physical_dimensions and runs them through a new BookFormatNormalizer helper. The string match handles "Hardcover", "Hardback", "Paperback", "Mass Market Paperback", "Large Print" etc. Dimensions parsing is a fallback that can only confidently spot mass-market (smaller envelope)
- trade vs hardcover isn't decidable from outer dims alone, so the normalizer returns null and the existing default sticks. The Bulk Add flow plumbs the detected format through DiscoveryRow into the saved Edition; manual override on the form still wins.

Renames the format dropdown to use a friendly label (BookFormatExtensions.DisplayName()) since "MassMarketPaperback" isn't great UX. Bumps the form column from col-md-2 to col-md-3 to fit the longer labels and rebalances the row.

Adds a generic MaintenanceLog table (Name unique, CompletedAt, Notes) for tracking one-shot data ops, plus a hosted EditionFormatBackfillService that runs once on startup, looks up every existing edition, updates Format when the lookup returns a confident value (preserves manual choices when it doesn't), and stamps the marker so subsequent startups short-circuit. The 200ms throttle is settable so tests don't sleep.

Tests: BookFormatNormalizerTests (string + dimensions + precedence) and EditionFormatBackfillServiceTests (marker gating, partial failure, null-format leaves data alone).