### PR TITLE
feat(add): no-ISBN flow — title/author search for pre-1974 books

### DIFF
--- a/BookTracker.Data/BookTrackerDbContext.cs
+++ b/BookTracker.Data/BookTrackerDbContext.cs
@@ -23,9 +23,12 @@ public class BookTrackerDbContext(DbContextOptions<BookTrackerDbContext> options
             .HasForeignKey(e => e.BookId)
             .OnDelete(DeleteBehavior.Cascade);
 
+        // Filtered unique index — no-ISBN editions (pre-1974 books) skip
+        // the constraint, so multiple null-ISBN editions can coexist.
         modelBuilder.Entity<Edition>()
             .HasIndex(e => e.Isbn)
-            .IsUnique();
+            .IsUnique()
+            .HasFilter("[Isbn] IS NOT NULL");
 
         modelBuilder.Entity<Edition>()
             .HasOne(e => e.Publisher)

--- a/BookTracker.Data/Migrations/20260419071438_AllowNullableEditionIsbn.Designer.cs
+++ b/BookTracker.Data/Migrations/20260419071438_AllowNullableEditionIsbn.Designer.cs
@@ -4,6 +4,7 @@ using BookTracker.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BookTracker.Data.Migrations
 {
     [DbContext(typeof(BookTrackerDbContext))]
-    partial class BookTrackerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260419071438_AllowNullableEditionIsbn")]
+    partial class AllowNullableEditionIsbn
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BookTracker.Data/Migrations/20260419071438_AllowNullableEditionIsbn.cs
+++ b/BookTracker.Data/Migrations/20260419071438_AllowNullableEditionIsbn.cs
@@ -1,0 +1,61 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BookTracker.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AllowNullableEditionIsbn : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Editions_Isbn",
+                table: "Editions");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Isbn",
+                table: "Editions",
+                type: "nvarchar(20)",
+                maxLength: 20,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(20)",
+                oldMaxLength: 20);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Editions_Isbn",
+                table: "Editions",
+                column: "Isbn",
+                unique: true,
+                filter: "[Isbn] IS NOT NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Editions_Isbn",
+                table: "Editions");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Isbn",
+                table: "Editions",
+                type: "nvarchar(20)",
+                maxLength: 20,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(20)",
+                oldMaxLength: 20,
+                oldNullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Editions_Isbn",
+                table: "Editions",
+                column: "Isbn",
+                unique: true);
+        }
+    }
+}

--- a/BookTracker.Data/Models/Edition.cs
+++ b/BookTracker.Data/Models/Edition.cs
@@ -9,8 +9,11 @@ public class Edition
     public int BookId { get; set; }
     public Book Book { get; set; } = null!;
 
-    [Required, MaxLength(20)]
-    public string Isbn { get; set; } = string.Empty;
+    // Nullable to support pre-1974 books that predate ISBN. The unique index
+    // in BookTrackerDbContext is filtered (WHERE Isbn IS NOT NULL) so any
+    // number of no-ISBN editions can coexist without colliding.
+    [MaxLength(20)]
+    public string? Isbn { get; set; }
 
     public BookFormat Format { get; set; } = BookFormat.TradePaperback;
 

--- a/BookTracker.Tests/Services/EditionFormatBackfillServiceTests.cs
+++ b/BookTracker.Tests/Services/EditionFormatBackfillServiceTests.cs
@@ -34,7 +34,7 @@ public class EditionFormatBackfillServiceTests
         await CreateService().RunBackfillAsync(CancellationToken.None);
 
         using var db = _factory.CreateDbContext();
-        var byIsbn = db.Editions.ToDictionary(e => e.Isbn);
+        var byIsbn = db.Editions.ToDictionary(e => e.Isbn!);
         Assert.Equal(BookFormat.MassMarketPaperback, byIsbn["9780000000001"].Format);
         Assert.Equal(BookFormat.Hardcover, byIsbn["9780000000002"].Format);
 
