### PR TITLE
feat(dates): support imprecise print and first-published dates

### DIFF
--- a/BookTracker.Data/Migrations/20260420052605_AddDatePrecisionColumns.Designer.cs
+++ b/BookTracker.Data/Migrations/20260420052605_AddDatePrecisionColumns.Designer.cs
@@ -4,6 +4,7 @@ using BookTracker.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BookTracker.Data.Migrations
 {
     [DbContext(typeof(BookTrackerDbContext))]
-    partial class BookTrackerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260420052605_AddDatePrecisionColumns")]
+    partial class AddDatePrecisionColumns
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BookTracker.Data/Migrations/20260420052605_AddDatePrecisionColumns.cs
+++ b/BookTracker.Data/Migrations/20260420052605_AddDatePrecisionColumns.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BookTracker.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDatePrecisionColumns : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "FirstPublishedDatePrecision",
+                table: "Works",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "DatePrintedPrecision",
+                table: "Editions",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "FirstPublishedDatePrecision",
+                table: "Works");
+
+            migrationBuilder.DropColumn(
+                name: "DatePrintedPrecision",
+                table: "Editions");
+        }
+    }
+}

--- a/BookTracker.Data/Models/DatePrecision.cs
+++ b/BookTracker.Data/Models/DatePrecision.cs
@@ -1,0 +1,13 @@
+namespace BookTracker.Data.Models;
+
+// Companion column for date fields where the user often only knows part
+// of the date — print dates on older books frequently come as "1973" or
+// "October 1973" without a day. The DateOnly column still stores a real
+// date (with month/day defaulted to 1) so sorting works; the precision
+// flag drives display ("1973" vs "Oct 1973" vs "12 Oct 1973").
+public enum DatePrecision
+{
+    Day = 0,
+    Month = 1,
+    Year = 2,
+}

--- a/BookTracker.Data/Models/Edition.cs
+++ b/BookTracker.Data/Models/Edition.cs
@@ -19,6 +19,9 @@ public class Edition
 
     public DateOnly? DatePrinted { get; set; }
 
+    /// <summary>How precise <see cref="DatePrinted"/> is — drives display formatting.</summary>
+    public DatePrecision DatePrintedPrecision { get; set; } = DatePrecision.Day;
+
     [MaxLength(500)]
     public string? CoverUrl { get; set; }
 

--- a/BookTracker.Data/Models/Work.cs
+++ b/BookTracker.Data/Models/Work.cs
@@ -27,6 +27,9 @@ public class Work
     /// <summary>The year/date the Work was first published — distinct from any specific Edition's print date.</summary>
     public DateOnly? FirstPublishedDate { get; set; }
 
+    /// <summary>How precise <see cref="FirstPublishedDate"/> is — drives display formatting.</summary>
+    public DatePrecision FirstPublishedDatePrecision { get; set; } = DatePrecision.Day;
+
     public List<Genre> Genres { get; set; } = [];
 
     public int? SeriesId { get; set; }

