### PR TITLE
fix(ui): hide blazor-error-ui by default; keep OCR camera live across batch captures

### DIFF
--- a/BookTracker.Web/Components/Pages/Books/BulkAdd.razor
+++ b/BookTracker.Web/Components/Pages/Books/BulkAdd.razor
@@ -339,9 +339,9 @@
             VM.IsbnInput = isbn;
             await VM.AddIsbnAsync();
 
-            // Stop camera after successful capture
-            await JS.InvokeVoidAsync("PhotoCapture.stop");
-            photoActive = false;
+            // Camera stays live so the user can capture the next book in
+            // the batch without re-opening it. The "Cancel photo" button
+            // explicitly stops the stream when they're done.
         }
         catch (Exception ex)
         {

--- a/BookTracker.Web/wwwroot/css/site.css
+++ b/BookTracker.Web/wwwroot/css/site.css
@@ -8,6 +8,29 @@ html {
   }
 }
 
+/* Hidden by default; Blazor sets display:block on this element when an
+   unhandled circuit error occurs. Without this rule the div from
+   MainLayout.razor sits visible at the bottom of every page. */
+#blazor-error-ui {
+  background: lightyellow;
+  bottom: 0;
+  box-shadow: 0 -1px 2px rgba(0, 0, 0, 0.2);
+  box-sizing: border-box;
+  display: none;
+  left: 0;
+  padding: 0.6rem 1.25rem 0.7rem 1.25rem;
+  position: fixed;
+  width: 100%;
+  z-index: 1000;
+}
+
+#blazor-error-ui .dismiss {
+  cursor: pointer;
+  position: absolute;
+  right: 0.75rem;
+  top: 0.5rem;
+}
+
 .btn:focus, .btn:active:focus, .btn-link.nav-link:focus, .form-control:focus, .form-check-input:focus {
   box-shadow: 0 0 0 0.1rem white, 0 0 0 0.25rem #258cfb;
 }


### PR DESCRIPTION
Two unrelated UI fixes:

1. wwwroot/css/site.css was missing the standard #blazor-error-ui CSS
   rule, so the "An unhandled error has occurred" div from
   MainLayout.razor sat visible at the bottom of every page on both
   web and mobile. Adds the conventional rule (display:none by
   default; Blazor flips it to display:block when a circuit error
   actually fires) plus a small style for the dismiss button.

2. BulkAdd's photo OCR flow stopped the camera after every successful
   capture. Drew batches photo captures (the no-barcode ones get done
   together at the end of a session), so re-opening the camera per
   book was friction. Removes the stop-after-capture so the camera
   stays live until "Cancel photo" is clicked.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
