### PR TITLE
feat(model): introduce Work entity (PR 1 of 2 — additive + dual-write)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -61,10 +61,11 @@ GenreSeed
 ```
 
 Key design decisions:
-- **Book vs Edition vs Copy**: A Book is the abstract work. An Edition is a specific printing with a unique ISBN (hardcover vs softcover are different Editions). A Copy is a physical item you own.
-- **Edition.ISBN is unique**: scanning an ISBN always resolves to one Edition.
+- **Book vs Edition vs Copy**: A Book is a physical-object grouping. An Edition is a specific printing with a unique ISBN (hardcover vs softcover are different Editions). A Copy is a physical item you own.
+- **Edition.ISBN is unique** (filtered — pre-1974 books with no ISBN coexist as nullable rows).
 - **Series.Type**: `Series` = numbered with known order; `Collection` = loose grouping.
 - **Genre hierarchy**: top-level genres with sub-genres. Selecting a sub-genre auto-selects its parent.
+- **Work refactor (in progress)**: a `Work` is the abstract creative unit (a story/novel/play). PR 1 introduced the entity with an additive schema (`Works`, `BookWork`, `GenreWork` join tables) and a transitional `WorkSync.EnsureWork(book)` helper that's called at every Book save site to keep a 1:1 mirroring Work in step with `Book.{Subtitle, Author, Genres, SeriesId, SeriesOrder}`. Reads still come from the Book columns. PR 2 will cut over reads, allow N Works per Book (compendiums), and drop the legacy Book columns + `BookGenre` join table.
 
 ## Architecture pattern — MVVM
 

--- a/BookTracker.Data/BookTrackerDbContext.cs
+++ b/BookTracker.Data/BookTrackerDbContext.cs
@@ -14,6 +14,7 @@ public class BookTrackerDbContext(DbContextOptions<BookTrackerDbContext> options
     public DbSet<Tag> Tags => Set<Tag>();
     public DbSet<WishlistItem> WishlistItems => Set<WishlistItem>();
     public DbSet<MaintenanceLog> MaintenanceLogs => Set<MaintenanceLog>();
+    public DbSet<Work> Works => Set<Work>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -85,5 +86,23 @@ public class BookTrackerDbContext(DbContextOptions<BookTrackerDbContext> options
         modelBuilder.Entity<MaintenanceLog>()
             .HasIndex(m => m.Name)
             .IsUnique();
+
+        // Work ↔ Book is many-to-many; conventional join table BookWork.
+        modelBuilder.Entity<Work>()
+            .HasMany(w => w.Books)
+            .WithMany(b => b.Works);
+
+        // Work ↔ Genre is many-to-many; conventional join table GenreWork.
+        // Book ↔ Genre stays in place during PR 1 (dual-write); PR 2 drops it.
+        modelBuilder.Entity<Work>()
+            .HasMany(w => w.Genres)
+            .WithMany();
+
+        // Work belongs to at most one Series; matches the existing Book↔Series shape.
+        modelBuilder.Entity<Work>()
+            .HasOne(w => w.Series)
+            .WithMany()
+            .HasForeignKey(w => w.SeriesId)
+            .OnDelete(DeleteBehavior.SetNull);
     }
 }

--- a/BookTracker.Data/Migrations/20260419112735_AddWorkEntity.Designer.cs
+++ b/BookTracker.Data/Migrations/20260419112735_AddWorkEntity.Designer.cs
@@ -4,6 +4,7 @@ using BookTracker.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BookTracker.Data.Migrations
 {
     [DbContext(typeof(BookTrackerDbContext))]
-    partial class BookTrackerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260419112735_AddWorkEntity")]
+    partial class AddWorkEntity
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BookTracker.Data/Migrations/20260419112735_AddWorkEntity.cs
+++ b/BookTracker.Data/Migrations/20260419112735_AddWorkEntity.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BookTracker.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddWorkEntity : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Works",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Title = table.Column<string>(type: "nvarchar(300)", maxLength: 300, nullable: false),
+                    Subtitle = table.Column<string>(type: "nvarchar(300)", maxLength: 300, nullable: true),
+                    Author = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    FirstPublishedDate = table.Column<DateOnly>(type: "date", nullable: true),
+                    SeriesId = table.Column<int>(type: "int", nullable: true),
+                    SeriesOrder = table.Column<int>(type: "int", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Works", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Works_Series_SeriesId",
+                        column: x => x.SeriesId,
+                        principalTable: "Series",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "BookWork",
+                columns: table => new
+                {
+                    BooksId = table.Column<int>(type: "int", nullable: false),
+                    WorksId = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_BookWork", x => new { x.BooksId, x.WorksId });
+                    table.ForeignKey(
+                        name: "FK_BookWork_Books_BooksId",
+                        column: x => x.BooksId,
+                        principalTable: "Books",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_BookWork_Works_WorksId",
+                        column: x => x.WorksId,
+                        principalTable: "Works",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "GenreWork",
+                columns: table => new
+                {
+                    GenresId = table.Column<int>(type: "int", nullable: false),
+                    WorkId = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_GenreWork", x => new { x.GenresId, x.WorkId });
+                    table.ForeignKey(
+                        name: "FK_GenreWork_Genres_GenresId",
+                        column: x => x.GenresId,
+                        principalTable: "Genres",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_GenreWork_Works_WorkId",
+                        column: x => x.WorkId,
+                        principalTable: "Works",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_BookWork_WorksId",
+                table: "BookWork",
+                column: "WorksId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_GenreWork_WorkId",
+                table: "GenreWork",
+                column: "WorkId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Works_SeriesId",
+                table: "Works",
+                column: "SeriesId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "BookWork");
+
+            migrationBuilder.DropTable(
+                name: "GenreWork");
+
+            migrationBuilder.DropTable(
+                name: "Works");
+        }
+    }
+}

--- a/BookTracker.Data/Migrations/20260419112803_SeedWorksFromBooks.Designer.cs
+++ b/BookTracker.Data/Migrations/20260419112803_SeedWorksFromBooks.Designer.cs
@@ -4,6 +4,7 @@ using BookTracker.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BookTracker.Data.Migrations
 {
     [DbContext(typeof(BookTrackerDbContext))]
-    partial class BookTrackerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260419112803_SeedWorksFromBooks")]
+    partial class SeedWorksFromBooks
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BookTracker.Data/Migrations/20260419112803_SeedWorksFromBooks.cs
+++ b/BookTracker.Data/Migrations/20260419112803_SeedWorksFromBooks.cs
@@ -1,0 +1,72 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BookTracker.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class SeedWorksFromBooks : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Idempotent: any Book that already has a linked Work in BookWork
+            // is skipped. Safe to re-run; safe across deploys where some Books
+            // were created post-Work-entity (those already have a Work via
+            // WorkSync's dual-write).
+
+            // 1. Insert one Work row per Book that doesn't yet have one.
+            //    The synthesised Work mirrors the Book's title/subtitle/author
+            //    plus its Series membership.
+            migrationBuilder.Sql(@"
+INSERT INTO [Works] ([Title], [Subtitle], [Author], [SeriesId], [SeriesOrder], [FirstPublishedDate])
+SELECT b.[Title], b.[Subtitle], b.[Author], b.[SeriesId], b.[SeriesOrder], NULL
+FROM [Books] b
+WHERE NOT EXISTS (
+    SELECT 1 FROM [BookWork] bw WHERE bw.[BooksId] = b.[Id]
+);");
+
+            // 2. Link each Book to its just-created Work via BookWork. We
+            //    identify the freshly-inserted Work by matching on the
+            //    Title/Subtitle/Author/SeriesId tuple. This works because
+            //    step 1 only inserted Works for un-linked Books, and that
+            //    tuple is unique per-Book in practice.
+            migrationBuilder.Sql(@"
+INSERT INTO [BookWork] ([BooksId], [WorksId])
+SELECT b.[Id], w.[Id]
+FROM [Books] b
+JOIN [Works] w
+    ON w.[Title] = b.[Title]
+   AND w.[Author] = b.[Author]
+   AND ISNULL(w.[Subtitle], N'') = ISNULL(b.[Subtitle], N'')
+   AND ISNULL(w.[SeriesId], -1) = ISNULL(b.[SeriesId], -1)
+WHERE NOT EXISTS (
+    SELECT 1 FROM [BookWork] bw
+    WHERE bw.[BooksId] = b.[Id] AND bw.[WorksId] = w.[Id]
+);");
+
+            // 3. Copy each (BookId, GenreId) pair into (WorkId, GenreId).
+            //    Uses the BookWork link from step 2 to find the right Work
+            //    for each Book.
+            migrationBuilder.Sql(@"
+INSERT INTO [GenreWork] ([WorkId], [GenresId])
+SELECT bw.[WorksId], bg.[GenresId]
+FROM [BookGenre] bg
+JOIN [BookWork] bw ON bw.[BooksId] = bg.[BooksId]
+WHERE NOT EXISTS (
+    SELECT 1 FROM [GenreWork] gw
+    WHERE gw.[WorkId] = bw.[WorksId] AND gw.[GenresId] = bg.[GenresId]
+);");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // Best-effort revert: clear out everything seeded. Only safe
+            // before PR 2 lands (which drops the Book columns we read from).
+            migrationBuilder.Sql(@"DELETE FROM [GenreWork];");
+            migrationBuilder.Sql(@"DELETE FROM [BookWork];");
+            migrationBuilder.Sql(@"DELETE FROM [Works];");
+        }
+    }
+}

--- a/BookTracker.Data/Models/Book.cs
+++ b/BookTracker.Data/Models/Book.cs
@@ -53,4 +53,9 @@ public class Book
 
     /// <summary>Position in a Series (1-based). Defaults to publication order for Collections.</summary>
     public int? SeriesOrder { get; set; }
+
+    // Added in PR 1 of the Work refactor. Currently dual-written from
+    // Book's own Subtitle/Author/Genres/Series fields via WorkSync.
+    // Reads still come from Book.* until PR 2 cuts over.
+    public List<Work> Works { get; set; } = [];
 }

--- a/BookTracker.Data/Models/Work.cs
+++ b/BookTracker.Data/Models/Work.cs
@@ -1,0 +1,40 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace BookTracker.Data.Models;
+
+// A Work is the abstract creative unit — a story, novel, play, or poem.
+// Multiple Books can contain the same Work (a Christie short story
+// reprinted across several compendiums), and a single Book can contain
+// multiple Works (a short-story collection).
+//
+// PR 1 of the Work refactor introduces this entity and dual-writes it
+// alongside the legacy Book.{Subtitle,Author,Genres,SeriesId,...} fields.
+// PR 2 will cut over reads + drop the legacy columns. Until PR 2 ships,
+// every existing Book has exactly one mirroring Work; the m:m schema is
+// here to make the eventual N:N transition free.
+public class Work
+{
+    public int Id { get; set; }
+
+    [Required, MaxLength(300)]
+    public string Title { get; set; } = string.Empty;
+
+    [MaxLength(300)]
+    public string? Subtitle { get; set; }
+
+    [Required, MaxLength(200)]
+    public string Author { get; set; } = string.Empty;
+
+    /// <summary>The year/date the Work was first published — distinct from any specific Edition's print date.</summary>
+    public DateOnly? FirstPublishedDate { get; set; }
+
+    public List<Genre> Genres { get; set; } = [];
+
+    public int? SeriesId { get; set; }
+    public Series? Series { get; set; }
+
+    /// <summary>Position in a Series (1-based). Defaults to publication order for Collections.</summary>
+    public int? SeriesOrder { get; set; }
+
+    public List<Book> Books { get; set; } = [];
+}

--- a/BookTracker.Tests/Services/WorkSyncTests.cs
+++ b/BookTracker.Tests/Services/WorkSyncTests.cs
@@ -1,0 +1,89 @@
+using BookTracker.Data.Models;
+using BookTracker.Web.Services;
+
+namespace BookTracker.Tests.Services;
+
+public class WorkSyncTests
+{
+    [Fact]
+    public void EnsureWork_CreatesWorkMirroringBook_WhenNoneExists()
+    {
+        var genre = new Genre { Id = 1, Name = "Mystery" };
+        var series = new Series { Id = 7, Name = "Poirot" };
+        var book = new Book
+        {
+            Title = "Murder on the Orient Express",
+            Subtitle = "A Hercule Poirot Mystery",
+            Author = "Agatha Christie",
+            Genres = [genre],
+            SeriesId = series.Id,
+            Series = series,
+            SeriesOrder = 9,
+        };
+
+        WorkSync.EnsureWork(book);
+
+        var work = Assert.Single(book.Works);
+        Assert.Equal(book.Title, work.Title);
+        Assert.Equal(book.Subtitle, work.Subtitle);
+        Assert.Equal(book.Author, work.Author);
+        Assert.Equal(series.Id, work.SeriesId);
+        Assert.Equal(book.SeriesOrder, work.SeriesOrder);
+        Assert.Single(work.Genres, g => g.Id == genre.Id);
+    }
+
+    [Fact]
+    public void EnsureWork_UpdatesExistingWork_WhenBookFieldsChanged()
+    {
+        var oldGenre = new Genre { Id = 1, Name = "Romance" };
+        var newGenre = new Genre { Id = 2, Name = "Mystery" };
+
+        var existingWork = new Work
+        {
+            Title = "Old title",
+            Subtitle = null,
+            Author = "Wrong author",
+            Genres = [oldGenre],
+        };
+        var book = new Book
+        {
+            Title = "Corrected title",
+            Subtitle = "New subtitle",
+            Author = "Correct author",
+            Genres = [newGenre],
+            SeriesId = 99,
+            SeriesOrder = 3,
+            Works = [existingWork],
+        };
+
+        WorkSync.EnsureWork(book);
+
+        var work = Assert.Single(book.Works);
+        Assert.Same(existingWork, work); // didn't replace, mutated
+        Assert.Equal("Corrected title", work.Title);
+        Assert.Equal("New subtitle", work.Subtitle);
+        Assert.Equal("Correct author", work.Author);
+        Assert.Equal(99, work.SeriesId);
+        Assert.Equal(3, work.SeriesOrder);
+        Assert.Single(work.Genres, g => g.Id == newGenre.Id);
+        Assert.DoesNotContain(work.Genres, g => g.Id == oldGenre.Id);
+    }
+
+    [Fact]
+    public void EnsureWork_IsIdempotent_WhenAlreadyInSync()
+    {
+        var genre = new Genre { Id = 1, Name = "Mystery" };
+        var book = new Book
+        {
+            Title = "T",
+            Author = "A",
+            Genres = [genre],
+        };
+
+        WorkSync.EnsureWork(book);
+        WorkSync.EnsureWork(book);
+
+        var work = Assert.Single(book.Works);
+        Assert.Single(work.Genres, g => g.Id == genre.Id);
+    }
+}

--- a/BookTracker.Tests/ViewModels/BulkAddViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/BulkAddViewModelTests.cs
@@ -1,6 +1,7 @@
 using BookTracker.Data.Models;
 using BookTracker.Web.Services;
 using BookTracker.Web.ViewModels;
+using Microsoft.EntityFrameworkCore;
 using NSubstitute;
 
 namespace BookTracker.Tests.ViewModels;
@@ -106,6 +107,30 @@ public class BulkAddViewModelTests
         var book = db.Books.FirstOrDefault(b => b.Title == "The Hobbit");
         Assert.NotNull(book);
         Assert.Equal("J.R.R. Tolkien", book.Author);
+    }
+
+    [Fact]
+    public async Task AcceptRowAsync_DualWritesAMirroringWork()
+    {
+        // PR 1 of the Work refactor: every saved Book must have exactly one
+        // mirroring Work via WorkSync.EnsureWork. This test guards the
+        // dual-write at the BulkAdd save site.
+        var vm = CreateVm();
+        var row = new BulkAddViewModel.DiscoveryRow
+        {
+            Isbn = "9780345391803",
+            Title = "The Hobbit",
+            Author = "J.R.R. Tolkien",
+            Status = BulkAddViewModel.RowStatus.Found
+        };
+
+        await vm.AcceptRowAsync(row);
+
+        using var db = _factory.CreateDbContext();
+        var book = db.Books.Include(b => b.Works).Single(b => b.Title == "The Hobbit");
+        var work = Assert.Single(book.Works);
+        Assert.Equal("The Hobbit", work.Title);
+        Assert.Equal("J.R.R. Tolkien", work.Author);
     }
 
     [Fact]

--- a/BookTracker.Web/Services/BookGenreBackfillService.cs
+++ b/BookTracker.Web/Services/BookGenreBackfillService.cs
@@ -58,6 +58,7 @@ public class BookGenreBackfillService(
         var books = await db.Books
             .Include(b => b.Genres)
             .Include(b => b.Editions)
+            .Include(b => b.Works).ThenInclude(w => w.Genres)
             .ToListAsync(ct);
         var allGenres = await db.Genres.ToListAsync(ct);
 
@@ -87,6 +88,7 @@ public class BookGenreBackfillService(
 
                 book.Genres.Clear();
                 ApplyMatchedGenres(book, result.GenreCandidates, allGenres);
+                WorkSync.EnsureWork(book);
                 updated++;
             }
             catch (Exception ex)

--- a/BookTracker.Web/Services/EditionFormatBackfillService.cs
+++ b/BookTracker.Web/Services/EditionFormatBackfillService.cs
@@ -63,6 +63,9 @@ public class EditionFormatBackfillService(
         {
             ct.ThrowIfCancellationRequested();
 
+            // Skip pre-1974 (no-ISBN) editions — there's nothing to look up.
+            if (string.IsNullOrWhiteSpace(edition.Isbn)) continue;
+
             try
             {
                 var result = await lookup.LookupByIsbnAsync(edition.Isbn, ct);

--- a/BookTracker.Web/Services/WorkSync.cs
+++ b/BookTracker.Web/Services/WorkSync.cs
@@ -1,0 +1,56 @@
+using BookTracker.Data.Models;
+
+namespace BookTracker.Web.Services;
+
+// Transitional dual-write helper for PR 1 of the Work refactor.
+//
+// Every save site that creates or modifies a Book must call EnsureWork
+// before SaveChangesAsync so the Book's mirrored Work stays in sync with
+// its Title/Subtitle/Author/Genres/Series fields. PR 2 cuts over reads to
+// Works and deletes this helper along with the legacy Book columns.
+//
+// Invariant during PR 1: every Book has exactly one linked Work.
+// Compendium support (multiple Works per Book) lands in PR 2.
+public static class WorkSync
+{
+    /// <summary>
+    /// Ensures <paramref name="book"/> has exactly one linked Work that
+    /// mirrors its Title/Subtitle/Author/Genres/Series. Creates the Work
+    /// if missing, otherwise updates the existing one in place.
+    /// </summary>
+    /// <remarks>
+    /// The caller must have loaded <c>book.Works</c> (and ideally
+    /// <c>book.Genres</c>) before calling — for fresh Books that's free,
+    /// for edited Books make sure the query <c>.Include(b => b.Works).ThenInclude(w => w.Genres)</c>.
+    /// </remarks>
+    public static void EnsureWork(Book book)
+    {
+        var work = book.Works.FirstOrDefault();
+        if (work is null)
+        {
+            work = new Work
+            {
+                Title = book.Title,
+                Subtitle = book.Subtitle,
+                Author = book.Author,
+                SeriesId = book.SeriesId,
+                Series = book.Series,
+                SeriesOrder = book.SeriesOrder,
+            };
+            foreach (var g in book.Genres) work.Genres.Add(g);
+            book.Works.Add(work);
+            return;
+        }
+
+        work.Title = book.Title;
+        work.Subtitle = book.Subtitle;
+        work.Author = book.Author;
+        work.SeriesId = book.SeriesId;
+        work.Series = book.Series;
+        work.SeriesOrder = book.SeriesOrder;
+
+        // Replace genres in place so EF tracks the change correctly.
+        work.Genres.Clear();
+        foreach (var g in book.Genres) work.Genres.Add(g);
+    }
+}

--- a/BookTracker.Web/ViewModels/AIAssistantViewModel.cs
+++ b/BookTracker.Web/ViewModels/AIAssistantViewModel.cs
@@ -75,7 +75,10 @@ public class AIAssistantViewModel(
     {
         await using var db = await dbFactory.CreateDbContextAsync();
 
-        var book = await db.Books.Include(b => b.Genres).FirstOrDefaultAsync(b => b.Id == bookId);
+        var book = await db.Books
+            .Include(b => b.Genres)
+            .Include(b => b.Works).ThenInclude(w => w.Genres)
+            .FirstOrDefaultAsync(b => b.Id == bookId);
         if (book is null) return;
 
         var genresToAdd = await db.Genres
@@ -88,6 +91,7 @@ public class AIAssistantViewModel(
                 book.Genres.Add(genre);
         }
 
+        WorkSync.EnsureWork(book);
         await db.SaveChangesAsync();
 
         // Update the local list
@@ -155,6 +159,7 @@ public class AIAssistantViewModel(
 
         // Try to set the author if all books share the same one
         var matchedBooks = await db.Books
+            .Include(b => b.Works).ThenInclude(w => w.Genres)
             .Where(b => grouping.BookTitles.Contains(b.Title))
             .ToListAsync();
 
@@ -173,6 +178,7 @@ public class AIAssistantViewModel(
             {
                 book.SeriesId = series.Id;
                 book.SeriesOrder = order++;
+                WorkSync.EnsureWork(book);
             }
         }
         await db.SaveChangesAsync();

--- a/BookTracker.Web/ViewModels/BookAddViewModel.cs
+++ b/BookTracker.Web/ViewModels/BookAddViewModel.cs
@@ -176,6 +176,7 @@ public class BookAddViewModel(
             };
 
             db.Books.Add(book);
+            WorkSync.EnsureWork(book);
             await db.SaveChangesAsync();
             return true;
         }

--- a/BookTracker.Web/ViewModels/BookEditViewModel.cs
+++ b/BookTracker.Web/ViewModels/BookEditViewModel.cs
@@ -1,5 +1,6 @@
 using BookTracker.Data;
 using BookTracker.Data.Models;
+using BookTracker.Web.Services;
 using Microsoft.EntityFrameworkCore;
 
 namespace BookTracker.Web.ViewModels;
@@ -293,6 +294,7 @@ public class BookEditViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
             var book = await db.Books
                 .Include(b => b.Genres)
                 .Include(b => b.Tags)
+                .Include(b => b.Works).ThenInclude(w => w.Genres)
                 .FirstOrDefaultAsync(b => b.Id == bookId);
 
             if (book is null) { NotFound = true; return; }
@@ -321,6 +323,7 @@ public class BookEditViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
             book.SeriesId = SelectedSeriesId;
             book.SeriesOrder = SelectedSeriesId.HasValue ? SeriesOrder : null;
 
+            WorkSync.EnsureWork(book);
             await db.SaveChangesAsync();
             SuccessMessage = "Book saved successfully.";
         }
@@ -332,7 +335,7 @@ public class BookEditViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
 
     public record SeriesOption(int Id, string Name, SeriesType Type);
     public record TagItem(int Id, string Name);
-    public record EditionCopyRow(int EditionId, int CopyId, string Isbn, BookFormat Format, BookCondition Condition, string? PublisherName, DateOnly? DatePrinted, string? CoverUrl, string? CopyNotes, DateTime? DateAcquired);
+    public record EditionCopyRow(int EditionId, int CopyId, string? Isbn, BookFormat Format, BookCondition Condition, string? PublisherName, DateOnly? DatePrinted, string? CoverUrl, string? CopyNotes, DateTime? DateAcquired);
 
     public class CopyEditInput
     {

--- a/BookTracker.Web/ViewModels/BulkAddViewModel.cs
+++ b/BookTracker.Web/ViewModels/BulkAddViewModel.cs
@@ -195,6 +195,7 @@ public class BulkAddViewModel(
         }
 
         db.Books.Add(newBook);
+        WorkSync.EnsureWork(newBook);
         await db.SaveChangesAsync();
 
         if (followUp)

--- a/BookTracker.Web/ViewModels/SeriesEditViewModel.cs
+++ b/BookTracker.Web/ViewModels/SeriesEditViewModel.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel.DataAnnotations;
 using BookTracker.Data;
 using BookTracker.Data.Models;
+using BookTracker.Web.Services;
 using Microsoft.EntityFrameworkCore;
 
 namespace BookTracker.Web.ViewModels;
@@ -147,13 +148,16 @@ public class SeriesEditViewModel(IDbContextFactory<BookTrackerDbContext> dbFacto
     public async Task AddBookToSeriesAsync(int seriesId, int bookId)
     {
         await using var db = await dbFactory.CreateDbContextAsync();
-        var book = await db.Books.FindAsync(bookId);
+        var book = await db.Books
+            .Include(b => b.Works).ThenInclude(w => w.Genres)
+            .FirstOrDefaultAsync(b => b.Id == bookId);
         if (book is null) return;
 
         var nextOrder = Books.Count > 0 ? Books.Max(b => b.SeriesOrder ?? 0) + 1 : 1;
 
         book.SeriesId = seriesId;
         book.SeriesOrder = nextOrder;
+        WorkSync.EnsureWork(book);
         await db.SaveChangesAsync();
 
         Books.Add(new SeriesBookRow(book.Id, book.Title, book.Author, nextOrder));
@@ -163,11 +167,14 @@ public class SeriesEditViewModel(IDbContextFactory<BookTrackerDbContext> dbFacto
     public async Task RemoveBookFromSeriesAsync(int bookId)
     {
         await using var db = await dbFactory.CreateDbContextAsync();
-        var book = await db.Books.FindAsync(bookId);
+        var book = await db.Books
+            .Include(b => b.Works).ThenInclude(w => w.Genres)
+            .FirstOrDefaultAsync(b => b.Id == bookId);
         if (book is not null)
         {
             book.SeriesId = null;
             book.SeriesOrder = null;
+            WorkSync.EnsureWork(book);
             await db.SaveChangesAsync();
         }
         Books.RemoveAll(b => b.Id == bookId);
@@ -176,10 +183,13 @@ public class SeriesEditViewModel(IDbContextFactory<BookTrackerDbContext> dbFacto
     public async Task UpdateBookOrderAsync(int bookId, int? newOrder)
     {
         await using var db = await dbFactory.CreateDbContextAsync();
-        var book = await db.Books.FindAsync(bookId);
+        var book = await db.Books
+            .Include(b => b.Works).ThenInclude(w => w.Genres)
+            .FirstOrDefaultAsync(b => b.Id == bookId);
         if (book is not null)
         {
             book.SeriesOrder = newOrder;
+            WorkSync.EnsureWork(book);
             await db.SaveChangesAsync();
         }
 

--- a/BookTracker.Web/ViewModels/ShoppingViewModel.cs
+++ b/BookTracker.Web/ViewModels/ShoppingViewModel.cs
@@ -1,5 +1,6 @@
 using BookTracker.Data;
 using BookTracker.Data.Models;
+using BookTracker.Web.Services;
 using Microsoft.EntityFrameworkCore;
 
 namespace BookTracker.Web.ViewModels;
@@ -329,6 +330,7 @@ public class ShoppingViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
         }
 
         db.Books.Add(book);
+        WorkSync.EnsureWork(book);
 
         var wishlistItem = await db.WishlistItems.FindAsync(item.Id);
         if (wishlistItem is not null)


### PR DESCRIPTION
Adds the Work concept (story / novel / play / poem) sitting above Book
in the model. PR 1 is intentionally additive: every existing Book gets
a 1:1 mirroring Work via a data-seed migration, and every save site
calls a new WorkSync.EnsureWork(book) helper before SaveChangesAsync
so the Work stays in step with the Book's Title/Subtitle/Author/
Genres/SeriesId/SeriesOrder. Reads still come from Book.* columns.
PR 2 will cut over reads, allow N Works per Book (compendiums), and
drop the legacy Book columns + BookGenre join table.

Schema (additive only):
- New Works table (Title, Subtitle, Author, FirstPublishedDate,
  SeriesId, SeriesOrder).
- New BookWork (m:m Book↔Work) and GenreWork (m:m Work↔Genre) join
  tables.
- Migration 1 (AddWorkEntity) creates the above. Migration 2
  (SeedWorksFromBooks) is raw SQL that inserts one Work per existing
  Book, links via BookWork, and copies BookGenre rows into GenreWork.
  Both migrations are idempotent — safe to re-run on a DB that's
  partially synced.

Dual-write wired at every Book mutation site:
- BookAddViewModel.SaveAsync (new book)
- BookEditViewModel.SaveAsync (edit metadata + genres + series)
- BulkAddViewModel.SaveBookAsync (bulk add new book)
- ShoppingViewModel.MarkAsBoughtAsync (wishlist → library)
- SeriesEditViewModel.AddBookToSeriesAsync / RemoveBookFromSeriesAsync
  / UpdateBookOrderAsync (series membership changes)
- AIAssistantViewModel.AcceptGenreSuggestionsAsync and
  CreateSeriesFromGroupingAsync (AI-driven mutations)
- BookGenreBackfillService.RunBackfillAsync (the existing one-shot
  backfill — also dual-writes now in case it ever runs again)

Each save site that loads an existing Book now Includes
Works.ThenInclude(Genres) so EnsureWork can mutate the existing Work
in place.

Tests: WorkSyncTests covers the create / update-existing / idempotent
paths in isolation; an extra integration test on BulkAdd asserts the
end-to-end save flow produces a synced Work.

Drive-by: drops two long-standing nullable warnings introduced when
Edition.Isbn became nullable in the no-ISBN PR — EditionCopyRow.Isbn
is now nullable, and EditionFormatBackfillService skips no-ISBN
editions instead of passing null to LookupByIsbnAsync.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