@@ -94,7 +94,7 @@ public class EditionFormatBackfillServiceTests
         await CreateService().RunBackfillAsync(CancellationToken.None);
 
         using var db = _factory.CreateDbContext();
-        var byIsbn = db.Editions.ToDictionary(e => e.Isbn);
+        var byIsbn = db.Editions.ToDictionary(e => e.Isbn!);
         Assert.Equal(BookFormat.TradePaperback, byIsbn["9780000000001"].Format);
         Assert.Equal(BookFormat.Hardcover, byIsbn["9780000000002"].Format);
 

--- a/BookTracker.Tests/ViewModels/BookAddViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/BookAddViewModelTests.cs
@@ -1,0 +1,152 @@
+using BookTracker.Data.Models;
+using BookTracker.Web.Services;
+using BookTracker.Web.ViewModels;
+using NSubstitute;
+
+namespace BookTracker.Tests.ViewModels;
+
+public class BookAddViewModelTests
+{
+    private readonly TestDbContextFactory _factory = new();
+    private readonly IBookLookupService _lookup = Substitute.For<IBookLookupService>();
+
+    private BookAddViewModel CreateVm() =>
+        new(_factory, _lookup, new SeriesMatchService(_factory));
+
+    private GenrePickerViewModel CreateGenrePicker() => new(_factory);
+
+    [Fact]
+    public async Task SearchAsync_EmptyInputs_ReportsMessageAndDoesNotCallLookup()
+    {
+        var vm = CreateVm();
+        vm.SearchTitle = "";
+        vm.SearchAuthor = "  ";
+
+        await vm.SearchAsync();
+
+        Assert.NotNull(vm.SearchMessage);
+        await _lookup.DidNotReceiveWithAnyArgs().SearchByTitleAuthorAsync(default, default, default);
+    }
+
+    [Fact]
+    public async Task SearchAsync_PopulatesCandidates()
+    {
+        var vm = CreateVm();
+        vm.SearchTitle = "Murder on the Orient Express";
+        vm.SearchAuthor = "Agatha Christie";
+
+        var candidate = new BookSearchCandidate(
+            WorkKey: "/works/OL45804W",
+            Title: "Murder on the Orient Express",
+            Author: "Agatha Christie",
+            FirstPublishYear: 1934,
+            EditionCount: 245,
+            CoverUrl: "https://covers.openlibrary.org/b/id/12345-M.jpg",
+            OpenLibraryUrl: "https://openlibrary.org/works/OL45804W/editions");
+
+        _lookup.SearchByTitleAuthorAsync("Murder on the Orient Express", "Agatha Christie", Arg.Any<CancellationToken>())
+            .Returns([candidate]);
+
+        await vm.SearchAsync();
+
+        Assert.Single(vm.SearchCandidates);
+        Assert.Equal("Murder on the Orient Express", vm.SearchCandidates[0].Title);
+        Assert.Null(vm.SearchMessage);
+    }
+
+    [Fact]
+    public async Task SearchAsync_NoResults_SetsHelpfulMessage()
+    {
+        var vm = CreateVm();
+        vm.SearchTitle = "An obscure title that doesn't exist";
+
+        _lookup.SearchByTitleAuthorAsync(Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<BookSearchCandidate>());
+
+        await vm.SearchAsync();
+
+        Assert.Empty(vm.SearchCandidates);
+        Assert.Contains("No matches", vm.SearchMessage);
+    }
+
+    [Fact]
+    public async Task ApplyCandidateAsync_PrefillsEmptyFields()
+    {
+        var vm = CreateVm();
+        var candidate = new BookSearchCandidate(
+            WorkKey: "/works/OL1W",
+            Title: "And Then There Were None",
+            Author: "Agatha Christie",
+            FirstPublishYear: 1939,
+            EditionCount: 100,
+            CoverUrl: "https://example.invalid/cover.jpg",
+            OpenLibraryUrl: null);
+
+        await vm.ApplyCandidateAsync(candidate, CreateGenrePicker());
+
+        Assert.Equal("And Then There Were None", vm.BookInput.Title);
+        Assert.Equal("Agatha Christie", vm.BookInput.Author);
+        Assert.Equal("https://example.invalid/cover.jpg", vm.BookInput.DefaultCoverArtUrl);
+        Assert.Equal(new DateOnly(1939, 1, 1), vm.EditionInput.DatePrinted);
+    }
+
+    [Fact]
+    public async Task ApplyCandidateAsync_DoesNotOverwriteUserFilledFields()
+    {
+        var vm = CreateVm();
+        vm.BookInput.Title = "User typed this";
+        vm.BookInput.Author = "User author";
+        vm.EditionInput.DatePrinted = new DateOnly(1972, 6, 15);
+
+        var candidate = new BookSearchCandidate(
+            WorkKey: "/works/OL1W",
+            Title: "Lookup title",
+            Author: "Lookup author",
+            FirstPublishYear: 1939,
+            EditionCount: 1,
+            CoverUrl: null,
+            OpenLibraryUrl: null);
+
+        await vm.ApplyCandidateAsync(candidate, CreateGenrePicker());
+
+        Assert.Equal("User typed this", vm.BookInput.Title);
+        Assert.Equal("User author", vm.BookInput.Author);
+        Assert.Equal(new DateOnly(1972, 6, 15), vm.EditionInput.DatePrinted);
+    }
+
+    [Fact]
+    public async Task SaveAsync_BlankIsbnPersistsAsNull()
+    {
+        var vm = CreateVm();
+        vm.BookInput.Title = "And Then There Were None";
+        vm.BookInput.Author = "Agatha Christie";
+        vm.EditionInput.Isbn = "";
+
+        var ok = await vm.SaveAsync(new List<int>());
+
+        Assert.True(ok);
+        using var db = _factory.CreateDbContext();
+        var edition = db.Editions.Single();
+        Assert.Null(edition.Isbn);
+    }
+
+    [Fact]
+    public async Task SaveAsync_TwoNoIsbnEditions_CoexistWithoutCollision()
+    {
+        // Verifies the filtered unique index actually permits multiple null
+        // ISBNs. With an unfiltered unique index this would throw on the
+        // second save.
+        var vm1 = CreateVm();
+        vm1.BookInput.Title = "Book A";
+        vm1.BookInput.Author = "Author A";
+        Assert.True(await vm1.SaveAsync(new List<int>()));
+
+        var vm2 = CreateVm();
+        vm2.BookInput.Title = "Book B";
+        vm2.BookInput.Author = "Author B";
+        Assert.True(await vm2.SaveAsync(new List<int>()));
+
+        using var db = _factory.CreateDbContext();
+        Assert.Equal(2, db.Editions.Count(e => e.Isbn == null));
+    }
+}

