### PR TITLE
feat(library): group-by Author / Genre / Series with collapsible accordion

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -112,7 +112,7 @@ A short-lived context is created per operation. Never inject `DbContext` directl
 | Route | Page | Purpose |
 |-------|------|---------|
 | `/` | Home | Dashboard — book count, author/genre stats |
-| `/books` | Library | Filterable book list (search, category, genre, tag, author). Desktop table + mobile cards. |
+| `/books` | Library | Filterable book list (search, category, genre, tag, author). Group-by picker (Author / Genre / Series / None) renders the books as a collapsible accordion of groups, each with its own paginated book list (lazy-loaded on first expand). Filters reduce within groups. Desktop table + mobile cards. |
 | `/books/add` | Add Book | ISBN lookup + manual entry. Creates Book + Edition + Copy. Series suggestion after lookup. |
 | `/books/{id}/edit` | Edit Book | Edit metadata, genres, tags, series assignment. Manage editions and copies. Delete book. |
 | `/books/bulk-add` | Bulk Add | Rapid ISBN entry (text or barcode scanner). Discovery grid with async lookup, accept/follow-up, duplicate detection. |

--- a/BookTracker.Tests/ViewModels/BookListViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/BookListViewModelTests.cs
@@ -1,0 +1,157 @@
+using BookTracker.Data.Models;
+using BookTracker.Web.ViewModels;
+
+namespace BookTracker.Tests.ViewModels;
+
+// Focused on the grouping behaviour added with the library-groupings PR.
+// The flat-list path is exercised indirectly elsewhere; here we cover the
+// new GroupBy enum + canonical-author rollup + (no genre)/(no series)
+// trailing buckets.
+public class BookListViewModelTests
+{
+    private static async Task SeedSampleLibraryAsync(TestDbContextFactory factory)
+    {
+        using var db = factory.CreateDbContext();
+
+        // Authors: Stephen King canonical, Richard Bachman as alias.
+        var king = new Author { Name = "Stephen King" };
+        db.Authors.Add(king);
+        await db.SaveChangesAsync();
+
+        var bachman = new Author { Name = "Richard Bachman", CanonicalAuthorId = king.Id };
+        var christie = new Author { Name = "Agatha Christie" };
+        db.Authors.AddRange(bachman, christie);
+
+        var horror = new Genre { Name = "Horror" };
+        var mystery = new Genre { Name = "Mystery" };
+        db.Genres.AddRange(horror, mystery);
+
+        var poirot = new Series { Name = "Hercule Poirot", Type = SeriesType.Collection };
+        db.Series.Add(poirot);
+
+        db.Books.AddRange(
+            new Book
+            {
+                Title = "Carrie",
+                Works = [new Work { Title = "Carrie", Author = king, Genres = [horror] }]
+            },
+            new Book
+            {
+                Title = "The Long Walk",
+                Works = [new Work { Title = "The Long Walk", Author = bachman, Genres = [horror] }]
+            },
+            new Book
+            {
+                Title = "Murder on the Orient Express",
+                Works = [new Work { Title = "Murder on the Orient Express", Author = christie, Genres = [mystery], Series = poirot, SeriesOrder = 9 }]
+            },
+            new Book
+            {
+                // No genre, no series — exercises the trailing buckets.
+                Title = "Mystery Book Without Tags",
+                Works = [new Work { Title = "Mystery Book Without Tags", Author = christie }]
+            });
+
+        await db.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task GroupByAuthor_RollsAliasesUnderCanonical()
+    {
+        var factory = new TestDbContextFactory();
+        await SeedSampleLibraryAsync(factory);
+
+        var vm = new BookListViewModel(factory) { SelectedGroupBy = LibraryGroupBy.Author };
+        await vm.InitializeAsync();
+
+        // Christie has 2 books; King has 2 (Carrie + Bachman's The Long Walk
+        // rolled up). Expect exactly two author groups, no Bachman row.
+        Assert.Equal(2, vm.Groups.Count);
+        Assert.Contains(vm.Groups, g => g.Label == "Stephen King" && g.Count == 2);
+        Assert.Contains(vm.Groups, g => g.Label == "Agatha Christie" && g.Count == 2);
+        Assert.DoesNotContain(vm.Groups, g => g.Label == "Richard Bachman");
+    }
+
+    [Fact]
+    public async Task GroupByGenre_AppendsNoGenreBucket()
+    {
+        var factory = new TestDbContextFactory();
+        await SeedSampleLibraryAsync(factory);
+
+        var vm = new BookListViewModel(factory) { SelectedGroupBy = LibraryGroupBy.Genre };
+        await vm.InitializeAsync();
+
+        // Horror: 2 (Carrie, The Long Walk). Mystery: 1 (Orient Express).
+        // Plus the no-genre book in the trailing "(no genre)" bucket.
+        Assert.Contains(vm.Groups, g => g.Label == "Horror" && g.Count == 2);
+        Assert.Contains(vm.Groups, g => g.Label == "Mystery" && g.Count == 1);
+        Assert.Contains(vm.Groups, g => g.Label == "(no genre)" && g.Count == 1);
+        // The no-genre bucket should be last.
+        Assert.Equal("(no genre)", vm.Groups.Last().Label);
+    }
+
+    [Fact]
+    public async Task GroupByCollection_AppendsNoSeriesBucket()
+    {
+        var factory = new TestDbContextFactory();
+        await SeedSampleLibraryAsync(factory);
+
+        var vm = new BookListViewModel(factory) { SelectedGroupBy = LibraryGroupBy.Collection };
+        await vm.InitializeAsync();
+
+        Assert.Contains(vm.Groups, g => g.Label == "Hercule Poirot" && g.Count == 1);
+        Assert.Contains(vm.Groups, g => g.Label == "(no series)" && g.Count == 3);
+        Assert.Equal("(no series)", vm.Groups.Last().Label);
+    }
+
+    [Fact]
+    public async Task ToggleGroupAsync_ExpandsAndLoadsBooks()
+    {
+        var factory = new TestDbContextFactory();
+        await SeedSampleLibraryAsync(factory);
+
+        var vm = new BookListViewModel(factory) { SelectedGroupBy = LibraryGroupBy.Author };
+        await vm.InitializeAsync();
+
+        var kingGroup = vm.Groups.First(g => g.Label == "Stephen King");
+        await vm.ToggleGroupAsync(kingGroup.Key);
+
+        Assert.Contains(kingGroup.Key, vm.ExpandedGroupKeys);
+        var loaded = vm.LoadedGroups[kingGroup.Key];
+        Assert.Equal(2, loaded.TotalCount);
+        // Includes the Bachman alias title.
+        Assert.Contains(loaded.Books, b => b.Title == "The Long Walk");
+        Assert.Contains(loaded.Books, b => b.Title == "Carrie");
+
+        // Toggling again collapses without reloading.
+        await vm.ToggleGroupAsync(kingGroup.Key);
+        Assert.DoesNotContain(kingGroup.Key, vm.ExpandedGroupKeys);
+    }
+
+    [Fact]
+    public async Task GroupByGenre_GenreFilterReducesGroupsAndCounts()
+    {
+        var factory = new TestDbContextFactory();
+        await SeedSampleLibraryAsync(factory);
+
+        Genre mystery;
+        using (var db = factory.CreateDbContext())
+        {
+            mystery = db.Genres.Single(g => g.Name == "Mystery");
+        }
+
+        var vm = new BookListViewModel(factory)
+        {
+            SelectedGroupBy = LibraryGroupBy.Genre,
+            SelectedGenreId = mystery.Id,
+        };
+        await vm.InitializeAsync();
+
+        // Filtering to Mystery should leave only the Mystery group; no
+        // (no genre) trailing bucket because the no-genre book doesn't
+        // pass the filter.
+        Assert.Single(vm.Groups);
+        Assert.Equal("Mystery", vm.Groups[0].Label);
+        Assert.Equal(1, vm.Groups[0].Count);
+    }
+}

--- a/BookTracker.Web/Components/Pages/Books/List.razor
+++ b/BookTracker.Web/Components/Pages/Books/List.razor
@@ -26,6 +26,15 @@
             <div class="@FilterPanelCss">
                 <div class="row g-3 align-items-end">
                     <div class="col-6 col-md">
+                        <label class="form-label small text-muted">Group by</label>
+                        <select class="form-select" @bind="GroupBySelected" @bind:after="ChangeGroupingAsync">
+                            <option value="@LibraryGroupBy.Author">Author</option>
+                            <option value="@LibraryGroupBy.Genre">Genre</option>
+                            <option value="@LibraryGroupBy.Collection">Series / Collection</option>
+                            <option value="@LibraryGroupBy.None">None (flat list)</option>
+                        </select>
+                    </div>
+                    <div class="col-6 col-md">
                         <label class="form-label small text-muted">Category</label>
                         <select class="form-select" @bind="VM.SelectedCategory" @bind:after="() => VM.ApplyFiltersAsync()">
                             <option value="">All</option>
@@ -78,151 +87,124 @@
 @if (VM.Loading)
 {
     <div class="text-center py-5">
-        <div class="spinner-border" role="status">
-            <span class="visually-hidden">Loading...</span>
-        </div>
+        <div class="spinner-border" role="status"><span class="visually-hidden">Loading...</span></div>
     </div>
 }
-else if (VM.Books.Count == 0)
+else if (VM.SelectedGroupBy == LibraryGroupBy.None)
 {
-    <div class="text-center py-5 text-muted">
-        <p class="mb-2">No books found.</p>
-        <a href="/books/add" class="btn btn-primary btn-sm">Add your first book</a>
-    </div>
+    @* Flat list — original behaviour *@
+    @if (VM.Books.Count == 0)
+    {
+        <div class="text-center py-5 text-muted">
+            <p class="mb-2">No books found.</p>
+            <a href="/books/add" class="btn btn-primary btn-sm">Add your first book</a>
+        </div>
+    }
+    else
+    {
+        @RenderBooks(VM.Books)
+
+        @if (VM.TotalPages > 1)
+        {
+            <nav aria-label="Book list pagination" class="mt-3">
+                <ul class="pagination pagination-sm justify-content-center">
+                    <li class="page-item @(VM.CurrentPage <= 1 ? "disabled" : "")">
+                        <button class="page-link" @onclick="() => VM.GoToPageAsync(VM.CurrentPage - 1)" disabled="@(VM.CurrentPage <= 1)">Prev</button>
+                    </li>
+                    @for (int p = 1; p <= VM.TotalPages; p++)
+                    {
+                        var pageNum = p;
+                        <li class="page-item @(pageNum == VM.CurrentPage ? "active" : "")">
+                            <button class="page-link" @onclick="() => VM.GoToPageAsync(pageNum)">@(pageNum)</button>
+                        </li>
+                    }
+                    <li class="page-item @(VM.CurrentPage >= VM.TotalPages ? "disabled" : "")">
+                        <button class="page-link" @onclick="() => VM.GoToPageAsync(VM.CurrentPage + 1)" disabled="@(VM.CurrentPage >= VM.TotalPages)">Next</button>
+                    </li>
+                </ul>
+            </nav>
+        }
+
+        <div class="text-center text-muted small mb-3">
+            Showing @((VM.CurrentPage - 1) * BookListViewModel.PageSize + 1)–@Math.Min(VM.CurrentPage * BookListViewModel.PageSize, VM.TotalCount) of @VM.TotalCount books
+        </div>
+    }
 }
 else
 {
-    @* Desktop table — hidden on mobile *@
-    <div class="d-none d-md-block table-responsive">
-        <table class="table table-hover align-middle">
-            <thead class="table-light">
-                <tr>
-                    <th style="width: 60px;"></th>
-                    <th>Title</th>
-                    <th>Author</th>
-                    <th>Genres</th>
-                    <th>Tags</th>
-                    <th>Status</th>
-                    <th style="width: 110px;">Rating</th>
-                </tr>
-            </thead>
-            <tbody>
-                @foreach (var book in VM.Books)
-                {
-                    <tr role="button" @onclick="() => NavigateToEdit(book.Id)" style="cursor: pointer;">
-                        <td>
-                            @if (!string.IsNullOrWhiteSpace(book.CoverUrl))
-                            {
-                                <img src="@book.CoverUrl" alt="" class="rounded" style="width: 40px; height: 56px; object-fit: cover;" />
-                            }
-                            else
-                            {
-                                <div class="rounded bg-light d-flex align-items-center justify-content-center" style="width: 40px; height: 56px;">
-                                    <span class="text-muted small">--</span>
-                                </div>
-                            }
-                        </td>
-                        <td>
-                            <div class="fw-semibold">@book.Title</div>
-                            @if (!string.IsNullOrWhiteSpace(book.Subtitle))
-                            {
-                                <div class="text-muted small">@book.Subtitle</div>
-                            }
-                        </td>
-                        <td>@book.Author</td>
-                        <td>
-                            @foreach (var genre in book.Genres)
-                            {
-                                <span class="badge bg-light text-dark border me-1 mb-1">@genre</span>
-                            }
-                        </td>
-                        <td>
-                            @foreach (var tag in book.Tags)
-                            {
-                                <span class="badge bg-info text-dark me-1 mb-1">@tag</span>
-                            }
-                        </td>
-                        <td>
-                            <span class="badge @BookListViewModel.StatusBadgeClass(book.Status)">@book.Status</span>
-                        </td>
-                        <td>
-                            @for (int i = 1; i <= 5; i++)
-                            {
-                                var filled = i <= book.Rating;
-                                <span class="@(filled ? "text-warning" : "text-muted")" style="font-size: 0.85rem;">&#9733;</span>
-                            }
-                        </td>
-                    </tr>
-                }
-            </tbody>
-        </table>
-    </div>
-
-    @* Mobile card layout — hidden on desktop *@
-    <div class="d-md-none">
-        @foreach (var book in VM.Books)
-        {
-            <div class="book-card-mobile d-flex gap-3 align-items-start" @onclick="() => NavigateToEdit(book.Id)">
-                @if (!string.IsNullOrWhiteSpace(book.CoverUrl))
-                {
-                    <img src="@book.CoverUrl" alt="" class="rounded flex-shrink-0" style="width: 48px; height: 68px; object-fit: cover;" />
-                }
-                else
-                {
-                    <div class="rounded bg-light d-flex align-items-center justify-content-center flex-shrink-0" style="width: 48px; height: 68px;">
-                        <span class="text-muted small">--</span>
-                    </div>
-                }
-                <div class="flex-grow-1 min-width-0">
-                    <div class="fw-semibold text-truncate">@book.Title</div>
-                    <div class="text-muted small">@book.Author</div>
-                    <div class="mt-1 d-flex flex-wrap gap-1 align-items-center">
-                        <span class="badge @BookListViewModel.StatusBadgeClass(book.Status)">@book.Status</span>
-                        @for (int i = 1; i <= 5; i++)
-                        {
-                            var filled = i <= book.Rating;
-                            <span class="@(filled ? "text-warning" : "text-muted")" style="font-size: 0.75rem;">&#9733;</span>
-                        }
-                    </div>
-                </div>
-            </div>
-        }
-    </div>
-
-    @if (VM.TotalPages > 1)
+    @* Grouped accordion view *@
+    @if (VM.Groups.Count == 0)
     {
-        <nav aria-label="Book list pagination" class="mt-3">
-            <ul class="pagination pagination-sm justify-content-center">
-                <li class="page-item @(VM.CurrentPage <= 1 ? "disabled" : "")">
-                    <button class="page-link" @onclick="() => VM.GoToPageAsync(VM.CurrentPage - 1)" disabled="@(VM.CurrentPage <= 1)">Prev</button>
-                </li>
-                @for (int p = 1; p <= VM.TotalPages; p++)
-                {
-                    var pageNum = p;
-                    <li class="page-item @(pageNum == VM.CurrentPage ? "active" : "")">
-                        <button class="page-link" @onclick="() => VM.GoToPageAsync(pageNum)">@(pageNum)</button>
-                    </li>
-                }
-                <li class="page-item @(VM.CurrentPage >= VM.TotalPages ? "disabled" : "")">
-                    <button class="page-link" @onclick="() => VM.GoToPageAsync(VM.CurrentPage + 1)" disabled="@(VM.CurrentPage >= VM.TotalPages)">Next</button>
-                </li>
-            </ul>
-        </nav>
+        <div class="text-center py-5 text-muted">
+            <p class="mb-2">No books found.</p>
+            <a href="/books/add" class="btn btn-primary btn-sm">Add your first book</a>
+        </div>
     }
+    else
+    {
+        <div class="accordion">
+            @foreach (var group in VM.Groups)
+            {
+                var isOpen = VM.ExpandedGroupKeys.Contains(group.Key);
+                var loaded = VM.LoadedGroups.GetValueOrDefault(group.Key);
+                <div class="accordion-item">
+                    <h2 class="accordion-header">
+                        <button class="accordion-button @(isOpen ? "" : "collapsed")" type="button" @onclick="() => VM.ToggleGroupAsync(group.Key)">
+                            <span class="fw-semibold">@group.Label</span>
+                            <span class="badge bg-light text-dark border ms-2">@group.Count book@(group.Count == 1 ? "" : "s")</span>
+                        </button>
+                    </h2>
+                    @if (isOpen)
+                    {
+                        <div class="accordion-collapse collapse show">
+                            <div class="accordion-body p-0">
+                                @if (loaded is null)
+                                {
+                                    <div class="text-center py-3">
+                                        <div class="spinner-border spinner-border-sm" role="status"><span class="visually-hidden">Loading...</span></div>
+                                    </div>
+                                }
+                                else
+                                {
+                                    @RenderBooks(loaded.Books)
 
-    <div class="text-center text-muted small mb-3">
-        Showing @((VM.CurrentPage - 1) * BookListViewModel.PageSize + 1)–@Math.Min(VM.CurrentPage * BookListViewModel.PageSize, VM.TotalCount) of @VM.TotalCount books
-    </div>
+                                    @if (loaded.TotalPages > 1)
+                                    {
+                                        <nav class="d-flex justify-content-center py-2 border-top">
+                                            <ul class="pagination pagination-sm mb-0">
+                                                <li class="page-item @(loaded.Page <= 1 ? "disabled" : "")">
+                                                    <button class="page-link" @onclick="() => VM.LoadGroupBooksAsync(group.Key, loaded.Page - 1)" disabled="@(loaded.Page <= 1)">Prev</button>
+                                                </li>
+                                                <li class="page-item disabled"><span class="page-link">@loaded.Page / @loaded.TotalPages</span></li>
+                                                <li class="page-item @(loaded.Page >= loaded.TotalPages ? "disabled" : "")">
+                                                    <button class="page-link" @onclick="() => VM.LoadGroupBooksAsync(group.Key, loaded.Page + 1)" disabled="@(loaded.Page >= loaded.TotalPages)">Next</button>
+                                                </li>
+                                            </ul>
+                                        </nav>
+                                    }
+                                }
+                            </div>
+                        </div>
+                    }
+                </div>
+            }
+        </div>
+    }
 }
 
 @code {
     private bool showFilters;
+    private LibraryGroupBy GroupBySelected { get; set; } = LibraryGroupBy.Author;
 
     private string FilterPanelCss => showFilters
         ? "col-12 mt-2 d-md-contents"
         : "col-12 mt-2 d-none d-md-contents";
 
-    protected override async Task OnInitializedAsync() => await VM.InitializeAsync();
+    protected override async Task OnInitializedAsync()
+    {
+        await VM.InitializeAsync();
+        GroupBySelected = VM.SelectedGroupBy;
+    }
 
     private async Task HandleSearchKeyUp(KeyboardEventArgs e)
     {
@@ -230,5 +212,110 @@ else
             await VM.ApplyFiltersAsync();
     }
 
+    private async Task ChangeGroupingAsync()
+    {
+        await VM.ChangeGroupingAsync(GroupBySelected);
+    }
+
     private void NavigateToEdit(int bookId) => Nav.NavigateTo($"/books/{bookId}/edit");
+
+    private RenderFragment RenderBooks(IReadOnlyList<BookListViewModel.BookListItem> books) =>
+    @<text>
+        @* Desktop table — hidden on mobile *@
+        <div class="d-none d-md-block table-responsive">
+            <table class="table table-hover align-middle mb-0">
+                <thead class="table-light">
+                    <tr>
+                        <th style="width: 60px;"></th>
+                        <th>Title</th>
+                        <th>Author</th>
+                        <th>Genres</th>
+                        <th>Tags</th>
+                        <th>Status</th>
+                        <th style="width: 110px;">Rating</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var book in books)
+                    {
+                        <tr role="button" @onclick="() => NavigateToEdit(book.Id)" style="cursor: pointer;">
+                            <td>
+                                @if (!string.IsNullOrWhiteSpace(book.CoverUrl))
+                                {
+                                    <img src="@book.CoverUrl" alt="" class="rounded" style="width: 40px; height: 56px; object-fit: cover;" />
+                                }
+                                else
+                                {
+                                    <div class="rounded bg-light d-flex align-items-center justify-content-center" style="width: 40px; height: 56px;">
+                                        <span class="text-muted small">--</span>
+                                    </div>
+                                }
+                            </td>
+                            <td>
+                                <div class="fw-semibold">@book.Title</div>
+                                @if (!string.IsNullOrWhiteSpace(book.Subtitle))
+                                {
+                                    <div class="text-muted small">@book.Subtitle</div>
+                                }
+                            </td>
+                            <td>@book.Author</td>
+                            <td>
+                                @foreach (var genre in book.Genres)
+                                {
+                                    <span class="badge bg-light text-dark border me-1 mb-1">@genre</span>
+                                }
+                            </td>
+                            <td>
+                                @foreach (var tag in book.Tags)
+                                {
+                                    <span class="badge bg-info text-dark me-1 mb-1">@tag</span>
+                                }
+                            </td>
+                            <td>
+                                <span class="badge @BookListViewModel.StatusBadgeClass(book.Status)">@book.Status</span>
+                            </td>
+                            <td>
+                                @for (int i = 1; i <= 5; i++)
+                                {
+                                    var filled = i <= book.Rating;
+                                    <span class="@(filled ? "text-warning" : "text-muted")" style="font-size: 0.85rem;">&#9733;</span>
+                                }
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+
+        @* Mobile card layout — hidden on desktop *@
+        <div class="d-md-none">
+            @foreach (var book in books)
+            {
+                <div class="book-card-mobile d-flex gap-3 align-items-start" @onclick="() => NavigateToEdit(book.Id)">
+                    @if (!string.IsNullOrWhiteSpace(book.CoverUrl))
+                    {
+                        <img src="@book.CoverUrl" alt="" class="rounded flex-shrink-0" style="width: 48px; height: 68px; object-fit: cover;" />
+                    }
+                    else
+                    {
+                        <div class="rounded bg-light d-flex align-items-center justify-content-center flex-shrink-0" style="width: 48px; height: 68px;">
+                            <span class="text-muted small">--</span>
+                        </div>
+                    }
+                    <div class="flex-grow-1 min-width-0">
+                        <div class="fw-semibold text-truncate">@book.Title</div>
+                        <div class="text-muted small">@book.Author</div>
+                        <div class="mt-1 d-flex flex-wrap gap-1 align-items-center">
+                            <span class="badge @BookListViewModel.StatusBadgeClass(book.Status)">@book.Status</span>
+                            @for (int i = 1; i <= 5; i++)
+                            {
+                                var filled = i <= book.Rating;
+                                <span class="@(filled ? "text-warning" : "text-muted")" style="font-size: 0.75rem;">&#9733;</span>
+                            }
+                        </div>
+                    </div>
+                </div>
+            }
+        </div>
+    </text>;
 }

--- a/BookTracker.Web/ViewModels/BookListViewModel.cs
+++ b/BookTracker.Web/ViewModels/BookListViewModel.cs
@@ -4,15 +4,27 @@ using Microsoft.EntityFrameworkCore;
 
 namespace BookTracker.Web.ViewModels;
 
+public enum LibraryGroupBy { None, Author, Genre, Collection }
+
 public class BookListViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory)
 {
     public const int PageSize = 20;
 
     public bool Loading { get; private set; } = true;
+
+    // Flat list (used only when GroupBy == None).
     public List<BookListItem> Books { get; private set; } = [];
     public int TotalCount { get; private set; }
     public int CurrentPage { get; private set; } = 1;
     public int TotalPages { get; private set; }
+
+    // Grouped view state. The group list is loaded up front (with counts)
+    // and rendered as a collapsible accordion. Each group's books are
+    // fetched lazily on first expand and paged independently.
+    public LibraryGroupBy SelectedGroupBy { get; set; } = LibraryGroupBy.Author;
+    public List<GroupRow> Groups { get; private set; } = [];
+    public Dictionary<string, GroupBooks> LoadedGroups { get; } = [];
+    public HashSet<string> ExpandedGroupKeys { get; } = [];
 
     public string SearchTerm { get; set; } = "";
     public string SelectedCategory { get; set; } = "";
@@ -27,7 +39,19 @@ public class BookListViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
     public async Task InitializeAsync()
     {
         await LoadFilterOptionsAsync();
-        await LoadBooksAsync();
+        await ReloadAsync();
+    }
+
+    public async Task ReloadAsync()
+    {
+        if (SelectedGroupBy == LibraryGroupBy.None)
+        {
+            await LoadBooksAsync();
+        }
+        else
+        {
+            await LoadGroupsAsync();
+        }
     }
 
     private async Task LoadFilterOptionsAsync()
@@ -64,14 +88,207 @@ public class BookListViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
     public async Task LoadBooksAsync()
     {
         Loading = true;
-
         await using var db = await dbFactory.CreateDbContextAsync();
 
-        IQueryable<Book> query = db.Books
-            .Include(b => b.Tags)
-            .Include(b => b.Works).ThenInclude(w => w.Genres)
-            .Include(b => b.Works).ThenInclude(w => w.Author);
+        var query = ApplyFilters(BookQueryWithIncludes(db));
 
+        TotalCount = await query.CountAsync();
+        TotalPages = Math.Max(1, (int)Math.Ceiling(TotalCount / (double)PageSize));
+        if (CurrentPage > TotalPages) CurrentPage = TotalPages;
+
+        var raw = await query
+            .OrderByDescending(b => b.DateAdded)
+            .Skip((CurrentPage - 1) * PageSize)
+            .Take(PageSize)
+            .ToListAsync();
+
+        Books = raw.Select(ToBookListItem).ToList();
+        Loading = false;
+    }
+
+    public async Task LoadGroupsAsync()
+    {
+        Loading = true;
+        Groups = [];
+        LoadedGroups.Clear();
+        ExpandedGroupKeys.Clear();
+
+        await using var db = await dbFactory.CreateDbContextAsync();
+        var filtered = ApplyFilters(BookQueryWithIncludes(db));
+
+        // Each grouping reduces the filtered set into (Key, Label, Count)
+        // rows. Books with no grouping value (no genre, no series) bucket
+        // into an explicit "(none)" row at the end.
+        Groups = SelectedGroupBy switch
+        {
+            LibraryGroupBy.Author => await GroupByAuthorAsync(db, filtered),
+            LibraryGroupBy.Genre => await GroupByGenreAsync(db, filtered),
+            LibraryGroupBy.Collection => await GroupBySeriesAsync(db, filtered),
+            _ => [],
+        };
+
+        Loading = false;
+    }
+
+    public async Task ToggleGroupAsync(string key)
+    {
+        if (ExpandedGroupKeys.Contains(key))
+        {
+            ExpandedGroupKeys.Remove(key);
+            return;
+        }
+
+        ExpandedGroupKeys.Add(key);
+        if (!LoadedGroups.ContainsKey(key))
+        {
+            await LoadGroupBooksAsync(key, page: 1);
+        }
+    }
+
+    public async Task LoadGroupBooksAsync(string key, int page)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync();
+        var filtered = ApplyFilters(BookQueryWithIncludes(db));
+        filtered = ApplyGroupFilter(filtered, key);
+
+        var total = await filtered.CountAsync();
+        var raw = await filtered
+            .OrderBy(b => b.Title)
+            .Skip((page - 1) * PageSize)
+            .Take(PageSize)
+            .ToListAsync();
+
+        var items = raw.Select(ToBookListItem).ToList();
+        LoadedGroups[key] = new GroupBooks(items, page, total);
+    }
+
+    private IQueryable<Book> ApplyGroupFilter(IQueryable<Book> q, string key)
+    {
+        if (key == NoneKey)
+        {
+            return SelectedGroupBy switch
+            {
+                LibraryGroupBy.Genre => q.Where(b => !b.Works.Any(w => w.Genres.Any())),
+                LibraryGroupBy.Collection => q.Where(b => !b.Works.Any(w => w.SeriesId.HasValue)),
+                _ => q, // Author always has a value since Work.AuthorId is non-null
+            };
+        }
+
+        if (!int.TryParse(key, out var id)) return q;
+
+        return SelectedGroupBy switch
+        {
+            // Author key is the CANONICAL author id — match any Work whose
+            // Author is the canonical OR an alias of it.
+            LibraryGroupBy.Author => q.Where(b => b.Works.Any(w =>
+                w.Author.Id == id || w.Author.CanonicalAuthorId == id)),
+            LibraryGroupBy.Genre => q.Where(b => b.Works.Any(w => w.Genres.Any(g => g.Id == id))),
+            LibraryGroupBy.Collection => q.Where(b => b.Works.Any(w => w.SeriesId == id)),
+            _ => q,
+        };
+    }
+
+    private async Task<List<GroupRow>> GroupByAuthorAsync(BookTrackerDbContext db, IQueryable<Book> filtered)
+    {
+        // Roll up by canonical author id (CanonicalAuthorId ?? Id) so a
+        // Bachman title appears under King.
+        var raw = await filtered
+            .SelectMany(b => b.Works.Select(w => new
+            {
+                BookId = b.Id,
+                CanonicalId = w.Author.CanonicalAuthorId ?? w.Author.Id,
+            }))
+            .Distinct() // Avoid double-counting a book whose two Works share a canonical author.
+            .GroupBy(x => x.CanonicalId)
+            .Select(g => new { CanonicalId = g.Key, Count = g.Count() })
+            .ToListAsync();
+
+        var canonicalIds = raw.Select(r => r.CanonicalId).ToList();
+        var names = await db.Authors
+            .Where(a => canonicalIds.Contains(a.Id))
+            .Select(a => new { a.Id, a.Name })
+            .ToDictionaryAsync(x => x.Id, x => x.Name);
+
+        return raw
+            .Select(r => new GroupRow(
+                Key: r.CanonicalId.ToString(),
+                Label: names.GetValueOrDefault(r.CanonicalId) ?? "(unknown)",
+                Count: r.Count))
+            .OrderBy(g => g.Label)
+            .ToList();
+    }
+
+    private async Task<List<GroupRow>> GroupByGenreAsync(BookTrackerDbContext db, IQueryable<Book> filtered)
+    {
+        var raw = await filtered
+            .SelectMany(b => b.Works.SelectMany(w => w.Genres.Select(g => new { BookId = b.Id, GenreId = g.Id })))
+            .Distinct()
+            .GroupBy(x => x.GenreId)
+            .Select(g => new { GenreId = g.Key, Count = g.Count() })
+            .ToListAsync();
+
+        var genreIds = raw.Select(r => r.GenreId).ToList();
+        var names = await db.Genres
+            .Where(g => genreIds.Contains(g.Id))
+            .Select(g => new { g.Id, g.Name })
+            .ToDictionaryAsync(x => x.Id, x => x.Name);
+
+        var groups = raw
+            .Select(r => new GroupRow(
+                Key: r.GenreId.ToString(),
+                Label: names.GetValueOrDefault(r.GenreId) ?? "(unknown)",
+                Count: r.Count))
+            .OrderBy(g => g.Label)
+            .ToList();
+
+        var ungenredCount = await filtered.CountAsync(b => !b.Works.Any(w => w.Genres.Any()));
+        if (ungenredCount > 0)
+        {
+            groups.Add(new GroupRow(NoneKey, "(no genre)", ungenredCount));
+        }
+        return groups;
+    }
+
+    private async Task<List<GroupRow>> GroupBySeriesAsync(BookTrackerDbContext db, IQueryable<Book> filtered)
+    {
+        var raw = await filtered
+            .SelectMany(b => b.Works
+                .Where(w => w.SeriesId.HasValue)
+                .Select(w => new { BookId = b.Id, SeriesId = w.SeriesId!.Value }))
+            .Distinct()
+            .GroupBy(x => x.SeriesId)
+            .Select(g => new { SeriesId = g.Key, Count = g.Count() })
+            .ToListAsync();
+
+        var seriesIds = raw.Select(r => r.SeriesId).ToList();
+        var names = await db.Series
+            .Where(s => seriesIds.Contains(s.Id))
+            .Select(s => new { s.Id, s.Name })
+            .ToDictionaryAsync(x => x.Id, x => x.Name);
+
+        var groups = raw
+            .Select(r => new GroupRow(
+                Key: r.SeriesId.ToString(),
+                Label: names.GetValueOrDefault(r.SeriesId) ?? "(unknown)",
+                Count: r.Count))
+            .OrderBy(g => g.Label)
+            .ToList();
+
+        var unseriesedCount = await filtered.CountAsync(b => !b.Works.Any(w => w.SeriesId.HasValue));
+        if (unseriesedCount > 0)
+        {
+            groups.Add(new GroupRow(NoneKey, "(no series)", unseriesedCount));
+        }
+        return groups;
+    }
+
+    private IQueryable<Book> BookQueryWithIncludes(BookTrackerDbContext db) => db.Books
+        .Include(b => b.Tags)
+        .Include(b => b.Works).ThenInclude(w => w.Genres)
+        .Include(b => b.Works).ThenInclude(w => w.Author);
+
+    private IQueryable<Book> ApplyFilters(IQueryable<Book> query)
+    {
         if (!string.IsNullOrWhiteSpace(SearchTerm))
         {
             var term = SearchTerm.Trim();
@@ -98,46 +315,29 @@ public class BookListViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
         if (!string.IsNullOrWhiteSpace(SelectedAuthor))
         {
             var author = SelectedAuthor.Trim();
-            // Match either the Work's own author OR the canonical it
-            // resolves to — so picking "Stephen King" surfaces Bachman
-            // titles too without needing to also pick "Richard Bachman".
             query = query.Where(b => b.Works.Any(w =>
                 w.Author.Name == author ||
                 (w.Author.CanonicalAuthor != null && w.Author.CanonicalAuthor.Name == author)));
         }
 
-        TotalCount = await query.CountAsync();
-        TotalPages = Math.Max(1, (int)Math.Ceiling(TotalCount / (double)PageSize));
-        if (CurrentPage > TotalPages) CurrentPage = TotalPages;
-
-        var raw = await query
-            .OrderByDescending(b => b.DateAdded)
-            .Skip((CurrentPage - 1) * PageSize)
-            .Take(PageSize)
-            .ToListAsync();
-
-        // Aggregate Work-level fields into the row shape — one row per Book,
-        // joining the contained Works' authors and genres for display. Most
-        // books have a single Work so this is a no-op join in practice.
-        Books = raw.Select(b => new BookListItem(
-            b.Id,
-            b.Title,
-            b.Works.FirstOrDefault()?.Subtitle,
-            string.Join(", ", b.Works.Select(w => w.Author.Name).Distinct()),
-            b.DefaultCoverArtUrl,
-            b.Status,
-            b.Rating,
-            b.Works.SelectMany(w => w.Genres).Select(g => g.Name).Distinct().ToList(),
-            b.Tags.Select(t => t.Name).ToList()
-        )).ToList();
-
-        Loading = false;
+        return query;
     }
+
+    private static BookListItem ToBookListItem(Book b) => new(
+        b.Id,
+        b.Title,
+        b.Works.FirstOrDefault()?.Subtitle,
+        string.Join(", ", b.Works.Select(w => w.Author.Name).Distinct()),
+        b.DefaultCoverArtUrl,
+        b.Status,
+        b.Rating,
+        b.Works.SelectMany(w => w.Genres).Select(g => g.Name).Distinct().ToList(),
+        b.Tags.Select(t => t.Name).ToList());
 
     public async Task ApplyFiltersAsync()
     {
         CurrentPage = 1;
-        await LoadBooksAsync();
+        await ReloadAsync();
     }
 
     public async Task ClearFiltersAsync()
@@ -148,7 +348,7 @@ public class BookListViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
         SelectedTagId = 0;
         SelectedAuthor = "";
         CurrentPage = 1;
-        await LoadBooksAsync();
+        await ReloadAsync();
     }
 
     public async Task GoToPageAsync(int page)
