### PR TITLE
feat(lookup): chain Trove (NLA) after Open Library + Google Books for…

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -91,7 +91,7 @@ The app follows an MVVM (Model-View-ViewModel) pattern:
 
 - **ViewModels** are plain C# classes under `BookTracker.Web/ViewModels/`. They hold all state and business logic.
 - **Razor components** are thin views that inject a VM and bind to its properties. They handle only UI concerns: JS interop, navigation, Blazor lifecycle.
-- **Services** handle external concerns: ISBN lookup (Open Library / Google Books), AI features (Anthropic API), series matching.
+- **Services** handle external concerns: ISBN lookup (Open Library / Google Books / Trove), AI features (Anthropic API), series matching.
 
 VM lifetime:
 - **Transient**: most VMs — each component instance gets its own.
@@ -134,7 +134,7 @@ A short-lived context is created per operation. Never inject `DbContext` directl
 ## Services
 
 ### BookLookupService
-Looks up book metadata by ISBN. Tries Open Library first, falls back to Google Books. Returns `BookLookupResult` with title, author, publisher, genres, cover URL, etc.
+Looks up book metadata by ISBN. Tries Open Library first, falls back to Google Books, then Trove (NLA) as a coverage-of-last-resort for self-published / Australian titles the other two tend to miss. Trove is skipped silently when no API key is configured. Returns `BookLookupResult` with title, author, publisher, genres, cover URL, etc.
 
 ### SeriesMatchService
 Local series detection after ISBN lookup. Strategies:
@@ -203,8 +203,9 @@ CI runs `dotnet test` on all PRs to main.
 | `AI:AzureOpenAI:Endpoint` | Bicep output | Azure OpenAI endpoint URL |
 | `AI:AzureOpenAI:ApiKey` | Key Vault ref (written by Bicep via `listKeys()`) | Azure OpenAI key |
 | `AI:AzureOpenAI:Deployment` | Bicep output | GPT-4o deployment name |
+| `Trove:ApiKey` | Key Vault ref (prod) / appsettings (dev) | National Library of Australia API key — optional third-line ISBN lookup provider |
 
-In prod, secret App Settings resolve via `@Microsoft.KeyVault(SecretUri=…)` references — the App Service's managed identity has `Key Vault Secrets User` on the vault. `deploy.ps1` writes `AuthClientSecret` + optionally `AIAnthropicApiKey` to the vault; `ai-services.bicep` writes `AIAzureOpenAIApiKey` via `listKeys()` against the newly-created OpenAI account.
+In prod, secret App Settings resolve via `@Microsoft.KeyVault(SecretUri=…)` references — the App Service's managed identity has `Key Vault Secrets User` on the vault. `deploy.ps1` writes `AuthClientSecret` + optionally `AIAnthropicApiKey` and `TroveApiKey` to the vault; `ai-services.bicep` writes `AIAzureOpenAIApiKey` via `listKeys()` against the newly-created OpenAI account.
 
 Dev config templates: `appsettings.Example.json`, `appsettings.Development.Example.json`. Copy and fill in secrets. Only configure providers you want to use — the toggle auto-detects available providers.
 