--- a/BookTracker.Tests/Services/PartialDateParserTests.cs
+++ b/BookTracker.Tests/Services/PartialDateParserTests.cs
@@ -1,0 +1,100 @@
+using BookTracker.Data.Models;
+using BookTracker.Web.Services;
+
+namespace BookTracker.Tests.Services;
+
+public class PartialDateParserTests
+{
+    [Theory]
+    [InlineData("1973", 1973, 1, 1, DatePrecision.Year)]
+    [InlineData("1934", 1934, 1, 1, DatePrecision.Year)]
+    public void TryParse_YearOnly(string input, int y, int m, int d, DatePrecision precision)
+    {
+        var result = PartialDateParser.TryParse(input);
+        Assert.NotNull(result);
+        Assert.Equal(new DateOnly(y, m, d), result!.Date);
+        Assert.Equal(precision, result.Precision);
+    }
+
+    [Theory]
+    [InlineData("1973-10", 1973, 10, 1, DatePrecision.Month)]
+    [InlineData("10/1973", 1973, 10, 1, DatePrecision.Month)]
+    [InlineData("1/2024", 2024, 1, 1, DatePrecision.Month)]
+    [InlineData("Oct 1973", 1973, 10, 1, DatePrecision.Month)]
+    [InlineData("October 1973", 1973, 10, 1, DatePrecision.Month)]
+    public void TryParse_MonthYear(string input, int y, int m, int d, DatePrecision precision)
+    {
+        var result = PartialDateParser.TryParse(input);
+        Assert.NotNull(result);
+        Assert.Equal(new DateOnly(y, m, d), result!.Date);
+        Assert.Equal(precision, result.Precision);
+    }
+
+    [Theory]
+    [InlineData("1973-10-12", 1973, 10, 12)]
+    [InlineData("12 Oct 1973", 1973, 10, 12)]
+    [InlineData("12 October 1973", 1973, 10, 12)]
+    public void TryParse_FullDate(string input, int y, int m, int d)
+    {
+        var result = PartialDateParser.TryParse(input);
+        Assert.NotNull(result);
+        Assert.Equal(new DateOnly(y, m, d), result!.Date);
+        Assert.Equal(DatePrecision.Day, result.Precision);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void TryParse_BlankInput_ReturnsEmptyPartialDate(string? input)
+    {
+        var result = PartialDateParser.TryParse(input);
+        Assert.NotNull(result);
+        Assert.Null(result!.Date);
+        Assert.Equal(DatePrecision.Day, result.Precision);
+    }
+
+    [Theory]
+    [InlineData("not a date")]
+    [InlineData("13/2024")]   // invalid month
+    [InlineData("3000")]       // year out of range
+    [InlineData("0099")]       // year out of range
+    [InlineData("Octobre 1973")] // wrong language
+    public void TryParse_GarbageInput_ReturnsNull(string input)
+    {
+        Assert.Null(PartialDateParser.TryParse(input));
+    }
+
+    [Theory]
+    [InlineData(2024, 3, 15, DatePrecision.Day, "15 Mar 2024")]
+    [InlineData(1973, 10, 1, DatePrecision.Month, "Oct 1973")]
+    [InlineData(1934, 1, 1, DatePrecision.Year, "1934")]
+    public void Format_RendersAccordingToPrecision(int y, int m, int d, DatePrecision precision, string expected)
+    {
+        Assert.Equal(expected, PartialDateParser.Format(new DateOnly(y, m, d), precision));
+    }
+
+    [Fact]
+    public void Format_NullDate_ReturnsEmpty()
+    {
+        Assert.Equal("", PartialDateParser.Format(null, DatePrecision.Day));
+    }
+
+    [Fact]
+    public void RoundTrip_YearText_PreservesYearPrecision()
+    {
+        var parsed = PartialDateParser.TryParse("1934");
+        Assert.NotNull(parsed);
+        var formatted = PartialDateParser.Format(parsed!.Date, parsed.Precision);
+        Assert.Equal("1934", formatted);
+    }
+
+    [Fact]
+    public void RoundTrip_MonthText_PreservesMonthPrecision()
+    {
+        var parsed = PartialDateParser.TryParse("Oct 1973");
+        Assert.NotNull(parsed);
+        var formatted = PartialDateParser.Format(parsed!.Date, parsed.Precision);
+        Assert.Equal("Oct 1973", formatted);
+    }
+}

--- a/BookTracker.Tests/ViewModels/BookAddViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/BookAddViewModelTests.cs
@@ -91,7 +91,8 @@ public class BookAddViewModelTests
         Assert.Equal("And Then There Were None", vm.WorkInput.Title);
         Assert.Equal("Agatha Christie", vm.WorkInput.Author);
         Assert.Equal("https://example.invalid/cover.jpg", vm.BookInput.DefaultCoverArtUrl);
-        Assert.Equal(new DateOnly(1939, 1, 1), vm.WorkInput.FirstPublishedDate);
+        // Year-only candidate → year-precision text in the input.
+        Assert.Equal("1939", vm.WorkInput.FirstPublishedDate);
     }
 
     [Fact]
@@ -101,7 +102,7 @@ public class BookAddViewModelTests
         vm.BookInput.Title = "User typed this";
         vm.WorkInput.Title = "User typed this";
         vm.WorkInput.Author = "User author";
-        vm.WorkInput.FirstPublishedDate = new DateOnly(1939, 6, 15);
+        vm.WorkInput.FirstPublishedDate = "15 Jun 1939";
 
         var candidate = new BookSearchCandidate(
             WorkKey: "/works/OL1W",
@@ -116,7 +117,7 @@ public class BookAddViewModelTests
 
         Assert.Equal("User typed this", vm.BookInput.Title);
         Assert.Equal("User author", vm.WorkInput.Author);
-        Assert.Equal(new DateOnly(1939, 6, 15), vm.WorkInput.FirstPublishedDate);
+        Assert.Equal("15 Jun 1939", vm.WorkInput.FirstPublishedDate);
     }
 
     [Fact]
@@ -224,7 +225,7 @@ public class BookAddViewModelTests
         vm.BookInput.Title = "The Hobbit";
         vm.WorkInput.Title = "The Hobbit";
         vm.WorkInput.Author = "J.R.R. Tolkien";
-        vm.WorkInput.FirstPublishedDate = new DateOnly(1937, 9, 21);
+        vm.WorkInput.FirstPublishedDate = "21 Sep 1937";
         vm.EditionInput.Isbn = "9780345391803";
 
         var ok = await vm.SaveAsync(new List<int>());
@@ -236,5 +237,6 @@ public class BookAddViewModelTests
         Assert.Equal("The Hobbit", work.Title);
         Assert.Equal("J.R.R. Tolkien", work.Author.Name);
         Assert.Equal(new DateOnly(1937, 9, 21), work.FirstPublishedDate);