--- a/BookTracker.Web/Components/Pages/Books/Add.razor
+++ b/BookTracker.Web/Components/Pages/Books/Add.razor
@@ -13,21 +13,99 @@
         <div class="col-12">
             <div class="card">
                 <div class="card-body">
-                    <label class="form-label fw-semibold">Look up by ISBN</label>
-                    <div class="input-group">
-                        <InputText @bind-Value="VM.LookupIsbn" class="form-control" placeholder="9780345391803" />
-                        <button type="button" class="btn btn-outline-primary" @onclick="LookupAsync" disabled="@VM.LookingUp">
-                            @if (VM.LookingUp)
-                            {
-                                <span class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>
-                            }
-                            Look up
-                        </button>
+                    <div class="form-check form-switch mb-3">
+                        <input type="checkbox" id="noIsbnToggle" class="form-check-input" @bind="VM.NoIsbnMode" />
+                        <label for="noIsbnToggle" class="form-check-label">No ISBN (pre-1974 book)</label>
                     </div>
-                    <div class="form-text">Searches Open Library, then Google Books. Prefills the fields below — you can edit anything before saving.</div>
-                    @if (!string.IsNullOrEmpty(VM.LookupMessage))
+
+                    @if (!VM.NoIsbnMode)
                     {
-                        <div class="alert alert-info mt-3 mb-0 py-2">@VM.LookupMessage</div>
+                        <label class="form-label fw-semibold">Look up by ISBN</label>
+                        <div class="input-group">
+                            <InputText @bind-Value="VM.LookupIsbn" class="form-control" placeholder="9780345391803" />
+                            <button type="button" class="btn btn-outline-primary" @onclick="LookupAsync" disabled="@VM.LookingUp">
+                                @if (VM.LookingUp)
+                                {
+                                    <span class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>
+                                }
+                                Look up
+                            </button>
+                        </div>
+                        <div class="form-text">Searches Open Library, then Google Books. Prefills the fields below — you can edit anything before saving.</div>
+                    }
+                    else
+                    {
+                        <label class="form-label fw-semibold">Search by title and/or author</label>
+                        <div class="row g-2">
+                            <div class="col-md-5">
+                                <InputText @bind-Value="VM.SearchTitle" class="form-control" placeholder="Title" />
+                            </div>
+                            <div class="col-md-5">
+                                <InputText @bind-Value="VM.SearchAuthor" class="form-control" placeholder="Author" />
+                            </div>
+                            <div class="col-md-2 d-grid">
+                                <button type="button" class="btn btn-outline-primary" @onclick="SearchAsync" disabled="@VM.Searching">
+                                    @if (VM.Searching)
+                                    {
+                                        <span class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>
+                                    }
+                                    Search
+                                </button>
+                            </div>
+                        </div>
+                        <div class="form-text">Searches Open Library by title/author. Pick a candidate to prefill — you'll need to fill format, exact print date, and publisher from the book in hand.</div>
+
+                        @if (VM.SearchCandidates.Count > 0)
+                        {
+                            <div class="mt-3 d-flex flex-column gap-2">
+                                @foreach (var candidate in VM.SearchCandidates)
+                                {
+                                    <div class="card border-secondary-subtle">
+                                        <div class="card-body py-2 d-flex align-items-center gap-3">
+                                            @if (!string.IsNullOrEmpty(candidate.CoverUrl))
+                                            {
+                                                <img src="@candidate.CoverUrl" alt="" style="width: 48px; height: 72px; object-fit: cover;" />
+                                            }
+                                            else
+                                            {
+                                                <div style="width: 48px; height: 72px; background: #eee;"></div>
+                                            }
+                                            <div class="flex-grow-1">
+                                                <div class="fw-semibold">@candidate.Title</div>
+                                                <div class="small text-muted">
+                                                    @candidate.Author
+                                                    @if (candidate.FirstPublishYear.HasValue)
+                                                    {
+                                                        <span> &middot; first published @candidate.FirstPublishYear</span>
+                                                    }
+                                                    @if (candidate.EditionCount is int n && n > 0)
+                                                    {
+                                                        <span> &middot; @n edition@(n == 1 ? "" : "s") on file</span>
+                                                    }
+                                                </div>
+                                                @if (!string.IsNullOrEmpty(candidate.OpenLibraryUrl))
+                                                {
+                                                    <div class="small">
+                                                        <a href="@candidate.OpenLibraryUrl" target="_blank" rel="noopener">Show all editions on Open Library &rarr;</a>
+                                                    </div>
+                                                }
+                                            </div>
+                                            <button type="button" class="btn btn-sm btn-primary" @onclick="() => ApplyCandidateAsync(candidate)">
+                                                Use this
+                                            </button>
+                                        </div>
+                                    </div>
+                                }
+                            </div>
+                        }
+                    }
+
+                    @{
+                        var lookupMsg = VM.NoIsbnMode ? VM.SearchMessage : VM.LookupMessage;
+                    }
+                    @if (!string.IsNullOrEmpty(lookupMsg))
+                    {
+                        <div class="alert alert-info mt-3 mb-0 py-2">@lookupMsg</div>
                     }
                     @if (VM.SeriesSuggestion is not null && !VM.SeriesSuggestionDismissed)
                     {
@@ -83,6 +161,19 @@
         if (genrePicker is not null)
         {
             await VM.LookupAsync(genrePicker.ViewModel);
+        }
+    }
+
+    private async Task SearchAsync()
+    {
+        await VM.SearchAsync();
+    }
+
+    private async Task ApplyCandidateAsync(BookSearchCandidate candidate)
+    {
+        if (genrePicker is not null)
+        {
+            await VM.ApplyCandidateAsync(candidate, genrePicker.ViewModel);
         }
     }
 