--- a/BookTracker.Tests/Services/BookLookupServiceTests.cs
+++ b/BookTracker.Tests/Services/BookLookupServiceTests.cs
@@ -1,0 +1,206 @@
+using System.Net;
+using System.Text;
+using BookTracker.Web.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace BookTracker.Tests.Services;
+
+public class BookLookupServiceTests
+{
+    private const string Isbn = "9780645840407";
+
+    [Fact]
+    public async Task LookupByIsbnAsync_UsesOpenLibraryFirst_AndDoesNotCallDownstreamProviders()
+    {
+        var handler = new FakeHandler
+        {
+            ["openlibrary.org/api/books"] = OkJson($$"""
+                {
+                  "ISBN:{{Isbn}}": {
+                    "title": "Open Library Title",
+                    "authors": [ { "name": "OL Author" } ]
+                  }
+                }
+                """)
+        };
+
+        var svc = CreateService(handler, troveKey: "present");
+        var result = await svc.LookupByIsbnAsync(Isbn, CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.Equal("Open Library", result!.Source);
+        Assert.Equal("Open Library Title", result.Title);
+        Assert.DoesNotContain(handler.Requests, r => r.Contains("googleapis.com"));
+        Assert.DoesNotContain(handler.Requests, r => r.Contains("trove.nla.gov.au"));
+    }
+
+    [Fact]
+    public async Task LookupByIsbnAsync_FallsThroughToTrove_WhenOpenLibraryAndGoogleBooksMiss()
+    {
+        var handler = new FakeHandler
+        {
+            // Open Library returns an empty object: no key matching the ISBN.
+            ["openlibrary.org/api/books"] = OkJson("{}"),
+            // Google Books returns no items.
+            ["googleapis.com/books/v1/volumes"] = OkJson("""{ "items": [] }"""),
+            ["trove.nla.gov.au"] = OkJson($$"""
+                {
+                  "category": [
+                    {
+                      "code": "book",
+                      "records": {
+                        "total": 1,
+                        "work": [
+                          {
+                            "title": "Trove Title",
+                            "contributor": ["Trove Author"],
+                            "issued": "2022",
+                            "subject": ["Horror", "Fiction"]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+                """)
+        };
+
+        var svc = CreateService(handler, troveKey: "present");
+        var result = await svc.LookupByIsbnAsync(Isbn, CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.Equal("Trove", result!.Source);
+        Assert.Equal("Trove Title", result.Title);
+        Assert.Equal("Trove Author", result.Author);
+        Assert.Equal(2022, result.DatePrinted?.Year);
+        Assert.Contains(result.GenreCandidates, g => g.Contains("Horror", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task LookupByIsbnAsync_SkipsTroveSilently_WhenApiKeyMissing()
+    {
+        var handler = new FakeHandler
+        {
+            ["openlibrary.org/api/books"] = OkJson("{}"),
+            ["googleapis.com/books/v1/volumes"] = OkJson("""{ "items": [] }""")
+        };
+
+        var svc = CreateService(handler, troveKey: "");
+        var result = await svc.LookupByIsbnAsync(Isbn, CancellationToken.None);
+
+        Assert.Null(result);
+        Assert.DoesNotContain(handler.Requests, r => r.Contains("trove.nla.gov.au"));
+    }
+
+    [Fact]
+    public async Task LookupByIsbnAsync_HandlesSingleValueTroveFields_AsStringsOrArrays()
+    {
+        // Trove v3 sometimes returns multi-valued fields as a single string
+        // instead of a one-element array when there's only one value. The
+        // service should treat both shapes identically.
+        var handler = new FakeHandler
+        {
+            ["openlibrary.org/api/books"] = OkJson("{}"),
+            ["googleapis.com/books/v1/volumes"] = OkJson("""{ "items": [] }"""),
+            ["trove.nla.gov.au"] = OkJson("""
+                {
+                  "category": [
+                    {
+                      "code": "book",
+                      "records": {
+                        "total": 1,
+                        "work": [
+                          {
+                            "title": "Solo Title",
+                            "contributor": "Solo Author",
+                            "issued": "2019",
+                            "subject": "Mystery"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+                """)
+        };
+
+        var svc = CreateService(handler, troveKey: "present");
+        var result = await svc.LookupByIsbnAsync(Isbn, CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.Equal("Solo Author", result!.Author);
+        Assert.Contains(result.GenreCandidates, g => g.Contains("Mystery", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task LookupByIsbnAsync_ReturnsNull_WhenTroveReturnsNoWork()
+    {
+        var handler = new FakeHandler
+        {
+            ["openlibrary.org/api/books"] = OkJson("{}"),
+            ["googleapis.com/books/v1/volumes"] = OkJson("""{ "items": [] }"""),
+            ["trove.nla.gov.au"] = OkJson("""
+                {
+                  "category": [
+                    { "code": "book", "records": { "total": 0 } }
+                  ]
+                }
+                """)
+        };
+
+        var svc = CreateService(handler, troveKey: "present");
+        var result = await svc.LookupByIsbnAsync(Isbn, CancellationToken.None);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task LookupByIsbnAsync_ReturnsNull_ForMalformedIsbn()
+    {
+        var handler = new FakeHandler();
+        var svc = CreateService(handler, troveKey: "present");
+
+        var result = await svc.LookupByIsbnAsync("not-an-isbn", CancellationToken.None);
+
+        Assert.Null(result);
+        Assert.Empty(handler.Requests);
+    }
+
+    private static BookLookupService CreateService(FakeHandler handler, string troveKey)
+    {
+        var http = new HttpClient(handler);
+        var options = Options.Create(new TroveOptions { ApiKey = troveKey });
+        return new BookLookupService(http, NullLogger<BookLookupService>.Instance, options);
+    }
+
+    private static HttpResponseMessage OkJson(string body) => new(HttpStatusCode.OK)
+    {
+        Content = new StringContent(body, Encoding.UTF8, "application/json")
+    };
+
+    private sealed class FakeHandler : HttpMessageHandler
+    {
+        private readonly Dictionary<string, HttpResponseMessage> _routes = new();
+        public List<string> Requests { get; } = [];
+
+        public HttpResponseMessage this[string urlSubstring]
+        {
+            set => _routes[urlSubstring] = value;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var url = request.RequestUri?.ToString() ?? "";
+            Requests.Add(url);
+            foreach (var (substring, response) in _routes)
+            {
+                if (url.Contains(substring, StringComparison.OrdinalIgnoreCase))
+                {
+                    return Task.FromResult(response);
+                }
+            }
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+        }
+    }
+}

--- a/BookTracker.Web/Program.cs
+++ b/BookTracker.Web/Program.cs
@@ -25,6 +25,9 @@ builder.Services.AddSignalR(options =>
 builder.Services.AddDbContextFactory<BookTrackerDbContext>(options =>
     options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
 
+builder.Services.Configure<TroveOptions>(
+    builder.Configuration.GetSection(TroveOptions.SectionName));
+
 builder.Services.AddHttpClient<IBookLookupService, BookLookupService>(client =>
 {
     client.Timeout = TimeSpan.FromSeconds(10);

--- a/BookTracker.Web/Services/BookLookupService.cs
+++ b/BookTracker.Web/Services/BookLookupService.cs
@@ -2,10 +2,14 @@ using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using BookTracker.Data.Models;
+using Microsoft.Extensions.Options;
 
 namespace BookTracker.Web.Services;
 
-public class BookLookupService(HttpClient http, ILogger<BookLookupService> logger) : IBookLookupService
+public class BookLookupService(
+    HttpClient http,
+    ILogger<BookLookupService> logger,
+    IOptions<TroveOptions> troveOptions) : IBookLookupService
 {
     public async Task<BookLookupResult?> LookupByIsbnAsync(string isbn, CancellationToken ct)
     {
@@ -15,8 +19,13 @@ public class BookLookupService(HttpClient http, ILogger<BookLookupService> logge
             return null;
         }
 
+        // Trove (National Library of Australia) sits last in the chain as a
+        // coverage-of-last-resort for self-published / Australian titles that
+        // Open Library and Google Books tend to miss. Skipped silently when
+        // no API key is configured.
         return await TryOpenLibraryAsync(cleanIsbn, ct)
-            ?? await TryGoogleBooksAsync(cleanIsbn, ct);
+            ?? await TryGoogleBooksAsync(cleanIsbn, ct)
+            ?? await TryTroveAsync(cleanIsbn, ct);
     }
 
     public async Task<IReadOnlyList<BookSearchCandidate>> SearchByTitleAuthorAsync(
@@ -149,6 +158,82 @@ public class BookLookupService(HttpClient http, ILogger<BookLookupService> logge
         }
     }
 
+    private async Task<BookLookupResult?> TryTroveAsync(string isbn, CancellationToken ct)
+    {
+        var key = troveOptions.Value.ApiKey;
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            return null;
+        }
+
+        try
+        {
+            // include=all pulls in subject + contributor so we can map genres
+            // and author. n=1 because we only care about the top match.
+            var query = Uri.EscapeDataString($"isbn:{isbn}");
+            var url = $"https://api.trove.nla.gov.au/v3/result?q={query}&category=book&encoding=json&n=1&include=all&key={Uri.EscapeDataString(key)}";
+            var doc = await http.GetFromJsonAsync<TroveResponse>(url, ct);
+            var work = doc?.Category?
+                .FirstOrDefault(c => string.Equals(c.Code, "book", StringComparison.OrdinalIgnoreCase))?
+                .Records?.Work?.FirstOrDefault();
+            if (work is null || string.IsNullOrWhiteSpace(work.Title))
+            {
+                return null;
+            }
+
+            // Trove v3 returns multi-valued fields as arrays but occasionally
+            // falls back to a single string when there's only one value — the
+            // helper flattens both shapes.
+            var author = TroveStringValues(work.Contributor).FirstOrDefault();
+            var genres = TroveStringValues(work.Subject)
+                .Select(CleanGenre)
+                .Where(n => n is not null)
+                .Cast<string>()
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Take(10)
+                .ToList();
+            var (date, precision) = ParseLooseDate(work.Issued);
+
+            return new BookLookupResult(
+                Isbn: isbn,
+                Title: work.Title,
+                Subtitle: null,
+                Author: author,
+                Publisher: null,
+                GenreCandidates: genres,
+                DatePrinted: date,
+                CoverUrl: null,
+                Source: "Trove",
+                DatePrintedPrecision: precision);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Trove lookup failed for ISBN {Isbn}", isbn);
+            return null;
+        }
+    }
+
+    private static IEnumerable<string> TroveStringValues(JsonElement element)
+    {
+        switch (element.ValueKind)
+        {
+            case JsonValueKind.String:
+                var s = element.GetString();
+                if (!string.IsNullOrWhiteSpace(s)) yield return s;
+                break;
+            case JsonValueKind.Array:
+                foreach (var item in element.EnumerateArray())
+                {
+                    if (item.ValueKind == JsonValueKind.String)
+                    {
+                        var str = item.GetString();
+                        if (!string.IsNullOrWhiteSpace(str)) yield return str;
+                    }
+                }
+                break;
+        }
+    }
+
     private static string? CleanGenre(string raw) => GenreCandidateCleaner.Clean(raw);
 
     // Open Library / Google Books often only give a year ("1934") so we
@@ -224,5 +309,29 @@ public class BookLookupService(HttpClient http, ILogger<BookLookupService> logge
         [JsonPropertyName("first_publish_year")] public int? FirstPublishYear { get; set; }
         [JsonPropertyName("edition_count")] public int? EditionCount { get; set; }
         [JsonPropertyName("cover_i")] public int? CoverId { get; set; }
+    }
+
+    private sealed class TroveResponse
+    {
+        [JsonPropertyName("category")] public List<TroveCategory>? Category { get; set; }
+    }
+    private sealed class TroveCategory
+    {
+        [JsonPropertyName("code")] public string? Code { get; set; }
+        [JsonPropertyName("records")] public TroveRecords? Records { get; set; }
+    }
+    private sealed class TroveRecords
+    {
+        [JsonPropertyName("total")] public int Total { get; set; }
+        [JsonPropertyName("work")] public List<TroveWork>? Work { get; set; }
+    }
+    private sealed class TroveWork
+    {
+        [JsonPropertyName("title")] public string? Title { get; set; }
+        [JsonPropertyName("issued")] public string? Issued { get; set; }
+        // contributor / subject arrive as either a single string or an array;
+        // JsonElement lets TroveStringValues normalise both shapes.
+        [JsonPropertyName("contributor")] public JsonElement Contributor { get; set; }
+        [JsonPropertyName("subject")] public JsonElement Subject { get; set; }
     }
 }

--- a/BookTracker.Web/Services/TroveOptions.cs
+++ b/BookTracker.Web/Services/TroveOptions.cs
@@ -1,0 +1,8 @@
+namespace BookTracker.Web.Services;
+
+public class TroveOptions
+{
+    public const string SectionName = "Trove";
+
+    public string ApiKey { get; set; } = "";
+}

--- a/BookTracker.Web/appsettings.Development.Example.json
+++ b/BookTracker.Web/appsettings.Development.Example.json
@@ -3,6 +3,9 @@
   "ConnectionStrings": {
     "DefaultConnection": "Server=localhost,1433;Database=BookTracker;User Id=sa;Password=<your-docker-sa-password>;TrustServerCertificate=True;MultipleActiveResultSets=true"
   },
+  "Trove": {
+    "ApiKey": ""
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/BookTracker.Web/appsettings.Example.json
+++ b/BookTracker.Web/appsettings.Example.json
@@ -19,6 +19,9 @@
       "Deployment": ""
     }
   },
+  "Trove": {
+    "ApiKey": ""
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/TODO.md
+++ b/TODO.md
@@ -9,6 +9,7 @@ Outstanding work items for BookTracker. This is the single source of truth — c
 - [ ] GitHub Environment with required reviewers for staging-to-production slot swap (`infra/README.md`)
 - [ ] Re-add Microsoft Foundry (Claude on Azure) once on an EA / MCA-E subscription — Sponsored subscriptions are not eligible. Brings back `claude-sonnet-4-6` + `claude-opus-4-7` deployments, the Foundry Private Endpoint, and the `cognitiveservices.azure.com` DNS zone. Direct Anthropic API works in the meantime.
 - [ ] Schedule rotation of the Easy Auth client secret (`infra/deploy.ps1:105`) — currently rotated only when `deploy.ps1` is re-run, with a 2-year expiry. Options: time-triggered Function/Logic App that rotates the secret + writes the new value to KV, or move to a federated credential / certificate-based credential to drop the secret entirely.
+- [ ] Validate Trove ISBN lookup end-to-end once the NLA API key arrives — drop key into `appsettings.Development.json`, retry a self-published ISBN the other providers miss (e.g. `9780645840407`), and confirm the DTO parse matches Trove's live v3 response. Follow-up PR if the shape differs from the one coded against.
 
 ## UI / UX
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -61,6 +61,7 @@ All secret App Settings resolve via `@Microsoft.KeyVault(SecretUri=…)` referen
 | `MICROSOFT_PROVIDER_AUTHENTICATION_SECRET` | `AuthClientSecret` | rotated by `deploy.ps1` (2-year expiry) |
 | `AI__AzureOpenAI__ApiKey` | `AIAzureOpenAIApiKey` | written by `ai-services.bicep` via `listKeys()` — never seen by the deploy script |
 | `AI__Anthropic__ApiKey` | `AIAnthropicApiKey` | optional; supplied via `-AnthropicApiKey` |
+| `Trove__ApiKey` | `TroveApiKey` | optional; supplied via `-TroveApiKey` |
 
 App Service caches resolved KV values; rotating a secret takes effect on the next reference refresh (~24h, or immediate via portal "Refresh Key Vault references").
 
@@ -91,6 +92,7 @@ Optional parameters:
 | `-SecondaryLocation` | `eastus2` | region for the AI VNet + OpenAI account |
 | `-DevClientIp` | _empty_ | optional IPv4 to whitelist on the SQL firewall for ad-hoc local EF migrations; leave blank to keep SQL fully private |
 | `-AnthropicApiKey` | _empty_ | optional `sk-ant-…`; when supplied it's stored in Key Vault and exposed via a KV ref |
+| `-TroveApiKey` | _empty_ | optional NLA Trove API key; when supplied it's stored in Key Vault and exposed via a KV ref |
 
 What the script does:
 1. Signs you in to Azure + Microsoft Graph.
@@ -159,6 +161,20 @@ The Anthropic provider hits `api.anthropic.com` directly (no Azure resource need
 ```
 
 The script passes the key to Bicep, which writes it to Key Vault as `AIAnthropicApiKey`. The `AI__Anthropic__ApiKey` App Setting becomes a KV reference. Rotate later by re-running the deploy with a new key.
+
+## ISBN lookup providers
+
+`BookLookupService` tries Open Library first, then Google Books. Both are keyless and zero-config. A third provider, **Trove** (National Library of Australia), sits at the end of the chain and specifically catches self-published / Australian titles the other two tend to miss. Trove requires a free API key.
+
+### Trove (optional)
+
+Register at `https://trove.nla.gov.au/about/create-something/using-api` — approvals can take a few days. Once you have the key, provision it the same way as the Anthropic key:
+
+```powershell
+./deploy.ps1 -TenantId … -SubscriptionId … -TroveApiKey '<your-key>'
+```
+
+The script writes it to Key Vault as `TroveApiKey`; the `Trove__ApiKey` App Setting becomes a KV reference. Without a key, the Trove branch of the lookup chain is skipped silently — Open Library and Google Books continue to work as before.
 
 ### Azure OpenAI (gpt-4o, eastus2)
 

--- a/infra/deploy.ps1
+++ b/infra/deploy.ps1
@@ -22,7 +22,11 @@ param(
     [string] $SecondaryLocation = 'eastus2',
     # Optional Anthropic public-API key. When supplied it's stored in Key
     # Vault and exposed via a KV reference in App Settings.
-    [string] $AnthropicApiKey = ''
+    [string] $AnthropicApiKey = '',
+    # Optional Trove (National Library of Australia) API key. Used as a
+    # third-line ISBN lookup provider for titles Open Library and Google
+    # Books don't index. Same storage pattern as AnthropicApiKey.
+    [string] $TroveApiKey = ''
 )
 
 $ErrorActionPreference = 'Stop'
@@ -121,6 +125,7 @@ $templateParams = @{
     devClientIp         = $DevClientIp
     secondaryLocation   = $SecondaryLocation
     anthropicApiKey     = $AnthropicApiKey
+    troveApiKey         = $TroveApiKey
 }
 
 $deployment = New-AzSubscriptionDeployment `

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -37,6 +37,10 @@ param secondaryLocation string = 'eastus2'
 @secure()
 param anthropicApiKey string = ''
 
+@description('Optional Trove (NLA) API key. When supplied it is stored in Key Vault and exposed as the Trove__ApiKey app setting via a KV reference.')
+@secure()
+param troveApiKey string = ''
+
 var tags = {
   Client: 'Drew'
   Environment: 'Production'
@@ -66,6 +70,7 @@ module resources './modules/resources.bicep' = {
     devClientIp: devClientIp
     secondaryLocation: secondaryLocation
     anthropicApiKey: anthropicApiKey
+    troveApiKey: troveApiKey
   }
 }
 

--- a/infra/modules/app-config.bicep
+++ b/infra/modules/app-config.bicep
@@ -16,6 +16,9 @@ param keyVaultName string
 @description('True if the optional Anthropic API key was supplied (and therefore stored in KV). When false the AI__Anthropic__ApiKey setting is omitted.')
 param hasAnthropicKey bool = false
 
+@description('True if the optional Trove API key was supplied (and therefore stored in KV). When false the Trove__ApiKey setting is omitted.')
+param hasTroveKey bool = false
+
 // AI provider config (non-secret values only — secrets resolve via KV refs).
 // MicrosoftFoundry settings are intentionally omitted: this subscription is
 // Sponsored, so Claude on Foundry isn't deployable; the MicrosoftFoundry
@@ -34,6 +37,7 @@ var kvBase = 'https://${keyVaultName}.vault.azure.net/secrets'
 var authClientSecretRef = '@Microsoft.KeyVault(SecretUri=${kvBase}/AuthClientSecret/)'
 var openAIKeyRef = '@Microsoft.KeyVault(SecretUri=${kvBase}/AIAzureOpenAIApiKey/)'
 var anthropicKeyRef = '@Microsoft.KeyVault(SecretUri=${kvBase}/AIAnthropicApiKey/)'
+var troveKeyRef = '@Microsoft.KeyVault(SecretUri=${kvBase}/TroveApiKey/)'
 
 // Build app settings as a single object so prod and staging stay in sync.
 // Conditional members let us omit Anthropic when no key was provided.
@@ -46,7 +50,8 @@ var baseAppSettings = {
   AI__AzureOpenAI__ApiKey: openAIKeyRef
   AI__AzureOpenAI__Deployment: aiAzureOpenAIDeployment
 }
-var appSettingsValues = hasAnthropicKey ? union(baseAppSettings, { AI__Anthropic__ApiKey: anthropicKeyRef }) : baseAppSettings
+var withAnthropic = hasAnthropicKey ? union(baseAppSettings, { AI__Anthropic__ApiKey: anthropicKeyRef }) : baseAppSettings
+var appSettingsValues = hasTroveKey ? union(withAnthropic, { Trove__ApiKey: troveKeyRef }) : withAnthropic
 
 resource app 'Microsoft.Web/sites@2023-12-01' existing = {
   name: appServiceName

--- a/infra/modules/keyvault.bicep
+++ b/infra/modules/keyvault.bicep
@@ -14,6 +14,8 @@ param stagingSlotPrincipalId string
 param authClientSecret string
 @secure()
 param anthropicApiKey string = ''
+@secure()
+param troveApiKey string = ''
 
 resource kv 'Microsoft.KeyVault/vaults@2023-07-01' = {
   name: keyVaultName
@@ -77,6 +79,14 @@ resource secretAnthropicApiKey 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = 
   name: 'AIAnthropicApiKey'
   properties: {
     value: anthropicApiKey
+  }
+}
+
+resource secretTroveApiKey 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = if (!empty(troveApiKey)) {
+  parent: kv
+  name: 'TroveApiKey'
+  properties: {
+    value: troveApiKey
   }
 }
 

--- a/infra/modules/resources.bicep
+++ b/infra/modules/resources.bicep
@@ -22,6 +22,10 @@ param secondaryLocation string = 'eastus2'
 @secure()
 param anthropicApiKey string = ''
 
+@description('Optional Trove (NLA) API key. When supplied it is stored in Key Vault and exposed as the Trove__ApiKey app setting via a KV reference.')
+@secure()
+param troveApiKey string = ''
+
 // Short suffix to keep globally-unique names (App Service hostname, SQL server
 // name) stable across re-deploys while still being unique per-subscription.
 var uniqueSuffix = substring(uniqueString(resourceGroup().id), 0, 6)
@@ -128,6 +132,7 @@ module kv './keyvault.bicep' = {
     stagingSlotPrincipalId: app.outputs.stagingPrincipalId
     authClientSecret: authClientSecret
     anthropicApiKey: anthropicApiKey
+    troveApiKey: troveApiKey
   }
 }
 
@@ -199,6 +204,7 @@ module appConfig './app-config.bicep' = {
     appInsightsConnectionString: obs.outputs.appInsightsConnectionString
     keyVaultName: keyVaultName
     hasAnthropicKey: !empty(anthropicApiKey)
+    hasTroveKey: !empty(troveApiKey)
     aiAzureOpenAIEndpoint: ai.outputs.openAIEndpoint
     aiAzureOpenAIDeployment: ai.outputs.openAIDeploymentName
   }


### PR DESCRIPTION
… ISBN fallback

Open Library and Google Books both miss self-published and Australian titles (e.g. 978-0-6458xxx registrants via Thorpe-Bowker / IngramSpark). Trove covers this long tail. Falls back silently when no API key is configured so the keyless dev loop is unchanged.

Trove key is optional end-to-end: pipe through deploy.ps1 -> main.bicep ->
resources.bicep -> keyvault.bicep (KV secret) + app-config.bicep (KV-ref app setting), mirroring the Anthropic key plumbing.