@@ -158,6 +358,13 @@ public class BookListViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
         await LoadBooksAsync();
     }
 
+    public async Task ChangeGroupingAsync(LibraryGroupBy newGroupBy)
+    {
+        SelectedGroupBy = newGroupBy;
+        CurrentPage = 1;
+        await ReloadAsync();
+    }
+
     public static string StatusBadgeClass(BookStatus status) => status switch
     {
         BookStatus.Reading => "bg-primary",
@@ -165,6 +372,14 @@ public class BookListViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
         BookStatus.Unread => "bg-secondary",
         _ => "bg-secondary"
     };
+
+    public const string NoneKey = "_none";
+
+    public record GroupRow(string Key, string Label, int Count);
+    public record GroupBooks(List<BookListItem> Books, int Page, int TotalCount)
+    {
+        public int TotalPages => Math.Max(1, (int)Math.Ceiling(TotalCount / (double)PageSize));
+    }
 
     public record BookListItem(
         int Id, string Title, string? Subtitle, string Author, string? CoverUrl,


### PR DESCRIPTION
Adds a "Group by" picker on the Library page (Author / Genre /
Series-or-Collection / None) so the list can be browsed as an
accordion of groups instead of a flat scroll. Default is Author.

Each group is collapsed by default with a count badge in its header.
Expanding a group fetches its books lazily (one round-trip per first
expand) and shows them with per-group pagination — tested at 20
books per page, which matches the existing flat-list page size.
Subsequent re-expands of the same group reuse the cached page.

Author grouping rolls aliases up under their canonical: a book whose
Work points at Bachman appears under Stephen King (King's count
includes both his own titles and the Bachman ones). The author
filter already does the same so the two stay consistent.

Trailing "(no genre)" / "(no series)" buckets appear at the end of
their respective groupings only when there are books in them.

Filters apply *within* groupings — group counts and the lazy-loaded
book pages all respect the active genre / tag / category / author /
search filter, so picking "Mystery" + grouping by Author shows each
author's mystery count.

Refactors BookListViewModel.LoadBooksAsync to share the filter
pipeline with the new group-summary and per-group queries via
ApplyFilters / BookQueryWithIncludes / ToBookListItem helpers, and
adds a ChangeGroupingAsync that swaps the view between grouped and
flat modes. List.razor pulls the table + mobile-card markup into a
shared RenderBooks RenderFragment so both flat and per-group blocks
render identically.

Tests cover the canonical-author rollup, the (no genre)/(no series)
trailing buckets, expand-then-load round-trip, and the
filter-reduces-groups path.

Brief note added to ARCHITECTURE.md's Pages table.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