--- a/BookTracker.Web/Services/BookLookupService.cs
+++ b/BookTracker.Web/Services/BookLookupService.cs
@@ -18,6 +18,50 @@ public class BookLookupService(HttpClient http, ILogger<BookLookupService> logge
             ?? await TryGoogleBooksAsync(cleanIsbn, ct);
     }
 
+    public async Task<IReadOnlyList<BookSearchCandidate>> SearchByTitleAuthorAsync(
+        string? title, string? author, CancellationToken ct)
+    {
+        var t = title?.Trim() ?? "";
+        var a = author?.Trim() ?? "";
+        if (t.Length == 0 && a.Length == 0)
+        {
+            return [];
+        }
+
+        try
+        {
+            var query = new List<string>();
+            if (t.Length > 0) query.Add($"title={Uri.EscapeDataString(t)}");
+            if (a.Length > 0) query.Add($"author={Uri.EscapeDataString(a)}");
+            // limit=10 keeps the UI manageable; fields= trims the response
+            // payload (Open Library's default includes hundreds of fields
+            // per row).
+            query.Add("limit=10");
+            query.Add("fields=key,title,author_name,first_publish_year,edition_count,cover_i");
+
+            var url = $"https://openlibrary.org/search.json?{string.Join("&", query)}";
+            var doc = await http.GetFromJsonAsync<OpenLibrarySearchResponse>(url, ct);
+            if (doc?.Docs is null) return [];
+
+            return doc.Docs
+                .Where(d => !string.IsNullOrWhiteSpace(d.Title))
+                .Select(d => new BookSearchCandidate(
+                    WorkKey: d.Key ?? "",
+                    Title: d.Title,
+                    Author: d.AuthorName is { Count: > 0 } ? string.Join(", ", d.AuthorName) : null,
+                    FirstPublishYear: d.FirstPublishYear,
+                    EditionCount: d.EditionCount,
+                    CoverUrl: d.CoverId is int id ? $"https://covers.openlibrary.org/b/id/{id}-M.jpg" : null,
+                    OpenLibraryUrl: string.IsNullOrEmpty(d.Key) ? null : $"https://openlibrary.org{d.Key}/editions"))
+                .ToList();
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Open Library title/author search failed for title={Title} author={Author}", t, a);
+            return [];
+        }
+    }
+
     private async Task<BookLookupResult?> TryOpenLibraryAsync(string isbn, CancellationToken ct)
     {
         try
@@ -157,5 +201,19 @@ public class BookLookupService(HttpClient http, ILogger<BookLookupService> logge
     {
         [JsonPropertyName("smallThumbnail")] public string? SmallThumbnail { get; set; }
         [JsonPropertyName("thumbnail")] public string? Thumbnail { get; set; }
+    }
+
+    private sealed class OpenLibrarySearchResponse
+    {
+        [JsonPropertyName("docs")] public List<OpenLibrarySearchDoc>? Docs { get; set; }
+    }
+    private sealed class OpenLibrarySearchDoc
+    {
+        [JsonPropertyName("key")] public string? Key { get; set; }
+        [JsonPropertyName("title")] public string? Title { get; set; }
+        [JsonPropertyName("author_name")] public List<string>? AuthorName { get; set; }
+        [JsonPropertyName("first_publish_year")] public int? FirstPublishYear { get; set; }
+        [JsonPropertyName("edition_count")] public int? EditionCount { get; set; }
+        [JsonPropertyName("cover_i")] public int? CoverId { get; set; }
     }
 }

--- a/BookTracker.Web/Services/BookSearchCandidate.cs
+++ b/BookTracker.Web/Services/BookSearchCandidate.cs
@@ -1,0 +1,15 @@
+namespace BookTracker.Web.Services;
+
+// One row in the title/author search results panel on the Add Book page.
+// Pre-1974 books predate ISBN, so the search has to surface enough hint
+// data for a human to disambiguate visually: cover, year, edition count.
+// OpenLibraryUrl is the "show all editions" escape hatch when the user
+// isn't sure which printing they're holding.
+public record BookSearchCandidate(
+    string WorkKey,
+    string? Title,
+    string? Author,
+    int? FirstPublishYear,
+    int? EditionCount,
+    string? CoverUrl,
+    string? OpenLibraryUrl);

--- a/BookTracker.Web/Services/IBookLookupService.cs
+++ b/BookTracker.Web/Services/IBookLookupService.cs
@@ -3,4 +3,11 @@ namespace BookTracker.Web.Services;
 public interface IBookLookupService
 {
     Task<BookLookupResult?> LookupByIsbnAsync(string isbn, CancellationToken ct);
+
+    // Used for pre-ISBN books (pre-1974). Returns up to ~10 work-level
+    // candidates from Open Library so the user can pick the right title
+    // visually. Title and author are both optional but at least one must
+    // be non-empty.
+    Task<IReadOnlyList<BookSearchCandidate>> SearchByTitleAuthorAsync(
+        string? title, string? author, CancellationToken ct);
 }

--- a/BookTracker.Web/ViewModels/BookAddViewModel.cs
+++ b/BookTracker.Web/ViewModels/BookAddViewModel.cs
@@ -20,6 +20,17 @@ public class BookAddViewModel(
     public bool LookingUp { get; private set; }
     public bool Saving { get; private set; }
 
+    // No-ISBN flow (web only — for pre-1974 books that predate ISBN).
+    // Toggling NoIsbnMode swaps the lookup panel from ISBN entry to a
+    // title/author search that returns work-level candidates from Open
+    // Library; selecting one prefills the form like an ISBN lookup would.
+    public bool NoIsbnMode { get; set; }
+    public string? SearchTitle { get; set; }
+    public string? SearchAuthor { get; set; }
+    public IReadOnlyList<BookSearchCandidate> SearchCandidates { get; private set; } = [];
+    public bool Searching { get; private set; }
+    public string? SearchMessage { get; private set; }
+
     public SeriesMatch? SeriesSuggestion { get; private set; }
     public bool SeriesSuggestionDismissed { get; set; }
 
@@ -65,6 +76,57 @@ public class BookAddViewModel(
         }
     }
 
+    public async Task SearchAsync()
+    {
+        SearchMessage = null;
+        SearchCandidates = [];
+
+        var t = SearchTitle?.Trim();
+        var a = SearchAuthor?.Trim();
+        if (string.IsNullOrEmpty(t) && string.IsNullOrEmpty(a))
+        {
+            SearchMessage = "Enter a title or author to search.";
+            return;
+        }
+
+        Searching = true;
+        try
+        {
+            SearchCandidates = await lookup.SearchByTitleAuthorAsync(t, a, CancellationToken.None);
+            if (SearchCandidates.Count == 0)
+            {
+                SearchMessage = "No matches found. Try different keywords or fill the form manually.";
+            }
+        }
+        finally
+        {
+            Searching = false;
+        }
+    }
+
+    public async Task ApplyCandidateAsync(BookSearchCandidate candidate, GenrePickerViewModel genrePicker)
+    {
+        if (string.IsNullOrWhiteSpace(BookInput.Title)) BookInput.Title = candidate.Title ?? "";
+        if (string.IsNullOrWhiteSpace(BookInput.Author)) BookInput.Author = candidate.Author ?? "";
+        if (string.IsNullOrWhiteSpace(BookInput.DefaultCoverArtUrl)) BookInput.DefaultCoverArtUrl = candidate.CoverUrl;
+        // first_publish_year is the WORK's first year, not necessarily this
+        // edition's print date — but it's a useful hint and the user will
+        // overwrite it from the copyright page.
+        if (EditionInput.DatePrinted is null && candidate.FirstPublishYear is int year)
+        {
+            EditionInput.DatePrinted = new DateOnly(year, 1, 1);
+        }
+
+        SearchMessage = $"Prefilled from Open Library. Fill in format, exact print date, and publisher from the book in hand.";
+
+        SeriesSuggestion = await seriesMatch.FindMatchAsync(candidate.Title, candidate.Author);
+        SeriesSuggestionDismissed = false;
+
+        // No genre auto-pick for the no-ISBN flow — search results don't
+        // carry subjects. User selects genres manually via the picker.
+        _ = genrePicker;
+    }
+
     public async Task<bool> SaveAsync(List<int> selectedGenreIds)
     {
         Saving = true;
@@ -103,7 +165,7 @@ public class BookAddViewModel(
                 [
                     new Edition
                     {
-                        Isbn = EditionInput.Isbn!.Trim(),
+                        Isbn = string.IsNullOrWhiteSpace(EditionInput.Isbn) ? null : EditionInput.Isbn.Trim(),
                         Format = EditionInput.Format,
                         DatePrinted = EditionInput.DatePrinted,
                         Publisher = publisher,

--- a/BookTracker.Web/ViewModels/EditionFormViewModel.cs
+++ b/BookTracker.Web/ViewModels/EditionFormViewModel.cs
@@ -22,7 +22,10 @@ public class EditionFormViewModel(IDbContextFactory<BookTrackerDbContext> dbFact
 
     public class EditionFormInput
     {
-        [Required, StringLength(20)]
+        // Optional to allow pre-1974 books with no ISBN. RegularExpression
+        // is skipped for null/empty values by default, so the regex only
+        // fires when something is entered.
+        [StringLength(20)]
         [RegularExpression(@"^(97(8|9))?\d{9}(\d|X|x)$", ErrorMessage = "Enter a valid 10- or 13-digit ISBN.")]
         public string? Isbn { get; set; }
 


### PR DESCRIPTION
Adds a "No ISBN (pre-1974 book)" toggle on the Add Book page that swaps the lookup panel from ISBN entry to a title/author search against Open Library. Results render as cards with cover, title, author, first publish year, and edition count, plus an "Show all editions on Open Library" escape link for visual disambiguation. Picking a candidate prefills the form (title/author/cover/year); format and exact print date are filled manually from the physical book in hand. Web-only — bulk add stays barcode-driven.

Schema: Edition.Isbn becomes nullable with a filtered unique index (WHERE Isbn IS NOT NULL), so any number of no-ISBN editions can coexist. EditionFormViewModel drops [Required] on Isbn (the regex still enforces a valid format when something is entered).

New BookSearchCandidate record + SearchByTitleAuthorAsync method on IBookLookupService, hitting Open Library's /search.json with a trimmed field set (limit=10, fields= avoids dragging back the hundreds of fields the default returns).

BookAddViewModel.SaveAsync now persists blank ISBN as null. Existing ISBN-based path is unchanged.

Tests: BookAddViewModelTests covers the search/empty-input/no-results paths, ApplyCandidateAsync prefill behaviour (and respect for already-filled fields), blank-ISBN-saves-as-null, and a sanity check that two no-ISBN editions can coexist (validates the filtered unique index is actually doing its job).

NOT UI-tested: the toggle/cards/dev-server flow wasn't exercised in a browser. Type-check and unit tests are green; the rendering should be checked manually.