### PR TITLE
fix(migration): make SeedWorksFromBooks 1:1 by construction

### DIFF
--- a/BookTracker.Data/Migrations/20260419112803_SeedWorksFromBooks.cs
+++ b/BookTracker.Data/Migrations/20260419112803_SeedWorksFromBooks.cs
@@ -14,49 +14,49 @@ namespace BookTracker.Data.Migrations
             // is skipped. Safe to re-run; safe across deploys where some Books
             // were created post-Work-entity (those already have a Work via
             // WorkSync's dual-write).
-
-            // 1. Insert one Work row per Book that doesn't yet have one.
-            //    The synthesised Work mirrors the Book's title/subtitle/author
-            //    plus its Series membership.
+            //
+            // The whole step runs as a single SQL batch so the @Mapping
+            // table-variable survives across the three statements. EF Core
+            // wraps the migration in a transaction by default so a failure
+            // anywhere rolls back to a clean state.
+            //
+            // Earlier shape used a Title/Author tuple JOIN to link Books to
+            // their newly-inserted Works. That over-matched whenever the
+            // library contained two Books with the same title (e.g. two
+            // separate printings of the same Christie novel entered under
+            // distinct ISBNs), producing duplicate (WorkId, GenresId) pairs
+            // in step 3 and a PK_GenreWork violation. The MERGE...OUTPUT
+            // pattern below maps each Book to a freshly-inserted Work
+            // 1:1 by construction, regardless of title duplication.
             migrationBuilder.Sql(@"
-INSERT INTO [Works] ([Title], [Subtitle], [Author], [SeriesId], [SeriesOrder], [FirstPublishedDate])
-SELECT b.[Title], b.[Subtitle], b.[Author], b.[SeriesId], b.[SeriesOrder], NULL
-FROM [Books] b
-WHERE NOT EXISTS (
-    SELECT 1 FROM [BookWork] bw WHERE bw.[BooksId] = b.[Id]
-);");
+DECLARE @Mapping TABLE (BookId INT, WorkId INT);
 
-            // 2. Link each Book to its just-created Work via BookWork. We
-            //    identify the freshly-inserted Work by matching on the
-            //    Title/Subtitle/Author/SeriesId tuple. This works because
-            //    step 1 only inserted Works for un-linked Books, and that
-            //    tuple is unique per-Book in practice.
-            migrationBuilder.Sql(@"
+MERGE INTO [Works] AS target
+USING (
+    SELECT b.[Id] AS BookId, b.[Title], b.[Subtitle], b.[Author],
+           b.[SeriesId], b.[SeriesOrder]
+    FROM [Books] b
+    WHERE NOT EXISTS (SELECT 1 FROM [BookWork] bw WHERE bw.[BooksId] = b.[Id])
+) AS source
+ON 1 = 0
+WHEN NOT MATCHED THEN
+    INSERT ([Title], [Subtitle], [Author], [SeriesId], [SeriesOrder], [FirstPublishedDate])
+    VALUES (source.[Title], source.[Subtitle], source.[Author],
+            source.[SeriesId], source.[SeriesOrder], NULL)
+OUTPUT source.BookId, inserted.[Id] INTO @Mapping (BookId, WorkId);
+
 INSERT INTO [BookWork] ([BooksId], [WorksId])
-SELECT b.[Id], w.[Id]
-FROM [Books] b
-JOIN [Works] w
-    ON w.[Title] = b.[Title]
-   AND w.[Author] = b.[Author]
-   AND ISNULL(w.[Subtitle], N'') = ISNULL(b.[Subtitle], N'')
-   AND ISNULL(w.[SeriesId], -1) = ISNULL(b.[SeriesId], -1)
-WHERE NOT EXISTS (
-    SELECT 1 FROM [BookWork] bw
-    WHERE bw.[BooksId] = b.[Id] AND bw.[WorksId] = w.[Id]
-);");
+SELECT BookId, WorkId FROM @Mapping;
 
-            // 3. Copy each (BookId, GenreId) pair into (WorkId, GenreId).
-            //    Uses the BookWork link from step 2 to find the right Work
-            //    for each Book.
-            migrationBuilder.Sql(@"
 INSERT INTO [GenreWork] ([WorkId], [GenresId])
-SELECT bw.[WorksId], bg.[GenresId]
-FROM [BookGenre] bg
-JOIN [BookWork] bw ON bw.[BooksId] = bg.[BooksId]
+SELECT DISTINCT m.WorkId, bg.[GenresId]
+FROM @Mapping m
+JOIN [BookGenre] bg ON bg.[BooksId] = m.BookId
 WHERE NOT EXISTS (
     SELECT 1 FROM [GenreWork] gw
-    WHERE gw.[WorkId] = bw.[WorksId] AND gw.[GenresId] = bg.[GenresId]
-);");
+    WHERE gw.[WorkId] = m.WorkId AND gw.[GenresId] = bg.[GenresId]
+);
+");
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Production deploy failed with PK_GenreWork violation (3, 495) because
the previous step-2 join matched Books to Works by Title/Subtitle/
Author/SeriesId tuple. Two Books with identical metadata (e.g. two
printings of the same Christie novel entered under separate ISBNs)
each linked to *both* freshly-inserted Works, then step 3's genre
copy produced duplicate (WorkId, GenresId) rows in a single SELECT.

Replaces the three-statement approach with a single MERGE...OUTPUT
batch that maps each unlinked Book to a freshly-inserted Work via a
@Mapping table-variable, then drives BookWork + GenreWork inserts
off that mapping. Each Book gets exactly one Work regardless of
title duplication. Adds DISTINCT on the GenreWork insert as a final
safety net.

The original migration was wrapped in a transaction that rolled back
on failure, so prod has no partial state — Works/BookWork/GenreWork
are empty and __EFMigrationsHistory has no SeedWorksFromBooks row.
Redeploying with the fixed body re-runs cleanly.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