+        Assert.Equal(DatePrecision.Day, work.FirstPublishedDatePrecision);
     }
 }

--- a/BookTracker.Web/Components/Pages/Books/Edit.razor
+++ b/BookTracker.Web/Components/Pages/Books/Edit.razor
@@ -208,7 +208,7 @@ else
                                                         </select>
                                                     </td>
                                                     <td><input type="text" class="form-control form-control-sm" @bind="VM.EditCopyInput.Publisher" /></td>
-                                                    <td><input type="date" class="form-control form-control-sm" @bind="VM.EditCopyInput.DatePrinted" /></td>
+                                                    <td><input type="text" class="form-control form-control-sm" @bind="VM.EditCopyInput.DatePrinted" placeholder="1973 / Oct 1973 / 12 Oct 1973" /></td>
                                                     <td>
                                                         <div class="btn-group btn-group-sm">
                                                             <button type="button" class="btn btn-outline-success" @onclick="VM.SaveCopyEditAsync">Save</button>
@@ -224,7 +224,7 @@ else
                                                     <td>@copy.Format</td>
                                                     <td>@CopyFormViewModel.FormatCondition(copy.Condition)</td>
                                                     <td>@(copy.PublisherName ?? "—")</td>
-                                                    <td>@(copy.DatePrinted?.ToString("yyyy-MM-dd") ?? "—")</td>
+                                                    <td>@(string.IsNullOrEmpty(copy.DatePrintedDisplay) ? "—" : copy.DatePrintedDisplay)</td>
                                                     <td>
                                                         @if (VM.ConfirmingDeleteCopyId == copy.CopyId)
                                                         {

--- a/BookTracker.Web/Components/Shared/EditionCopyForm.razor
+++ b/BookTracker.Web/Components/Shared/EditionCopyForm.razor
@@ -20,7 +20,8 @@
             </div>
             <div class="col-md-3">
                 <label class="form-label">Date printed</label>
-                <InputDate @bind-Value="EditionInput.DatePrinted" class="form-control" />
+                <InputText @bind-Value="EditionInput.DatePrinted" class="form-control" placeholder="e.g. 1973, Oct 1973, or 12 Oct 1973" />
+                <div class="form-text">Year alone is fine if that's all you've got.</div>
             </div>
             <div class="col-md-3">
                 <label class="form-label">Condition</label>

--- a/BookTracker.Web/Components/Shared/WorkForm.razor
+++ b/BookTracker.Web/Components/Shared/WorkForm.razor
@@ -18,8 +18,8 @@
             </div>
             <div class="col-md-4">
                 <label class="form-label">First published</label>
-                <InputDate @bind-Value="Input.FirstPublishedDate" class="form-control" />
-                <div class="form-text">When the work itself was first published, not this edition's print date.</div>
+                <InputText @bind-Value="Input.FirstPublishedDate" class="form-control" placeholder="e.g. 1934, Jan 1934, 6 Jan 1934" />
+                <div class="form-text">When the work itself was first published. Year alone is fine.</div>
             </div>
         </div>
     </div>

--- a/BookTracker.Web/Services/BookLookupResult.cs
+++ b/BookTracker.Web/Services/BookLookupResult.cs
@@ -12,4 +12,5 @@ public record BookLookupResult(
     DateOnly? DatePrinted,
     string? CoverUrl,
     string Source,
-    BookFormat? Format = null);
+    BookFormat? Format = null,
+    DatePrecision DatePrintedPrecision = DatePrecision.Day);

--- a/BookTracker.Web/Services/BookLookupService.cs
+++ b/BookTracker.Web/Services/BookLookupService.cs
@@ -1,6 +1,7 @@
 using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using BookTracker.Data.Models;
 
 namespace BookTracker.Web.Services;
 
