### PR TITLE
chore(ui): route scanner JS through @Assets so each deploy cache-busts it

### DIFF
--- a/BookTracker.Web/Components/App.razor
+++ b/BookTracker.Web/Components/App.razor
@@ -15,8 +15,12 @@
     <Routes @rendermode="InteractiveServer" />
     <script src="@Assets["lib/bootstrap/dist/js/bootstrap.bundle.min.js"]"></script>
     <script src="_framework/blazor.web.js"></script>
-    <script src="lib/html5-qrcode/html5-qrcode.min.js"></script>
-    <script src="js/barcode-scanner.js"></script>
-    <script src="js/photo-capture.js"></script>
+    @* Route these through @Assets[] so each deploy cache-busts them. Mobile
+       users were otherwise stuck on a cached html5-qrcode.min.js / barcode-
+       scanner.js from a previous deploy, which surfaced as the scanner
+       panel flashing open and closing immediately after click. *@
+    <script src="@Assets["lib/html5-qrcode/html5-qrcode.min.js"]"></script>
+    <script src="@Assets["js/barcode-scanner.js"]"></script>
+    <script src="@Assets["js/photo-capture.js"]"></script>
 </body>
 </html>


### PR DESCRIPTION
The three vendored scripts loaded from the plain-path <script src="…">
lines in App.razor (html5-qrcode.min.js + barcode-scanner.js +
photo-capture.js) weren't being fingerprinted. Mobile users hit the
cached previous-deploy copy of these files after a release, which
surfaced as the bulk-add scanner panel flashing open and closing
immediately after click — start() threw against a stale library /
stale JS interop wrapper. Moving them behind @Assets[] gets them the
same hash-suffixed URLs the framework and Bootstrap scripts already
have, so every deploy is a fresh fetch.

No functional change when the browser isn't cached.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
