### PR TITLE
feat(add): existing-book detection, in-session re-scan, edition lookup, "Add another?" toggle

### DIFF
--- a/BookTracker.Tests/ViewModels/BookAddViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/BookAddViewModelTests.cs
@@ -130,7 +130,7 @@ public class BookAddViewModelTests
 
         var ok = await vm.SaveAsync(new List<int>());
 
-        Assert.True(ok);
+        Assert.NotNull(ok);
         using var db = _factory.CreateDbContext();
         var edition = db.Editions.Single();
         Assert.Null(edition.Isbn);
@@ -146,16 +146,75 @@ public class BookAddViewModelTests
         vm1.BookInput.Title = "Book A";
         vm1.WorkInput.Title = "Book A";
         vm1.WorkInput.Author = "Author A";
-        Assert.True(await vm1.SaveAsync(new List<int>()));
+        Assert.NotNull(await vm1.SaveAsync(new List<int>()));
 
         var vm2 = CreateVm();
         vm2.BookInput.Title = "Book B";
         vm2.WorkInput.Title = "Book B";
         vm2.WorkInput.Author = "Author B";
-        Assert.True(await vm2.SaveAsync(new List<int>()));
+        Assert.NotNull(await vm2.SaveAsync(new List<int>()));
 
         using var db = _factory.CreateDbContext();
         Assert.Equal(2, db.Editions.Count(e => e.Isbn == null));