@@ -83,6 +84,7 @@ public class BookLookupService(HttpClient http, ILogger<BookLookupService> logge
                 .Take(10)
                 .ToList();
 
+            var (olDate, olPrecision) = ParseLooseDate(book.PublishDate);
             return new BookLookupResult(
                 Isbn: isbn,
                 Title: book.Title,
@@ -90,10 +92,11 @@ public class BookLookupService(HttpClient http, ILogger<BookLookupService> logge
                 Author: book.Authors?.FirstOrDefault()?.Name,
                 Publisher: book.Publishers?.FirstOrDefault()?.Name,
                 GenreCandidates: genres,
-                DatePrinted: ParseLooseDate(book.PublishDate),
+                DatePrinted: olDate,
                 CoverUrl: book.Cover?.Large ?? book.Cover?.Medium ?? $"https://covers.openlibrary.org/b/isbn/{isbn}-L.jpg",
                 Source: "Open Library",
-                Format: BookFormatNormalizer.Normalize(book.PhysicalFormat, book.PhysicalDimensions));
+                Format: BookFormatNormalizer.Normalize(book.PhysicalFormat, book.PhysicalDimensions),
+                DatePrintedPrecision: olPrecision);
         }
         catch (Exception ex)
         {
@@ -126,6 +129,7 @@ public class BookLookupService(HttpClient http, ILogger<BookLookupService> logge
             var cover = item.ImageLinks?.Thumbnail?.Replace("http://", "https://")
                 ?? item.ImageLinks?.SmallThumbnail?.Replace("http://", "https://");
 
+            var (gbDate, gbPrecision) = ParseLooseDate(item.PublishedDate);
             return new BookLookupResult(
                 Isbn: isbn,
                 Title: item.Title,
@@ -133,9 +137,10 @@ public class BookLookupService(HttpClient http, ILogger<BookLookupService> logge
                 Author: item.Authors?.FirstOrDefault(),
                 Publisher: item.Publisher,
                 GenreCandidates: genres,
-                DatePrinted: ParseLooseDate(item.PublishedDate),
+                DatePrinted: gbDate,
                 CoverUrl: cover,
-                Source: "Google Books");
+                Source: "Google Books",
+                DatePrintedPrecision: gbPrecision);
         }
         catch (Exception ex)
         {
@@ -146,21 +151,25 @@ public class BookLookupService(HttpClient http, ILogger<BookLookupService> logge
 
     private static string? CleanGenre(string raw) => GenreCandidateCleaner.Clean(raw);
 
-    private static DateOnly? ParseLooseDate(string? raw)
+    // Open Library / Google Books often only give a year ("1934") so we
+    // route through the same partial-date parser used by the form inputs
+    // — the precision is then carried alongside the DateOnly so the UI
+    // doesn't render "1 Jan 1934" for a year-only source.
+    private static (DateOnly?, DatePrecision) ParseLooseDate(string? raw)
     {
-        if (string.IsNullOrWhiteSpace(raw))
+        var pd = PartialDateParser.TryParse(raw);
+        if (pd is { Date: DateOnly d }) return (d, pd.Precision);
+
+        // Last-resort year fallback: many records have noise like "1934, c1932"
+        // — try the leading 4 digits.
+        if (!string.IsNullOrWhiteSpace(raw)
+            && int.TryParse(raw[..Math.Min(4, raw.Length)], out var year)
+            && year is >= 1400 and <= 2999)
         {
-            return null;
+            return (new DateOnly(year, 1, 1), DatePrecision.Year);
         }
-        if (DateOnly.TryParse(raw, out var d))
-        {
-            return d;
-        }
-        if (int.TryParse(raw[..Math.Min(4, raw.Length)], out var year) && year is >= 1400 and <= 2999)
-        {
-            return new DateOnly(year, 1, 1);
-        }
-        return null;
+
+        return (null, DatePrecision.Day);
     }
 
     private sealed class OpenLibraryBook

--- a/BookTracker.Web/Services/PartialDate.cs
+++ b/BookTracker.Web/Services/PartialDate.cs
@@ -1,0 +1,110 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+using BookTracker.Data.Models;
+
+namespace BookTracker.Web.Services;
+
+// Pair of (date, precision) used as the form-input shape for date fields
+// where the user often only knows year or month-year. Storage stays as
+// `DateOnly?` + `DatePrecision` columns on the entity; this record is
+// the in-memory container that owns the round-trip from string text in
+// a form to the two columns and back.
+public record PartialDate(DateOnly? Date, DatePrecision Precision)
+{
+    public static PartialDate Empty => new(null, DatePrecision.Day);
+}
+
+// Parses free-form date text from form inputs. Accepts:
+//   "1973"                  → Year
+//   "1973-10"  / "10/1973"  → Month
+//   "1973-10-12"            → Day
+//   "Oct 1973" / "October 1973"  → Month
+//   "12 Oct 1973" / "12 October 1973"  → Day
+//
+// Returns null when the input is non-empty but doesn't match any pattern,
+// so the form can surface "couldn't read that date" without silently
+// dropping the user's typing.
+public static partial class PartialDateParser
+{
+    public static PartialDate? TryParse(string? input)
+    {
+        if (string.IsNullOrWhiteSpace(input)) return PartialDate.Empty;
+
+        var trimmed = input.Trim();
+
+        // Year only — 4 digits.
+        if (YearOnly().IsMatch(trimmed))
+        {
+            var year = int.Parse(trimmed, CultureInfo.InvariantCulture);
+            if (year is < 1400 or > 2999) return null;
+            return new PartialDate(new DateOnly(year, 1, 1), DatePrecision.Year);
+        }
+
+        // ISO month YYYY-MM
+        var isoMonth = IsoMonth().Match(trimmed);
+        if (isoMonth.Success)
+        {
+            var year = int.Parse(isoMonth.Groups[1].Value, CultureInfo.InvariantCulture);
+            var month = int.Parse(isoMonth.Groups[2].Value, CultureInfo.InvariantCulture);
+            if (year is < 1400 or > 2999 || month is < 1 or > 12) return null;
+            return new PartialDate(new DateOnly(year, month, 1), DatePrecision.Month);
+        }
+
+        // ISO day YYYY-MM-DD
+        if (DateOnly.TryParseExact(trimmed, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out var iso))
+        {
+            return new PartialDate(iso, DatePrecision.Day);
+        }
+
+        // M/YYYY (numeric month, four-digit year)
+        var slashMonth = SlashMonth().Match(trimmed);
+        if (slashMonth.Success)
+        {
+            var month = int.Parse(slashMonth.Groups[1].Value, CultureInfo.InvariantCulture);
+            var year = int.Parse(slashMonth.Groups[2].Value, CultureInfo.InvariantCulture);
+            if (year is < 1400 or > 2999 || month is < 1 or > 12) return null;
+            return new PartialDate(new DateOnly(year, month, 1), DatePrecision.Month);
+        }
+
+        // "Oct 1973" or "October 1973"
+        if (TryParseExact(trimmed, "MMM yyyy", out var monthShort)) return new(monthShort, DatePrecision.Month);
+        if (TryParseExact(trimmed, "MMMM yyyy", out var monthLong)) return new(monthLong, DatePrecision.Month);
+
+        // "12 Oct 1973" or "12 October 1973"
+        if (TryParseExact(trimmed, "d MMM yyyy", out var dayShort)) return new(dayShort, DatePrecision.Day);
+        if (TryParseExact(trimmed, "d MMMM yyyy", out var dayLong)) return new(dayLong, DatePrecision.Day);
+
+        // Last-resort culture-invariant DateOnly.TryParse for anything else
+        // (covers locale-agnostic formats like "1973-10-12T00:00:00").
+        if (DateOnly.TryParse(trimmed, CultureInfo.InvariantCulture, DateTimeStyles.None, out var loose))
+        {
+            return new PartialDate(loose, DatePrecision.Day);
+        }
+
+        return null;
+    }
+
+    public static string Format(DateOnly? date, DatePrecision precision)
+    {
+        if (date is null) return "";
+        var d = date.Value;
+        return precision switch
+        {
+            DatePrecision.Year => d.Year.ToString(CultureInfo.InvariantCulture),
+            DatePrecision.Month => d.ToString("MMM yyyy", CultureInfo.InvariantCulture),
+            _ => d.ToString("d MMM yyyy", CultureInfo.InvariantCulture),
+        };
+    }
+
+    private static bool TryParseExact(string input, string format, out DateOnly date) =>
+        DateOnly.TryParseExact(input, format, CultureInfo.InvariantCulture, DateTimeStyles.None, out date);
+
+    [GeneratedRegex(@"^\d{4}$")]
+    private static partial Regex YearOnly();
+
+    [GeneratedRegex(@"^(\d{4})-(\d{1,2})$")]
+    private static partial Regex IsoMonth();
+
+    [GeneratedRegex(@"^(\d{1,2})/(\d{4})$")]
+    private static partial Regex SlashMonth();
+}

--- a/BookTracker.Web/ViewModels/BookAddViewModel.cs
+++ b/BookTracker.Web/ViewModels/BookAddViewModel.cs
@@ -99,7 +99,10 @@ public class BookAddViewModel(
             if (string.IsNullOrWhiteSpace(WorkInput.Author)) WorkInput.Author = result.Author ?? "";
             if (string.IsNullOrWhiteSpace(EditionInput.Isbn)) EditionInput.Isbn = result.Isbn;
             if (string.IsNullOrWhiteSpace(EditionInput.Publisher)) EditionInput.Publisher = result.Publisher;
-            EditionInput.DatePrinted ??= result.DatePrinted;
+            if (string.IsNullOrWhiteSpace(EditionInput.DatePrinted) && result.DatePrinted is DateOnly d)
+            {
+                EditionInput.DatePrinted = PartialDateParser.Format(d, result.DatePrintedPrecision);
+            }
 
             LookupCandidates = result.GenreCandidates.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
             genrePicker.LookupCandidates = LookupCandidates;
@@ -204,10 +207,11 @@ public class BookAddViewModel(
         if (string.IsNullOrWhiteSpace(WorkInput.Title)) WorkInput.Title = candidate.Title ?? "";
         if (string.IsNullOrWhiteSpace(WorkInput.Author)) WorkInput.Author = candidate.Author ?? "";
         // first_publish_year is the WORK's first year — perfect fit for
-        // Work.FirstPublishedDate; not the edition's print date.
-        if (WorkInput.FirstPublishedDate is null && candidate.FirstPublishYear is int year)
+        // Work.FirstPublishedDate; not the edition's print date. We only
+        // know the year so format it as such.
+        if (string.IsNullOrWhiteSpace(WorkInput.FirstPublishedDate) && candidate.FirstPublishYear is int year)
         {
-            WorkInput.FirstPublishedDate = new DateOnly(year, 1, 1);
+            WorkInput.FirstPublishedDate = year.ToString();
         }
 
         SearchMessage = $"Prefilled from Open Library. Fill in format, exact print date, and publisher from the book in hand.";
@@ -244,15 +248,18 @@ public class BookAddViewModel(
             }
 
             var author = await AuthorResolver.FindOrCreateAsync(WorkInput.Author!, db);
+            var firstPub = PartialDateParser.TryParse(WorkInput.FirstPublishedDate) ?? PartialDate.Empty;
             var work = new Work
             {
                 Title = (WorkInput.Title ?? BookInput.Title)!.Trim(),
                 Subtitle = string.IsNullOrWhiteSpace(WorkInput.Subtitle) ? null : WorkInput.Subtitle!.Trim(),
                 Author = author,
-                FirstPublishedDate = WorkInput.FirstPublishedDate,
+                FirstPublishedDate = firstPub.Date,
+                FirstPublishedDatePrecision = firstPub.Precision,
                 Genres = selectedGenres,
             };
 
+            var datePrinted = PartialDateParser.TryParse(EditionInput.DatePrinted) ?? PartialDate.Empty;
             var book = new Book
             {
                 Title = BookInput.Title!.Trim(),
@@ -268,7 +275,8 @@ public class BookAddViewModel(
                     {
                         Isbn = string.IsNullOrWhiteSpace(EditionInput.Isbn) ? null : EditionInput.Isbn.Trim(),
                         Format = EditionInput.Format,
-                        DatePrinted = EditionInput.DatePrinted,
+                        DatePrinted = datePrinted.Date,
+                        DatePrintedPrecision = datePrinted.Precision,
                         Publisher = publisher,
                         CoverUrl = string.IsNullOrWhiteSpace(EditionInput.CoverUrl) ? null : EditionInput.CoverUrl.Trim(),
                         Copies = [new Copy { Condition = CopyInput.Condition }]

--- a/BookTracker.Web/ViewModels/BookEditViewModel.cs
+++ b/BookTracker.Web/ViewModels/BookEditViewModel.cs
@@ -96,7 +96,7 @@ public class BookEditViewModel(
                 Title = primary.Title,
                 Subtitle = primary.Subtitle,
                 Author = primary.Author.Name,
-                FirstPublishedDate = primary.FirstPublishedDate,
+                FirstPublishedDate = PartialDateParser.Format(primary.FirstPublishedDate, primary.FirstPublishedDatePrecision),
             };
             SelectedGenreIds = primary.Genres.Select(g => g.Id).ToList();
             SelectedSeriesId = primary.SeriesId;
@@ -116,8 +116,9 @@ public class BookEditViewModel(
         EditionCopies = book.Editions
             .SelectMany(e => e.Copies.Select(c => new EditionCopyRow(
                 e.Id, c.Id, e.Isbn, e.Format, c.Condition,
-                e.Publisher?.Name, e.DatePrinted, e.CoverUrl,
-                c.Notes, c.DateAcquired)))
+                e.Publisher?.Name,
+                PartialDateParser.Format(e.DatePrinted, e.DatePrintedPrecision),
+                e.CoverUrl, c.Notes, c.DateAcquired)))
             .ToList();
 
         await LoadAvailableTagsAsync();
@@ -214,7 +215,10 @@ public class BookEditViewModel(
             if (string.IsNullOrWhiteSpace(NewEditionInput.Isbn)) NewEditionInput.Isbn = result.Isbn;
             if (string.IsNullOrWhiteSpace(NewEditionInput.Publisher)) NewEditionInput.Publisher = result.Publisher;
             if (string.IsNullOrWhiteSpace(NewEditionInput.CoverUrl)) NewEditionInput.CoverUrl = result.CoverUrl;
-            NewEditionInput.DatePrinted ??= result.DatePrinted;
+            if (string.IsNullOrWhiteSpace(NewEditionInput.DatePrinted) && result.DatePrinted is DateOnly d)
+            {
+                NewEditionInput.DatePrinted = PartialDateParser.Format(d, result.DatePrintedPrecision);
+            }
             if (result.Format is BookFormat fmt) NewEditionInput.Format = fmt;
 
             NewEditionLookupMessage = $"Prefilled from {result.Source}. Edit anything before saving.";
@@ -243,12 +247,14 @@ public class BookEditViewModel(
             }
         }
 
+        var datePrinted = PartialDateParser.TryParse(NewEditionInput.DatePrinted) ?? PartialDate.Empty;
         var edition = new Edition
         {
             BookId = bookId,
             Isbn = NewEditionInput.Isbn.Trim(),
             Format = NewEditionInput.Format,
-            DatePrinted = NewEditionInput.DatePrinted,
+            DatePrinted = datePrinted.Date,
+            DatePrintedPrecision = datePrinted.Precision,
             Publisher = publisher,
             CoverUrl = string.IsNullOrWhiteSpace(NewEditionInput.CoverUrl) ? null : NewEditionInput.CoverUrl.Trim(),
             Copies = [new Copy { Condition = NewCopyInput.Condition }]
@@ -260,7 +266,9 @@ public class BookEditViewModel(
         var copy = edition.Copies[0];
         EditionCopies.Add(new EditionCopyRow(
             edition.Id, copy.Id, edition.Isbn, edition.Format, copy.Condition,
-            publisher?.Name, edition.DatePrinted, edition.CoverUrl, copy.Notes, copy.DateAcquired));
+            publisher?.Name,
+            PartialDateParser.Format(edition.DatePrinted, edition.DatePrintedPrecision),
+            edition.CoverUrl, copy.Notes, copy.DateAcquired));
         ShowingNewEdition = false;
     }
 
@@ -273,7 +281,7 @@ public class BookEditViewModel(
             Format = row.Format,
             Condition = row.Condition,
             Publisher = row.PublisherName,
-            DatePrinted = row.DatePrinted
+            DatePrinted = row.DatePrintedDisplay
         };
     }
 
@@ -290,7 +298,9 @@ public class BookEditViewModel(
         var edition = copy.Edition;
         edition.Isbn = EditCopyInput.Isbn?.Trim() ?? edition.Isbn;
         edition.Format = EditCopyInput.Format;
-        edition.DatePrinted = EditCopyInput.DatePrinted;
+        var datePrinted = PartialDateParser.TryParse(EditCopyInput.DatePrinted) ?? PartialDate.Empty;
+        edition.DatePrinted = datePrinted.Date;
+        edition.DatePrintedPrecision = datePrinted.Precision;
         copy.Condition = EditCopyInput.Condition;
 
         var pubName = EditCopyInput.Publisher?.Trim();
@@ -317,7 +327,9 @@ public class BookEditViewModel(
         {
             EditionCopies[idx] = new EditionCopyRow(
                 edition.Id, copy.Id, edition.Isbn, edition.Format, copy.Condition,
-                pubName, edition.DatePrinted, edition.CoverUrl, copy.Notes, copy.DateAcquired);
+                pubName,
+                PartialDateParser.Format(edition.DatePrinted, edition.DatePrintedPrecision),
+                edition.CoverUrl, copy.Notes, copy.DateAcquired);
         }
         EditingCopyId = null;
     }
@@ -452,7 +464,9 @@ public class BookEditViewModel(
                 primary.Title = PrimaryWorkInput.Title!.Trim();
                 primary.Subtitle = string.IsNullOrWhiteSpace(PrimaryWorkInput.Subtitle) ? null : PrimaryWorkInput.Subtitle.Trim();
                 primary.Author = await AuthorResolver.FindOrCreateAsync(PrimaryWorkInput.Author!, db);
-                primary.FirstPublishedDate = PrimaryWorkInput.FirstPublishedDate;
+                var firstPub = PartialDateParser.TryParse(PrimaryWorkInput.FirstPublishedDate) ?? PartialDate.Empty;
+                primary.FirstPublishedDate = firstPub.Date;
+                primary.FirstPublishedDatePrecision = firstPub.Precision;
                 primary.SeriesId = SelectedSeriesId;
                 primary.SeriesOrder = SelectedSeriesId.HasValue ? SeriesOrder : null;
 
@@ -474,7 +488,7 @@ public class BookEditViewModel(
 
     public record SeriesOption(int Id, string Name, SeriesType Type);
     public record TagItem(int Id, string Name);
-    public record EditionCopyRow(int EditionId, int CopyId, string? Isbn, BookFormat Format, BookCondition Condition, string? PublisherName, DateOnly? DatePrinted, string? CoverUrl, string? CopyNotes, DateTime? DateAcquired);
+    public record EditionCopyRow(int EditionId, int CopyId, string? Isbn, BookFormat Format, BookCondition Condition, string? PublisherName, string DatePrintedDisplay, string? CoverUrl, string? CopyNotes, DateTime? DateAcquired);
     public record WorkSummary(int Id, string Title, string Author, int GenreCount);
 
     public class CopyEditInput
@@ -483,6 +497,7 @@ public class BookEditViewModel(
         public BookFormat Format { get; set; }
         public BookCondition Condition { get; set; }
         public string? Publisher { get; set; }
-        public DateOnly? DatePrinted { get; set; }
+        // Free-form date text — parsed via PartialDateParser at save time.
+        public string? DatePrinted { get; set; }
     }
 }

--- a/BookTracker.Web/ViewModels/BulkAddViewModel.cs
+++ b/BookTracker.Web/ViewModels/BulkAddViewModel.cs
@@ -61,6 +61,7 @@ public class BulkAddViewModel(
                 row.Publisher = result.Publisher;
                 row.Subtitle = result.Subtitle;
                 row.DatePrinted = result.DatePrinted;
+                row.DatePrintedPrecision = result.DatePrintedPrecision;
                 row.GenreCandidates = result.GenreCandidates.ToList();
                 row.Format = result.Format;
                 row.Status = RowStatus.Found;
@@ -201,6 +202,7 @@ public class BulkAddViewModel(
                     Isbn = row.Isbn,
                     Format = row.Format ?? BookFormat.TradePaperback,
                     DatePrinted = row.DatePrinted,
+                    DatePrintedPrecision = row.DatePrintedPrecision,
                     Publisher = publisher,
                     Copies = [new Copy { Condition = BookCondition.Good }]
                 }
@@ -249,6 +251,7 @@ public class BulkAddViewModel(
         public string? Source { get; set; }
         public string? Publisher { get; set; }
         public DateOnly? DatePrinted { get; set; }
+        public DatePrecision DatePrintedPrecision { get; set; } = DatePrecision.Day;
         public List<string> GenreCandidates { get; set; } = [];
         // Null when the lookup couldn't infer a confident format; the save
         // path falls back to TradePaperback so manual override still wins

--- a/BookTracker.Web/ViewModels/EditionFormViewModel.cs
+++ b/BookTracker.Web/ViewModels/EditionFormViewModel.cs
@@ -31,7 +31,10 @@ public class EditionFormViewModel(IDbContextFactory<BookTrackerDbContext> dbFact
 
         public BookFormat Format { get; set; } = BookFormat.TradePaperback;
 
-        public DateOnly? DatePrinted { get; set; }
+        // Free-form text — accepts "1973", "Oct 1973", "12 Oct 1973",
+        // "1973-10", "1973-10-12". Parsed into Edition.DatePrinted +
+        // Edition.DatePrintedPrecision at save time.
+        public string? DatePrinted { get; set; }
 
         [StringLength(200)]
         public string? Publisher { get; set; }

--- a/BookTracker.Web/ViewModels/WorkFormViewModel.cs
+++ b/BookTracker.Web/ViewModels/WorkFormViewModel.cs
@@ -18,6 +18,9 @@ public class WorkFormViewModel
         [Required, StringLength(200)]
         public string? Author { get; set; }
 
-        public DateOnly? FirstPublishedDate { get; set; }
+        // Free-form text — accepts "1973", "Oct 1973", "12 Oct 1973",
+        // "1973-10", "1973-10-12". Parsed into Work.FirstPublishedDate +
+        // Work.FirstPublishedDatePrecision at save time.
+        public string? FirstPublishedDate { get; set; }
     }
 }


### PR DESCRIPTION
Older books often only carry a year ("1973") or a month-year
("October 1973") on their copyright page, so forcing a full DateOnly
input was wrong. This adds a DatePrecision enum (Day | Month | Year)
as a companion column on Edition.DatePrinted and Work.FirstPublishedDate
— the DateOnly storage stays sortable (month/day default to 1) while
the precision flag drives display formatting.

Schema (additive AddDatePrecisionColumns migration):
- Editions.DatePrintedPrecision (int, default 0 = Day)
- Works.FirstPublishedDatePrecision (int, default 0 = Day)
Existing rows default to Day precision since previous data was always
full DateOnly. The user can re-edit any row to set precision properly.

New PartialDateParser helper rounds the loop:
- Parses "1973", "1973-10", "10/1973", "Oct 1973", "October 1973",
  "1973-10-12", "12 Oct 1973", "12 October 1973".
- Format(date, precision) renders "1973" / "Oct 1973" / "12 Oct 1973".
- Rejects out-of-range years (<1400 or >2999), invalid months, and
  garbage text — returns null so the form can surface "couldn't read
  that date" instead of silently dropping input.

Form inputs: EditionFormViewModel.DatePrinted and
WorkFormViewModel.FirstPublishedDate are now string text fields
(parsed at save time). Razor inputs swapped from <InputDate> to
<InputText> with placeholder hint "e.g. 1973, Oct 1973, or 12 Oct
1973". Edit page Editions table renders a precision-aware display
string and the inline copy-edit row uses a text input too.

BookLookupService.ParseLooseDate now returns (DateOnly?, DatePrecision)
— Open Library's bare-year publish_date entries land as Year precision
so a Christie ISBN that returns "1934" no longer prefills as
"1 Jan 1934" in the Add form.

Tests: PartialDateParserTests covers each input shape (year / month-
year / full date / blank / garbage), round-trip preservation, and the
Format helper. Existing BookAddViewModelTests updated for the
string-typed FirstPublishedDate input.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