+    }
+
+    [Fact]
+    public async Task LookupAsync_ExistingIsbn_FlagsExistingBookInsteadOfPrefilling()
+    {
+        // Seed an existing book with the ISBN we're about to look up.
+        using (var db = _factory.CreateDbContext())
+        {
+            db.Books.Add(new Book
+            {
+                Title = "The Hobbit",
+                Works = [new Work { Title = "The Hobbit", Author = new Author { Name = "Tolkien" } }],
+                Editions = [new Edition { Isbn = "9780345391803", Copies = [new Copy { Condition = BookCondition.Good }] }]
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var vm = CreateVm();
+        vm.LookupIsbn = "9780345391803";
+
+        await vm.LookupAsync(CreateGenrePicker());
+
+        Assert.NotNull(vm.ExistingBook);
+        Assert.Equal("The Hobbit", vm.ExistingBook!.Title);
+        Assert.Equal(1, vm.ExistingBook.CopyCount);
+        // Form fields stay empty — the prefill path is skipped because the
+        // user is being told "you already own this book" instead.
+        Assert.Null(vm.BookInput.Title);
+        Assert.Null(vm.WorkInput.Author);
+        // Open Library shouldn't have been hit.
+        await _lookup.DidNotReceiveWithAnyArgs().LookupByIsbnAsync(default!, default);
+    }
+
+    [Fact]
+    public async Task AddCopyToExistingAsync_AppendsCopyToFlaggedEdition()
+    {
+        int editionId;
+        using (var db = _factory.CreateDbContext())
+        {
+            var book = new Book
+            {
+                Title = "The Hobbit",
+                Works = [new Work { Title = "The Hobbit", Author = new Author { Name = "Tolkien" } }],
+                Editions = [new Edition { Isbn = "9780345391803", Copies = [new Copy { Condition = BookCondition.Good }] }]
+            };
+            db.Books.Add(book);
+            await db.SaveChangesAsync();
+            editionId = book.Editions[0].Id;
+        }
+
+        var vm = CreateVm();
+        vm.LookupIsbn = "9780345391803";
+        await vm.LookupAsync(CreateGenrePicker());
+
+        var bookId = await vm.AddCopyToExistingAsync();
+
+        Assert.NotNull(bookId);
+        using var db2 = _factory.CreateDbContext();
+        Assert.Equal(2, db2.Copies.Count(c => c.EditionId == editionId));
     }
 
     [Fact]
@@ -170,7 +229,7 @@ public class BookAddViewModelTests
 
         var ok = await vm.SaveAsync(new List<int>());
 
-        Assert.True(ok);
+        Assert.NotNull(ok);
         using var db = _factory.CreateDbContext();
         var book = db.Books.Include(b => b.Works).ThenInclude(w => w.Author).Single();
         var work = Assert.Single(book.Works);

--- a/BookTracker.Tests/ViewModels/BulkAddViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/BulkAddViewModelTests.cs
@@ -28,8 +28,13 @@ public class BulkAddViewModelTests
     }
 
     [Fact]
-    public async Task AddIsbnAsync_IgnoresDuplicateIsbnInGrid()
+    public async Task AddIsbnAsync_AllowsSameIsbnAgain_ToCaptureSecondCopy()
     {
+        // Re-scanning the same barcode in one session is meaningful — it's
+        // a second physical copy of the book. Each scan creates its own
+        // row; SaveBookAsync re-checks the DB at save time and turns the
+        // second save into a Copy add rather than colliding on the unique
+        // ISBN constraint.
         var vm = CreateVm();
         vm.OnStateChanged = () => Task.CompletedTask;
 
@@ -38,7 +43,35 @@ public class BulkAddViewModelTests
         vm.IsbnInput = "9780345391803";
         await vm.AddIsbnAsync();
 
-        Assert.Single(vm.Rows);
+        Assert.Equal(2, vm.Rows.Count);
+    }
+
+    [Fact]
+    public async Task AcceptRowAsync_SecondScanOfSameIsbn_AddsCopyInsteadOfDuplicateBook()
+    {
+        var vm = CreateVm();
+        var first = new BulkAddViewModel.DiscoveryRow
+        {
+            Isbn = "9780345391803",
+            Title = "The Hobbit",
+            Author = "J.R.R. Tolkien",
+            Status = BulkAddViewModel.RowStatus.Found
+        };
+        var second = new BulkAddViewModel.DiscoveryRow
+        {
+            Isbn = "9780345391803",
+            Title = "The Hobbit",
+            Author = "J.R.R. Tolkien",
+            Status = BulkAddViewModel.RowStatus.Found
+        };
+
+        await vm.AcceptRowAsync(first);
+        await vm.AcceptRowAsync(second);
+
+        using var db = _factory.CreateDbContext();
+        Assert.Single(db.Books); // Only one Book row…
+        Assert.Single(db.Editions); // …and one Edition…
+        Assert.Equal(2, db.Copies.Count()); // …with two Copies.
     }
 
     [Fact]

--- a/BookTracker.Web/Components/Pages/Books/Add.razor
+++ b/BookTracker.Web/Components/Pages/Books/Add.razor
@@ -100,6 +100,26 @@
                         }
                     }
 
+                    @if (VM.ExistingBook is not null)
+                    {
+                        <div class="alert alert-warning mt-3 mb-0 py-2">
+                            <div class="fw-semibold mb-1">You already own this book.</div>
+                            <div class="small mb-2">
+                                <strong>@VM.ExistingBook.Title</strong> by @VM.ExistingBook.Author —
+                                @VM.ExistingBook.CopyCount cop@(VM.ExistingBook.CopyCount == 1 ? "y" : "ies") on file.
+                            </div>
+                            <div class="d-flex gap-2 flex-wrap">
+                                <button type="button" class="btn btn-success btn-sm" @onclick="AddCopyAsync" disabled="@VM.AddingCopy">
+                                    @if (VM.AddingCopy)
+                                    {
+                                        <span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>
+                                    }
+                                    Add another copy
+                                </button>
+                                <a class="btn btn-outline-primary btn-sm" href="@($"/books/{VM.ExistingBook.BookId}/edit")">Edit existing book</a>
+                            </div>
+                        </div>
+                    }
                     @{
                         var lookupMsg = VM.NoIsbnMode ? VM.SearchMessage : VM.LookupMessage;
                     }
@@ -143,7 +163,7 @@
             <EditionCopyForm EditionInput="VM.EditionInput" CopyInput="VM.CopyInput" Title="First edition & copy" />
         </div>
 
-        <div class="col-12 d-flex gap-2">
+        <div class="col-12 d-flex gap-2 align-items-center flex-wrap">
             <button type="submit" class="btn btn-primary" disabled="@VM.Saving">
                 @if (VM.Saving)
                 {
@@ -152,6 +172,10 @@
                 Save book
             </button>
             <a class="btn btn-outline-secondary" href="/">Cancel</a>
+            <div class="form-check ms-2">
+                <input type="checkbox" id="addAnother" class="form-check-input" @bind="addAnother" />
+                <label for="addAnother" class="form-check-label small">Add another?</label>
+            </div>
         </div>
     </div>
 </EditForm>
@@ -159,6 +183,7 @@
 @code {
     private List<int> selectedGenreIds = [];
     private GenrePicker? genrePicker;
+    private bool addAnother;
 
     private async Task LookupAsync()
     {
@@ -183,9 +208,39 @@
 
     private async Task SaveAsync()
     {
-        if (await VM.SaveAsync(selectedGenreIds))
+        var savedId = await VM.SaveAsync(selectedGenreIds);
+        if (savedId is null) return;
+
+        if (addAnother)
+        {
+            ResetForNextBook();
+        }
+        else
         {
             Nav.NavigateTo("/");
         }
+    }
+
+    private async Task AddCopyAsync()
+    {
+        var bookId = await VM.AddCopyToExistingAsync();
+        if (bookId is null) return;
+
+        if (addAnother)
+        {
+            ResetForNextBook();
+        }
+        else
+        {
+            Nav.NavigateTo($"/books/{bookId}/edit");
+        }
+    }
+
+    private void ResetForNextBook()
+    {
+        if (genrePicker is null) return;
+        VM.Reset(genrePicker.ViewModel);
+        selectedGenreIds = [];
+        StateHasChanged();
     }
 }

--- a/BookTracker.Web/Components/Pages/Books/Edit.razor
+++ b/BookTracker.Web/Components/Pages/Books/Edit.razor
@@ -253,6 +253,23 @@ else
                         @if (VM.ShowingNewEdition)
                         {
                             <div class="mt-3 pt-3 border-top">
+                                <div class="mb-3" style="max-width: 480px;">
+                                    <label class="form-label small text-muted">Look up by ISBN (prefills the fields below)</label>
+                                    <div class="input-group input-group-sm">
+                                        <input type="text" class="form-control" placeholder="9780345391803" @bind="VM.NewEditionLookupIsbn" />
+                                        <button type="button" class="btn btn-outline-primary" @onclick="VM.LookupNewEditionAsync" disabled="@VM.LookingUpNewEdition">
+                                            @if (VM.LookingUpNewEdition)
+                                            {
+                                                <span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>
+                                            }
+                                            Look up
+                                        </button>
+                                    </div>
+                                    @if (!string.IsNullOrEmpty(VM.NewEditionLookupMessage))
+                                    {
+                                        <div class="alert alert-info mt-2 mb-0 py-1 small">@VM.NewEditionLookupMessage</div>
+                                    }
+                                </div>
                                 <EditionCopyForm EditionInput="VM.NewEditionInput" CopyInput="VM.NewCopyInput" Title="New edition & copy" />
                                 <div class="mt-2 d-flex gap-2">
                                     <button type="button" class="btn btn-outline-success btn-sm" @onclick="() => VM.SaveNewEditionAsync(BookId)">Save</button>

--- a/BookTracker.Web/ViewModels/BookAddViewModel.cs
+++ b/BookTracker.Web/ViewModels/BookAddViewModel.cs
@@ -35,9 +35,18 @@ public class BookAddViewModel(
     public SeriesMatch? SeriesSuggestion { get; private set; }
     public bool SeriesSuggestionDismissed { get; set; }
 
+    // Existing-book detection — set during LookupAsync when the ISBN
+    // already maps to an Edition in the library. The Add page surfaces a
+    // banner offering "add another copy" / "edit existing" instead of
+    // letting the user accidentally hit the unique-ISBN constraint by
+    // saving a duplicate.
+    public ExistingBookMatch? ExistingBook { get; private set; }
+    public bool AddingCopy { get; private set; }
+
     public async Task LookupAsync(GenrePickerViewModel genrePicker)
     {
         LookupMessage = null;
+        ExistingBook = null;
         if (string.IsNullOrWhiteSpace(LookupIsbn))
         {
             LookupMessage = "Enter an ISBN to look up.";
@@ -47,6 +56,32 @@ public class BookAddViewModel(
         LookingUp = true;
         try
         {
+            // Existing-edition check first — if the ISBN already maps to a
+            // Book in the library, surface "add another copy" instead of
+            // letting the user save a duplicate that would hit the unique
+            // ISBN constraint.
+            var cleanIsbn = new string(LookupIsbn.Where(char.IsLetterOrDigit).ToArray()).ToUpperInvariant();
+            await using (var db = await dbFactory.CreateDbContextAsync())
+            {
+                var existing = await db.Editions
+                    .Include(e => e.Book)
+                        .ThenInclude(b => b.Works).ThenInclude(w => w.Author)
+                    .Include(e => e.Copies)
+                    .FirstOrDefaultAsync(e => e.Isbn == cleanIsbn);
+
+                if (existing is not null)
+                {
+                    ExistingBook = new ExistingBookMatch(
+                        existing.Book.Id,
+                        existing.Id,
+                        existing.Book.Title,
+                        string.Join(", ", existing.Book.Works.Select(w => w.Author.Name).Distinct()),
+                        existing.Copies.Count);
+                    LookupMessage = null;
+                    return;
+                }
+            }
+
             var result = await lookup.LookupByIsbnAsync(LookupIsbn, CancellationToken.None);
             if (result is null)
             {
@@ -80,6 +115,59 @@ public class BookAddViewModel(
             LookingUp = false;
         }
     }
+
+    /// <summary>
+    /// Adds a new Copy to the Edition flagged in <see cref="ExistingBook"/>.
+    /// Used by the "you already own this book" banner so re-scanning a
+    /// barcode for a second physical copy is a one-click action.
+    /// </summary>
+    /// <returns>The book id of the existing book the copy was attached to.</returns>
+    public async Task<int?> AddCopyToExistingAsync()
+    {
+        if (ExistingBook is null) return null;
+
+        AddingCopy = true;
+        try
+        {
+            await using var db = await dbFactory.CreateDbContextAsync();
+            var newCopy = new Copy
+            {
+                EditionId = ExistingBook.EditionId,
+                Condition = CopyInput.Condition,
+            };
+            db.Copies.Add(newCopy);
+            await db.SaveChangesAsync();
+            return ExistingBook.BookId;
+        }
+        finally
+        {
+            AddingCopy = false;
+        }
+    }
+
+    /// <summary>Resets all input state so the page is ready for the next book.</summary>
+    public void Reset(GenrePickerViewModel genrePicker)
+    {
+        BookInput = new();
+        WorkInput = new();
+        EditionInput = new();
+        CopyInput = new();
+        LookupIsbn = null;
+        LookupMessage = null;
+        LookupCandidates = [];
+        ExistingBook = null;
+        SeriesSuggestion = null;
+        SeriesSuggestionDismissed = false;
+        SearchTitle = null;
+        SearchAuthor = null;
+        SearchCandidates = [];
+        SearchMessage = null;
+        NoIsbnMode = false;
+        genrePicker.SelectedGenreIds = [];
+        genrePicker.LookupCandidates = [];
+    }
+
+    public record ExistingBookMatch(int BookId, int EditionId, string Title, string Author, int CopyCount);
 
     public async Task SearchAsync()
     {
@@ -132,7 +220,7 @@ public class BookAddViewModel(
         _ = genrePicker;
     }
 
-    public async Task<bool> SaveAsync(List<int> selectedGenreIds)
+    public async Task<int?> SaveAsync(List<int> selectedGenreIds)
     {
         Saving = true;
         try
@@ -190,7 +278,7 @@ public class BookAddViewModel(
 
             db.Books.Add(book);
             await db.SaveChangesAsync();
-            return true;
+            return book.Id;
         }
         finally
         {

--- a/BookTracker.Web/ViewModels/BookEditViewModel.cs
+++ b/BookTracker.Web/ViewModels/BookEditViewModel.cs
@@ -5,7 +5,9 @@ using Microsoft.EntityFrameworkCore;
 
 namespace BookTracker.Web.ViewModels;
 
-public class BookEditViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory)
+public class BookEditViewModel(
+    IDbContextFactory<BookTrackerDbContext> dbFactory,
+    IBookLookupService lookup)
 {
     public BookFormViewModel.BookFormInput? BookInput { get; private set; }
 
@@ -38,6 +40,9 @@ public class BookEditViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
     public bool ShowingNewEdition { get; set; }
     public EditionFormViewModel.EditionFormInput NewEditionInput { get; set; } = new();
     public CopyFormViewModel.CopyFormInput NewCopyInput { get; set; } = new();
+    public string? NewEditionLookupIsbn { get; set; }
+    public string? NewEditionLookupMessage { get; private set; }
+    public bool LookingUpNewEdition { get; private set; }
 
     // Inline edition/copy editing
     public int? EditingCopyId { get; set; }
@@ -176,7 +181,48 @@ public class BookEditViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
     {
         NewEditionInput = new EditionFormViewModel.EditionFormInput();
         NewCopyInput = new CopyFormViewModel.CopyFormInput();
+        NewEditionLookupIsbn = null;
+        NewEditionLookupMessage = null;
         ShowingNewEdition = true;
+    }
+
+    /// <summary>
+    /// Pre-fills the new-edition form fields by hitting the same Open
+    /// Library / Google Books pipeline used by the Add Book page. Only
+    /// touches Edition/publisher-shaped fields — the Book and Work it
+    /// will attach to are already known on the Edit page.
+    /// </summary>
+    public async Task LookupNewEditionAsync()
+    {
+        NewEditionLookupMessage = null;
+        if (string.IsNullOrWhiteSpace(NewEditionLookupIsbn))
+        {
+            NewEditionLookupMessage = "Enter an ISBN to look up.";
+            return;
+        }
+
+        LookingUpNewEdition = true;
+        try
+        {
+            var result = await lookup.LookupByIsbnAsync(NewEditionLookupIsbn, CancellationToken.None);
+            if (result is null)
+            {
+                NewEditionLookupMessage = $"No match found for ISBN {NewEditionLookupIsbn}.";
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(NewEditionInput.Isbn)) NewEditionInput.Isbn = result.Isbn;
+            if (string.IsNullOrWhiteSpace(NewEditionInput.Publisher)) NewEditionInput.Publisher = result.Publisher;
+            if (string.IsNullOrWhiteSpace(NewEditionInput.CoverUrl)) NewEditionInput.CoverUrl = result.CoverUrl;
+            NewEditionInput.DatePrinted ??= result.DatePrinted;
+            if (result.Format is BookFormat fmt) NewEditionInput.Format = fmt;
+
+            NewEditionLookupMessage = $"Prefilled from {result.Source}. Edit anything before saving.";
+        }
+        finally
+        {
+            LookingUpNewEdition = false;
+        }
     }
 
     public async Task SaveNewEditionAsync(int bookId)

--- a/BookTracker.Web/ViewModels/BulkAddViewModel.cs
+++ b/BookTracker.Web/ViewModels/BulkAddViewModel.cs
@@ -26,12 +26,12 @@ public class BulkAddViewModel(
         var isbn = IsbnInput.Trim();
         if (string.IsNullOrWhiteSpace(isbn)) return;
 
-        if (Rows.Any(r => string.Equals(r.Isbn, isbn, StringComparison.OrdinalIgnoreCase)))
-        {
-            IsbnInput = "";
-            return;
-        }
-
+        // Re-scanning the same ISBN is allowed and meaningful: each row
+        // represents one physical book to add, so a second scan adds a
+        // second copy. CheckDuplicateAsync flags the row as a duplicate
+        // (either against the DB or a previous in-session row) and the
+        // save path appends a new Copy to the existing Edition rather
+        // than trying to create a colliding Book.
         var row = new DiscoveryRow { Isbn = isbn, Status = RowStatus.Searching };
         Rows.Insert(0, row);
         IsbnInput = "";
@@ -118,30 +118,35 @@ public class BulkAddViewModel(
     {
         await using var db = await dbFactory.CreateDbContextAsync();
 
-        if (row.IsDuplicate)
-        {
-            var existingEdition = await db.Editions
+        // Re-check at save time rather than relying on row.IsDuplicate (which
+        // was set when the row was scanned). Two scans of the same ISBN in
+        // one session both start as not-duplicate, but by the time the
+        // second one's saved the first row may have already been accepted
+        // and inserted the Edition — in which case we want to add a Copy,
+        // not crash on the unique-ISBN constraint.
+        var existingEdition = string.IsNullOrWhiteSpace(row.Isbn)
+            ? null
+            : await db.Editions
                 .Include(e => e.Book)
                 .FirstOrDefaultAsync(e => e.Isbn == row.Isbn);
 
-            if (existingEdition is not null)
+        if (existingEdition is not null)
+        {
+            var newCopy = new Copy
             {
-                var newCopy = new Copy
-                {
-                    EditionId = existingEdition.Id,
-                    Condition = BookCondition.Good
-                };
-                db.Copies.Add(newCopy);
+                EditionId = existingEdition.Id,
+                Condition = BookCondition.Good
+            };
+            db.Copies.Add(newCopy);
 
-                if (followUp)
-                {
-                    var book = await db.Books.Include(b => b.Tags).FirstAsync(b => b.Id == existingEdition.BookId);
-                    await EnsureFollowUpTagAsync(db, book);
-                }
-
-                await db.SaveChangesAsync();
-                return;
+            if (followUp)
+            {
+                var book = await db.Books.Include(b => b.Tags).FirstAsync(b => b.Id == existingEdition.BookId);
+                await EnsureFollowUpTagAsync(db, book);
             }
+
+            await db.SaveChangesAsync();
+            return;
         }
 
         Publisher? publisher = null;


### PR DESCRIPTION
Four related quality-of-life fixes for the add flows.

#1 Add page now spots an ISBN that's already in the library before
   trying to save a duplicate. LookupAsync runs an Editions lookup
   first; if the ISBN matches an existing Edition, the prefill path
   is skipped and a banner surfaces "You already own this book —
   add another copy / edit existing". Clicking "Add another copy"
   creates a Copy on the existing Edition (one click) and either
   resets the page (when "Add another?" is on) or navigates to the
   book's Edit page.

#2 BulkAdd no longer silently drops a re-scan of the same ISBN. Each
   scan creates its own row; SaveBookAsync was tightened to re-check
   the DB at save time (rather than relying on the row-time
   IsDuplicate flag), so two scans of the same barcode in one
   session land as one Edition + two Copies instead of crashing
   on the unique-ISBN constraint.

#3 Edit Book's "Add edition" panel gains an ISBN lookup field above
   the form. New BookEditViewModel.LookupNewEditionAsync hits the
   existing IBookLookupService and prefills the Edition fields
   (ISBN, format, date, publisher, cover URL).

#4 Add page gets an "Add another?" checkbox. When ticked, saving
   (or adding a copy to an existing book) resets the form in place
   so the next book can be entered without going via /. Off by
   default — existing single-book flow unchanged.

BookAddViewModel.SaveAsync now returns the new book's id (was a
bool) so the page can navigate to /books/{id}/edit when a copy was
added to an existing book. ResetForNextBook clears all input state
plus the genre picker.

Tests: existing-ISBN-skips-prefill, AddCopyToExistingAsync appends
to the right Edition, BulkAdd same-ISBN re-scan creates two Copies.
Existing tests updated for the int? SaveAsync return.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
