### PR TITLE
feat(duplicates): author merge (PR 2 of dedup series)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -126,7 +126,8 @@ A short-lived context is created per operation. Never inject `DbContext` directl
 | `/series/{id}` | Edit Series | Edit series, manage books in series, reorder |
 | `/shopping` | Shopping Mode | Mobile-optimised. "Do I have this?" (scan/search), series gaps, shopping list with "bought" action. |
 | `/assistant` | AI Assistant | Book advisor (Opus), genre cleanup, collection cataloguing, shopping suggestions (Sonnet). |
-| `/duplicates` | Duplicates | Tabs for Authors / Works / Books / Editions. Lists candidate duplicate pairs detected on-demand. Dismiss false positives (reversible via the "Dismissed" section). Merge actions ship in later PRs. Web-primary, desktop-first layout. |
+| `/duplicates` | Duplicates | Tabs for Authors / Works / Books / Editions. Lists candidate duplicate pairs detected on-demand. Dismiss false positives (reversible via the "Dismissed" section). Author pairs have a Merge → button. Web-primary, desktop-first layout. |
+| `/duplicates/merge/author/{idA}/{idB}` | Merge authors | Side-by-side review of the pair, radio to pick a winner, preview of impact (N works + M aliases to reassign), transactional merge. Refuses when the two authors resolve to different canonicals — user resolves aliases on `/authors` first. |
 
 ## Shared components
 
@@ -143,7 +144,10 @@ A short-lived context is created per operation. Never inject `DbContext` directl
 Looks up book metadata by ISBN. Tries Open Library first, falls back to Google Books, then Trove (NLA) as a coverage-of-last-resort for self-published / Australian titles the other two tend to miss. Trove is skipped silently when no API key is configured. Returns `BookLookupResult` with title, author, publisher, genres, cover URL, etc.
 
 ### DuplicateDetectionService
-Scans the library for candidate duplicate pairs across Authors, Works, Books, and Editions. Authors match on either normalised full name *or* shared surname + first-name initial (so "Doug Preston" / "Douglas Preston" / "D Preston" all surface together). Works, Books, and Editions use exact-after-normalisation. Dismissed pairs are persisted in `IgnoredDuplicate` (polymorphic table, unique on `(EntityType, LowerId, HigherId)`) and orphaned rows are swept on each run. Returns a `DuplicateReport`. Merge actions ship in later PRs.
+Scans the library for candidate duplicate pairs across Authors, Works, Books, and Editions. Authors match on either normalised full name *or* shared surname + first-name initial (so "Doug Preston" / "Douglas Preston" / "D Preston" all surface together). Works, Books, and Editions use exact-after-normalisation. Dismissed pairs are persisted in `IgnoredDuplicate` (polymorphic table, unique on `(EntityType, LowerId, HigherId)`) and orphaned rows are swept on each run. Returns a `DuplicateReport`.
+
+### AuthorMergeService
+Merges two Author rows after user review. Refuses when the two authors resolve to different canonicals (user must resolve aliases on `/authors` first). Otherwise runs in one transaction: reassigns `Work.AuthorId`, reassigns external aliases' `CanonicalAuthorId`, clears any `IgnoredDuplicate` rows mentioning the loser, deletes the loser. One edge case: when the winner is itself an alias of the loser, winner is promoted to canonical before the delete so its `CanonicalAuthorId` doesn't dangle. Returns a result with reassignment counts + a flag for the promotion case.
 
 ### SeriesMatchService
 Local series detection after ISBN lookup. Strategies:

--- a/BookTracker.Tests/Services/AuthorMergeServiceTests.cs
+++ b/BookTracker.Tests/Services/AuthorMergeServiceTests.cs
@@ -1,0 +1,231 @@
+using BookTracker.Data.Models;
+using BookTracker.Web.Services;
+
+namespace BookTracker.Tests.Services;
+
+public class AuthorMergeServiceTests
+{
+    private readonly TestDbContextFactory _factory = new();
+
+    private AuthorMergeService CreateService() => new(_factory);
+
+    // ─── LoadAsync ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task LoadAsync_returns_both_details_with_counts_and_samples()
+    {
+        var ids = await SeedAuthorsWithWorksAsync(
+            ("Douglas Preston", ["Title A", "Title B", "Title C"]),
+            ("Doug Preston", ["Title D"]));
+
+        var result = await CreateService().LoadAsync(ids[0], ids[1]);
+
+        Assert.NotNull(result.Lower);
+        Assert.NotNull(result.Higher);
+        Assert.Equal(3, result.Lower!.WorkCount);
+        Assert.Equal(1, result.Higher!.WorkCount);
+        Assert.Null(result.IncompatibilityReason);
+    }
+
+    [Fact]
+    public async Task LoadAsync_reports_incompatibility_for_different_canonicals()
+    {
+        // "Doug Preston" aliased to Z1; "Douglas Preston" aliased to Z2.
+        // Directly merging these would silently drop one of the aliasings.
+        using var db = _factory.CreateDbContext();
+        var z1 = new Author { Name = "Canonical A" };
+        var z2 = new Author { Name = "Canonical B" };
+        db.Authors.AddRange(z1, z2);
+        await db.SaveChangesAsync();
+        var d1 = new Author { Name = "Doug Preston", CanonicalAuthorId = z1.Id };
+        var d2 = new Author { Name = "Douglas Preston", CanonicalAuthorId = z2.Id };
+        db.Authors.AddRange(d1, d2);
+        await db.SaveChangesAsync();
+
+        var result = await CreateService().LoadAsync(d1.Id, d2.Id);
+
+        Assert.NotNull(result.IncompatibilityReason);
+    }
+
+    [Fact]
+    public async Task LoadAsync_permits_merge_when_loser_is_alias_of_winner()
+    {
+        using var db = _factory.CreateDbContext();
+        var canonical = new Author { Name = "Stephen King" };
+        db.Authors.Add(canonical);
+        await db.SaveChangesAsync();
+        var alias = new Author { Name = "Stephen King (dup)", CanonicalAuthorId = canonical.Id };
+        db.Authors.Add(alias);
+        await db.SaveChangesAsync();
+
+        var result = await CreateService().LoadAsync(canonical.Id, alias.Id);
+
+        Assert.Null(result.IncompatibilityReason);
+    }
+
+    // ─── MergeAsync — reassignments ───────────────────────────────────
+
+    [Fact]
+    public async Task MergeAsync_reassigns_works_and_deletes_loser()
+    {
+        var ids = await SeedAuthorsWithWorksAsync(
+            ("Douglas Preston", ["Title A", "Title B"]),
+            ("Doug Preston", ["Title C"]));
+
+        var result = await CreateService().MergeAsync(winnerId: ids[0], loserId: ids[1]);
+
+        Assert.True(result.Success);
+        Assert.Equal(1, result.WorksReassigned);
+        Assert.Equal("Douglas Preston", result.WinnerName);
+        Assert.Equal("Doug Preston", result.LoserName);
+
+        using var db = _factory.CreateDbContext();
+        Assert.Equal(3, db.Works.Count(w => w.AuthorId == ids[0]));
+        Assert.Null(db.Authors.FirstOrDefault(a => a.Id == ids[1]));
+    }
+
+    [Fact]
+    public async Task MergeAsync_reassigns_aliases_of_loser_to_winner()
+    {
+        using var db = _factory.CreateDbContext();
+        var winner = new Author { Name = "Stephen King" };
+        var loser = new Author { Name = "S. King" };
+        db.Authors.AddRange(winner, loser);
+        await db.SaveChangesAsync();
+        // An existing pen name pointing at the loser — should reattach to winner.
+        var bachman = new Author { Name = "Richard Bachman", CanonicalAuthorId = loser.Id };
+        db.Authors.Add(bachman);
+        await db.SaveChangesAsync();
+
+        var result = await CreateService().MergeAsync(winner.Id, loser.Id);
+
+        Assert.True(result.Success);
+        Assert.Equal(1, result.AliasesReassigned);
+
+        using var verify = _factory.CreateDbContext();
+        var reloaded = verify.Authors.First(a => a.Id == bachman.Id);
+        Assert.Equal(winner.Id, reloaded.CanonicalAuthorId);
+    }
+
+    [Fact]
+    public async Task MergeAsync_promotes_winner_when_winner_was_alias_of_loser()
+    {
+        // Case: winner is "Stephen King" (an alias of loser "Steve King").
+        // After merge, winner must be promoted to canonical — otherwise its
+        // CanonicalAuthorId dangles at the deleted loser.
+        using var db = _factory.CreateDbContext();
+        var loser = new Author { Name = "Steve King" };
+        db.Authors.Add(loser);
+        await db.SaveChangesAsync();
+        var winner = new Author { Name = "Stephen King", CanonicalAuthorId = loser.Id };
+        db.Authors.Add(winner);
+        await db.SaveChangesAsync();
+
+        var result = await CreateService().MergeAsync(winner.Id, loser.Id);
+
+        Assert.True(result.Success);
+        Assert.True(result.WinnerPromotedToCanonical);
+
+        using var verify = _factory.CreateDbContext();
+        var reloaded = verify.Authors.First(a => a.Id == winner.Id);
+        Assert.Null(reloaded.CanonicalAuthorId);
+    }
+
+    [Fact]
+    public async Task MergeAsync_removes_ignored_duplicate_rows_referencing_loser()
+    {
+        var ids = await SeedAuthorsWithWorksAsync(
+            ("Douglas Preston", ["Title A"]),
+            ("Doug Preston", ["Title B"]),
+            ("Third Person", []));
+
+        using (var db = _factory.CreateDbContext())
+        {
+            db.IgnoredDuplicates.Add(new IgnoredDuplicate
+            {
+                EntityType = DuplicateEntityType.Author,
+                LowerId = Math.Min(ids[0], ids[1]),
+                HigherId = Math.Max(ids[0], ids[1])
+            });
+            // Unrelated pair that shouldn't be deleted.
+            db.IgnoredDuplicates.Add(new IgnoredDuplicate
+            {
+                EntityType = DuplicateEntityType.Author,
+                LowerId = Math.Min(ids[0], ids[2]),
+                HigherId = Math.Max(ids[0], ids[2])
+            });
+            await db.SaveChangesAsync();
+        }
+
+        await CreateService().MergeAsync(winnerId: ids[0], loserId: ids[1]);
+
+        using var verify = _factory.CreateDbContext();
+        Assert.Single(verify.IgnoredDuplicates);
+    }
+
+    // ─── MergeAsync — refusals ────────────────────────────────────────
+
+    [Fact]
+    public async Task MergeAsync_rejects_self_merge()
+    {
+        var ids = await SeedAuthorsWithWorksAsync(("Douglas Preston", []));
+
+        var result = await CreateService().MergeAsync(ids[0], ids[0]);
+
+        Assert.False(result.Success);
+        Assert.Contains("same", result.ErrorMessage!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task MergeAsync_rejects_missing_winner()
+    {
+        var ids = await SeedAuthorsWithWorksAsync(("Douglas Preston", []));
+
+        var result = await CreateService().MergeAsync(winnerId: 9999, loserId: ids[0]);
+
+        Assert.False(result.Success);
+    }
+
+    [Fact]
+    public async Task MergeAsync_rejects_incompatible_canonicals()
+    {
+        using var db = _factory.CreateDbContext();
+        var z1 = new Author { Name = "Canonical A" };
+        var z2 = new Author { Name = "Canonical B" };
+        db.Authors.AddRange(z1, z2);
+        await db.SaveChangesAsync();
+        var d1 = new Author { Name = "Doug Preston", CanonicalAuthorId = z1.Id };
+        var d2 = new Author { Name = "Douglas Preston", CanonicalAuthorId = z2.Id };
+        db.Authors.AddRange(d1, d2);
+        await db.SaveChangesAsync();
+
+        var result = await CreateService().MergeAsync(d1.Id, d2.Id);
+
+        Assert.False(result.Success);
+        Assert.NotNull(result.ErrorMessage);
+    }
+
+    // ─── Helpers ──────────────────────────────────────────────────────
+
+    private async Task<List<int>> SeedAuthorsWithWorksAsync(params (string Name, string[] WorkTitles)[] data)
+    {
+        using var db = _factory.CreateDbContext();
+        var authors = new List<Author>();
+        foreach (var (name, titles) in data)
+        {
+            var author = new Author { Name = name };
+            db.Authors.Add(author);
+            foreach (var t in titles)
+            {
+                db.Books.Add(new Book
+                {
+                    Title = t,
+                    Works = [new Work { Title = t, Author = author }]
+                });
+            }
+            authors.Add(author);
+        }
+        await db.SaveChangesAsync();
+        return authors.Select(a => a.Id).ToList();
+    }
+}

--- a/BookTracker.Tests/TestDbContextFactory.cs
+++ b/BookTracker.Tests/TestDbContextFactory.cs
@@ -1,11 +1,14 @@
 using BookTracker.Data;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 
 namespace BookTracker.Tests;
 
 /// <summary>
 /// Creates in-memory DbContext instances for unit testing.
 /// Each factory instance uses a unique database name so tests don't interfere.
+/// Transactions are silently no-oped by InMemory; we suppress the warning so
+/// services that wrap work in BeginTransactionAsync still pass under tests.
 /// </summary>
 public class TestDbContextFactory : IDbContextFactory<BookTrackerDbContext>
 {
@@ -16,6 +19,7 @@ public class TestDbContextFactory : IDbContextFactory<BookTrackerDbContext>
         databaseName ??= Guid.NewGuid().ToString();
         _options = new DbContextOptionsBuilder<BookTrackerDbContext>()
             .UseInMemoryDatabase(databaseName)
+            .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning))
             .Options;
     }
 

--- a/BookTracker.Tests/ViewModels/AuthorMergeViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/AuthorMergeViewModelTests.cs
@@ -1,0 +1,136 @@
+using BookTracker.Web.Services;
+using BookTracker.Web.ViewModels;
+using NSubstitute;
+
+namespace BookTracker.Tests.ViewModels;
+
+public class AuthorMergeViewModelTests
+{
+    private readonly IAuthorMergeService _merger = Substitute.For<IAuthorMergeService>();
+
+    private AuthorMergeViewModel CreateVm() => new(_merger);
+
+    private static AuthorMergeDetail Detail(int id, string name) =>
+        new(id, name, null, null, 0, 0, []);
+
+    [Fact]
+    public async Task LoadAsync_populates_both_details_and_clears_loading()
+    {
+        _merger.LoadAsync(1, 2, Arg.Any<CancellationToken>())
+            .Returns(new AuthorMergeLoadResult(Detail(1, "A"), Detail(2, "B"), null));
+
+        var vm = CreateVm();
+        await vm.LoadAsync(1, 2);
+
+        Assert.False(vm.Loading);
+        Assert.Equal("A", vm.Lower!.Name);
+        Assert.Equal("B", vm.Higher!.Name);
+        Assert.Null(vm.IncompatibilityReason);
+        Assert.Null(vm.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task LoadAsync_sets_error_when_entity_missing()
+    {
+        _merger.LoadAsync(1, 2, Arg.Any<CancellationToken>())
+            .Returns(new AuthorMergeLoadResult(null, Detail(2, "B"), null));
+
+        var vm = CreateVm();
+        await vm.LoadAsync(1, 2);
+
+        Assert.NotNull(vm.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task LoadAsync_surfaces_incompatibility_reason()
+    {
+        _merger.LoadAsync(1, 2, Arg.Any<CancellationToken>())
+            .Returns(new AuthorMergeLoadResult(Detail(1, "A"), Detail(2, "B"), "nope"));
+
+        var vm = CreateVm();
+        await vm.LoadAsync(1, 2);
+
+        Assert.Equal("nope", vm.IncompatibilityReason);
+        Assert.False(vm.CanMerge);
+    }
+
+    [Fact]
+    public async Task CanMerge_requires_a_selected_winner()
+    {
+        _merger.LoadAsync(1, 2, Arg.Any<CancellationToken>())
+            .Returns(new AuthorMergeLoadResult(Detail(1, "A"), Detail(2, "B"), null));
+
+        var vm = CreateVm();
+        await vm.LoadAsync(1, 2);
+
+        Assert.False(vm.CanMerge);
+        vm.SelectedWinnerId = 1;
+        Assert.True(vm.CanMerge);
+    }
+
+    [Fact]
+    public async Task LoserId_flips_based_on_selected_winner()
+    {
+        _merger.LoadAsync(1, 2, Arg.Any<CancellationToken>())
+            .Returns(new AuthorMergeLoadResult(Detail(1, "A"), Detail(2, "B"), null));
+
+        var vm = CreateVm();
+        await vm.LoadAsync(1, 2);
+
+        vm.SelectedWinnerId = 1;
+        Assert.Equal(2, vm.LoserId);
+        vm.SelectedWinnerId = 2;
+        Assert.Equal(1, vm.LoserId);
+    }
+
+    [Fact]
+    public async Task MergeAsync_calls_service_with_picked_winner_and_loser()
+    {
+        _merger.LoadAsync(1, 2, Arg.Any<CancellationToken>())
+            .Returns(new AuthorMergeLoadResult(Detail(1, "A"), Detail(2, "B"), null));
+        _merger.MergeAsync(1, 2, Arg.Any<CancellationToken>())
+            .Returns(new AuthorMergeResult(true, null, 3, 1, false, "A", "B"));
+
+        var vm = CreateVm();
+        await vm.LoadAsync(1, 2);
+        vm.SelectedWinnerId = 1;
+
+        var result = await vm.MergeAsync();
+
+        Assert.NotNull(result);
+        Assert.True(result!.Success);
+        await _merger.Received(1).MergeAsync(1, 2, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task MergeAsync_surfaces_error_when_service_fails()
+    {
+        _merger.LoadAsync(1, 2, Arg.Any<CancellationToken>())
+            .Returns(new AuthorMergeLoadResult(Detail(1, "A"), Detail(2, "B"), null));
+        _merger.MergeAsync(1, 2, Arg.Any<CancellationToken>())
+            .Returns(new AuthorMergeResult(false, "boom", 0, 0, false, null, null));
+
+        var vm = CreateVm();
+        await vm.LoadAsync(1, 2);
+        vm.SelectedWinnerId = 1;
+
+        await vm.MergeAsync();
+
+        Assert.Equal("boom", vm.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task MergeAsync_is_noop_when_no_winner_selected()
+    {
+        _merger.LoadAsync(1, 2, Arg.Any<CancellationToken>())
+            .Returns(new AuthorMergeLoadResult(Detail(1, "A"), Detail(2, "B"), null));
+
+        var vm = CreateVm();
+        await vm.LoadAsync(1, 2);
+
+        var result = await vm.MergeAsync();
+
+        Assert.Null(result);
+        await _merger.DidNotReceiveWithAnyArgs().MergeAsync(default, default, default);
+    }
+}

--- a/BookTracker.Web/Components/Pages/Duplicates/Index.razor
+++ b/BookTracker.Web/Components/Pages/Duplicates/Index.razor
@@ -56,7 +56,8 @@ else
             @foreach (var pair in VM.ActiveAuthorPairs)
             {
                 <PairCard MatchReason="@pair.MatchReason"
-                          OnDismiss="() => VM.DismissAsync(DuplicateEntityType.Author, pair.Lower.Id, pair.Higher.Id)">
+                          OnDismiss="() => VM.DismissAsync(DuplicateEntityType.Author, pair.Lower.Id, pair.Higher.Id)"
+                          MergeHref="@($"/duplicates/merge/author/{pair.Lower.Id}/{pair.Higher.Id}")">
                     <Left><AuthorSide Snap="pair.Lower" /></Left>
                     <Right><AuthorSide Snap="pair.Higher" /></Right>
                 </PairCard>
@@ -205,5 +206,26 @@ else
     private bool _showDismissedBooks;
     private bool _showDismissedEditions;
 
-    protected override async Task OnInitializedAsync() => await VM.LoadAsync();
+    // Surfaced from a successful merge redirect (e.g. from /duplicates/merge/author/*).
+    [SupplyParameterFromQuery(Name = "mergedAuthorWinner")] public string? MergedAuthorWinner { get; set; }
+    [SupplyParameterFromQuery(Name = "mergedAuthorLoser")] public string? MergedAuthorLoser { get; set; }
+    [SupplyParameterFromQuery(Name = "worksReassigned")] public int? WorksReassigned { get; set; }
+    [SupplyParameterFromQuery(Name = "aliasesReassigned")] public int? AliasesReassigned { get; set; }
+    [SupplyParameterFromQuery(Name = "promoted")] public string? Promoted { get; set; }
+
+    protected override async Task OnInitializedAsync()
+    {
+        await VM.LoadAsync();
+
+        if (!string.IsNullOrEmpty(MergedAuthorWinner) && !string.IsNullOrEmpty(MergedAuthorLoser))
+        {
+            VM.ActiveTab = DuplicateEntityType.Author;
+            var works = WorksReassigned ?? 0;
+            var aliases = AliasesReassigned ?? 0;
+            var promoted = Promoted == "1";
+            VM.SuccessMessage = $"Merged \"{MergedAuthorLoser}\" into \"{MergedAuthorWinner}\" — "
+                + $"{works} work{(works == 1 ? "" : "s")}, {aliases} alias{(aliases == 1 ? "" : "es")} reassigned."
+                + (promoted ? $" \"{MergedAuthorWinner}\" was promoted to canonical." : "");
+        }
+    }
 }

--- a/BookTracker.Web/Components/Pages/Duplicates/MergeAuthor.razor
+++ b/BookTracker.Web/Components/Pages/Duplicates/MergeAuthor.razor
@@ -1,0 +1,134 @@
+@page "/duplicates/merge/author/{idA:int}/{idB:int}"
+@using BookTracker.Web.Services
+@inject AuthorMergeViewModel VM
+@inject NavigationManager Nav
+
+<PageTitle>Merge authors - BookTracker</PageTitle>
+
+<h1 class="mb-3">Merge authors</h1>
+<p class="text-muted">
+    Pick a winner. The other author will be deleted, and its works and aliases
+    will be reassigned to the winner. This cannot be undone — if you need to
+    keep any fields from the loser (notes, specific spellings), copy them into
+    the winner on the <a href="/authors" target="_blank" rel="noopener">Authors</a>
+    page first.
+</p>
+
+@if (!string.IsNullOrEmpty(VM.ErrorMessage))
+{
+    <div class="alert alert-danger">@VM.ErrorMessage</div>
+}
+
+@if (VM.Loading)
+{
+    <div class="text-center py-5">
+        <div class="spinner-border" role="status"><span class="visually-hidden">Loading...</span></div>
+    </div>
+}
+else if (VM.Lower is null || VM.Higher is null)
+{
+    <a href="/duplicates" class="btn btn-outline-secondary">Back to duplicates</a>
+}
+else if (!string.IsNullOrEmpty(VM.IncompatibilityReason))
+{
+    <div class="alert alert-warning">
+        <strong>Can't merge these two directly.</strong>
+        <p class="mb-0">@VM.IncompatibilityReason</p>
+    </div>
+    <a href="/duplicates" class="btn btn-outline-secondary">Back to duplicates</a>
+}
+else
+{
+    <div class="row g-3 mb-3">
+        <div class="col-md-6">@AuthorCard(VM.Lower)</div>
+        <div class="col-md-6">@AuthorCard(VM.Higher)</div>
+    </div>
+
+    @if (VM.SelectedWinnerId is not null && VM.Loser is not null)
+    {
+        <div class="alert alert-info">
+            <div class="mb-2">
+                <strong>Winner:</strong> @(VM.SelectedWinnerId == VM.Lower.Id ? VM.Lower.Name : VM.Higher.Name)
+            </div>
+            <div class="small">
+                Will reassign <strong>@VM.Loser.WorkCount work@(VM.Loser.WorkCount == 1 ? "" : "s")</strong>
+                and <strong>@VM.Loser.AliasCount alias@(VM.Loser.AliasCount == 1 ? "" : "es")</strong>
+                from "@VM.Loser.Name" to the winner, then delete "@VM.Loser.Name".
+            </div>
+        </div>
+    }
+
+    <div class="d-flex gap-2">
+        <button type="button" class="btn btn-primary"
+                disabled="@(!VM.CanMerge || VM.Merging)"
+                @onclick="OnMergeClickAsync">
+            @(VM.Merging ? "Merging..." : "Merge")
+        </button>
+        <a href="/duplicates" class="btn btn-outline-secondary">Cancel</a>
+    </div>
+}
+
+@code {
+    [Parameter] public int IdA { get; set; }
+    [Parameter] public int IdB { get; set; }
+
+    protected override async Task OnInitializedAsync() => await VM.LoadAsync(IdA, IdB);
+
+    private async Task OnMergeClickAsync()
+    {
+        var result = await VM.MergeAsync();
+        if (result is { Success: true })
+        {
+            var winner = Uri.EscapeDataString(result.WinnerName ?? "winner");
+            var loser = Uri.EscapeDataString(result.LoserName ?? "loser");
+            var promoted = result.WinnerPromotedToCanonical ? "1" : "0";
+            Nav.NavigateTo($"/duplicates?mergedAuthorWinner={winner}&mergedAuthorLoser={loser}&worksReassigned={result.WorksReassigned}&aliasesReassigned={result.AliasesReassigned}&promoted={promoted}");
+        }
+    }
+
+    private RenderFragment AuthorCard(AuthorMergeDetail detail) =>
+        @<div class="card @(VM.SelectedWinnerId == detail.Id ? "border-primary" : "")">
+            <div class="card-body">
+                <div class="form-check mb-2">
+                    <input class="form-check-input" type="radio"
+                           name="winner" id="@($"winner-{detail.Id}")"
+                           checked="@(VM.SelectedWinnerId == detail.Id)"
+                           @onchange="() => VM.SelectedWinnerId = detail.Id" />
+                    <label class="form-check-label fw-semibold" for="@($"winner-{detail.Id}")">
+                        Make @detail.Name the winner
+                    </label>
+                </div>
+                <div class="small mb-1">
+                    @if (detail.CanonicalAuthorId.HasValue)
+                    {
+                        <span class="badge bg-info text-dark">alias of @detail.CanonicalName</span>
+                    }
+                    else
+                    {
+                        <span class="badge bg-light text-dark border">canonical</span>
+                    }
+                    <span class="text-muted ms-2">id @detail.Id</span>
+                </div>
+                <div class="small text-muted mb-2">
+                    @detail.WorkCount work@(detail.WorkCount == 1 ? "" : "s")
+                    · @detail.AliasCount alias@(detail.AliasCount == 1 ? "" : "es")
+                </div>
+                @if (detail.SampleWorkTitles.Count > 0)
+                {
+                    <div class="small">
+                        <div class="text-muted mb-1">Sample works:</div>
+                        <ul class="mb-0 ps-3">
+                            @foreach (var title in detail.SampleWorkTitles)
+                            {
+                                <li>@title</li>
+                            }
+                            @if (detail.WorkCount > detail.SampleWorkTitles.Count)
+                            {
+                                <li class="text-muted">…and @(detail.WorkCount - detail.SampleWorkTitles.Count) more</li>
+                            }
+                        </ul>
+                    </div>
+                }
+            </div>
+        </div>;
+}

--- a/BookTracker.Web/Components/Pages/Duplicates/PairCard.razor
+++ b/BookTracker.Web/Components/Pages/Duplicates/PairCard.razor
@@ -18,9 +18,13 @@
             <div class="col-md-6">@Right</div>
         </div>
     </div>
-    <div class="card-footer text-end">
+    <div class="card-footer d-flex gap-2 justify-content-end">
         @if (Dismissed is null)
         {
+            @if (!string.IsNullOrEmpty(MergeHref))
+            {
+                <a href="@MergeHref" class="btn btn-sm btn-primary">Merge →</a>
+            }
             <button type="button" class="btn btn-sm btn-outline-secondary" @onclick="OnDismiss">Dismiss</button>
         }
         else
@@ -37,4 +41,5 @@
     [Parameter, EditorRequired] public RenderFragment Right { get; set; } = null!;
     [Parameter] public EventCallback OnDismiss { get; set; }
     [Parameter] public EventCallback OnUnignore { get; set; }
+    [Parameter] public string? MergeHref { get; set; }
 }

--- a/BookTracker.Web/Program.cs
+++ b/BookTracker.Web/Program.cs
@@ -37,6 +37,7 @@ builder.Services.AddHttpClient<IBookLookupService, BookLookupService>(client =>
 builder.Services.AddTransient<SeriesMatchService>();
 
 builder.Services.AddScoped<IDuplicateDetectionService, DuplicateDetectionService>();
+builder.Services.AddScoped<IAuthorMergeService, AuthorMergeService>();
 
 // One-shot startup task that re-classifies existing Editions using the
 // richer BookFormat enum (populated from upstream metadata). Idempotent via
@@ -72,6 +73,7 @@ builder.Services.AddTransient<SeriesEditViewModel>();
 builder.Services.AddTransient<AuthorListViewModel>();
 builder.Services.AddTransient<ShoppingViewModel>();
 builder.Services.AddTransient<DuplicatesViewModel>();
+builder.Services.AddTransient<AuthorMergeViewModel>();
 builder.Services.AddScoped<AIAssistantViewModel>();
 
 var app = builder.Build();

--- a/BookTracker.Web/Services/AuthorMergeService.cs
+++ b/BookTracker.Web/Services/AuthorMergeService.cs
@@ -1,0 +1,177 @@
+using BookTracker.Data;
+using BookTracker.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookTracker.Web.Services;
+
+public interface IAuthorMergeService
+{
+    Task<AuthorMergeLoadResult> LoadAsync(int idA, int idB, CancellationToken ct = default);
+    Task<AuthorMergeResult> MergeAsync(int winnerId, int loserId, CancellationToken ct = default);
+}
+
+public record AuthorMergeLoadResult(
+    AuthorMergeDetail? Lower,
+    AuthorMergeDetail? Higher,
+    string? IncompatibilityReason);
+
+public record AuthorMergeDetail(
+    int Id,
+    string Name,
+    int? CanonicalAuthorId,
+    string? CanonicalName,
+    int WorkCount,
+    int AliasCount,
+    IReadOnlyList<string> SampleWorkTitles);
+
+public record AuthorMergeResult(
+    bool Success,
+    string? ErrorMessage,
+    int WorksReassigned,
+    int AliasesReassigned,
+    bool WinnerPromotedToCanonical,
+    string? WinnerName,
+    string? LoserName);
+
+public class AuthorMergeService(IDbContextFactory<BookTrackerDbContext> dbFactory) : IAuthorMergeService
+{
+    private const int SampleWorkLimit = 5;
+
+    public async Task<AuthorMergeLoadResult> LoadAsync(int idA, int idB, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+
+        var (lowerId, higherId) = idA < idB ? (idA, idB) : (idB, idA);
+
+        var lower = await LoadDetailAsync(db, lowerId, ct);
+        var higher = await LoadDetailAsync(db, higherId, ct);
+
+        string? incompatibility = null;
+        if (lower is not null && higher is not null)
+        {
+            incompatibility = CheckCompatibility(lower, higher);
+        }
+
+        return new AuthorMergeLoadResult(lower, higher, incompatibility);
+    }
+
+    public async Task<AuthorMergeResult> MergeAsync(int winnerId, int loserId, CancellationToken ct = default)
+    {
+        if (winnerId == loserId)
+        {
+            return Failure("Winner and loser cannot be the same author.");
+        }
+
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+
+        var winner = await db.Authors.FirstOrDefaultAsync(a => a.Id == winnerId, ct);
+        var loser = await db.Authors.FirstOrDefaultAsync(a => a.Id == loserId, ct);
+        if (winner is null || loser is null)
+        {
+            return Failure("One or both authors could not be found — they may already have been merged or deleted.");
+        }
+
+        var winnerDetail = MinimalDetail(winner);
+        var loserDetail = MinimalDetail(loser);
+        var incompatibility = CheckCompatibility(winnerDetail, loserDetail);
+        if (incompatibility is not null)
+        {
+            return Failure(incompatibility);
+        }
+
+        // Case 4 in the compatibility matrix: winner is an alias of loser.
+        // Loser is about to be deleted, so winner must be promoted to canonical
+        // before the delete — otherwise winner's CanonicalAuthorId would dangle.
+        var winnerWasAliasOfLoser = winner.CanonicalAuthorId == loser.Id;
+
+        await using var tx = await db.Database.BeginTransactionAsync(ct);
+
+        if (winnerWasAliasOfLoser)
+        {
+            winner.CanonicalAuthorId = null;
+        }
+
+        var works = await db.Works.Where(w => w.AuthorId == loser.Id).ToListAsync(ct);
+        foreach (var w in works)
+        {
+            w.AuthorId = winner.Id;
+        }
+
+        // External aliases of the loser become aliases of the winner. Must
+        // exclude the winner explicitly — if winner was an alias of loser its
+        // CanonicalAuthorId was nulled in memory above, but the pending
+        // change isn't visible to this query via the InMemory provider, so
+        // the winner would otherwise be re-pointed at itself.
+        var aliases = await db.Authors
+            .Where(a => a.CanonicalAuthorId == loser.Id && a.Id != winner.Id)
+            .ToListAsync(ct);
+        foreach (var a in aliases)
+        {
+            a.CanonicalAuthorId = winner.Id;
+        }
+
+        // Clear any dismissed-dup rows referencing the loser — they're about to
+        // become orphans anyway. DetectAllAsync would sweep them on the next
+        // run, but removing them here keeps the UI tidy immediately.
+        var staleIgnores = await db.IgnoredDuplicates
+            .Where(d => d.EntityType == DuplicateEntityType.Author
+                    && (d.LowerId == loser.Id || d.HigherId == loser.Id))
+            .ToListAsync(ct);
+        db.IgnoredDuplicates.RemoveRange(staleIgnores);
+
+        db.Authors.Remove(loser);
+
+        await db.SaveChangesAsync(ct);
+        await tx.CommitAsync(ct);
+
+        return new AuthorMergeResult(
+            Success: true,
+            ErrorMessage: null,
+            WorksReassigned: works.Count,
+            AliasesReassigned: aliases.Count,
+            WinnerPromotedToCanonical: winnerWasAliasOfLoser,
+            WinnerName: winner.Name,
+            LoserName: loser.Name);
+    }
+
+    private static async Task<AuthorMergeDetail?> LoadDetailAsync(BookTrackerDbContext db, int id, CancellationToken ct)
+    {
+        var author = await db.Authors
+            .Include(a => a.CanonicalAuthor)
+            .FirstOrDefaultAsync(a => a.Id == id, ct);
+        if (author is null) return null;
+
+        var workCount = await db.Works.CountAsync(w => w.AuthorId == id, ct);
+        var aliasCount = await db.Authors.CountAsync(a => a.CanonicalAuthorId == id, ct);
+        var sampleTitles = await db.Works
+            .Where(w => w.AuthorId == id)
+            .OrderBy(w => w.Title)
+            .Take(SampleWorkLimit)
+            .Select(w => w.Title)
+            .ToListAsync(ct);
+
+        return new AuthorMergeDetail(
+            author.Id, author.Name,
+            author.CanonicalAuthorId,
+            author.CanonicalAuthor?.Name,
+            workCount, aliasCount, sampleTitles);
+    }
+
+    private static AuthorMergeDetail MinimalDetail(Author a) =>
+        new(a.Id, a.Name, a.CanonicalAuthorId, null, 0, 0, []);
+
+    // Compatibility matrix. Both authors must resolve to the same canonical
+    // (either directly or by one being an alias of the other). Anything else
+    // is refused — the user resolves alias relationships on /authors first.
+    private static string? CheckCompatibility(AuthorMergeDetail a, AuthorMergeDetail b)
+    {
+        if (a.CanonicalAuthorId == b.CanonicalAuthorId) return null;
+        if (a.CanonicalAuthorId == b.Id) return null;
+        if (b.CanonicalAuthorId == a.Id) return null;
+
+        return $"\"{a.Name}\" and \"{b.Name}\" resolve to different canonical authors, so merging them directly would silently drop the pen-name relationship. Resolve the aliases on /authors first (promote one to canonical, or alias both to the same root), then come back to merge.";
+    }
+
+    private static AuthorMergeResult Failure(string message) =>
+        new(false, message, 0, 0, false, null, null);
+}

--- a/BookTracker.Web/ViewModels/AuthorMergeViewModel.cs
+++ b/BookTracker.Web/ViewModels/AuthorMergeViewModel.cs
@@ -1,0 +1,74 @@
+using BookTracker.Web.Services;
+
+namespace BookTracker.Web.ViewModels;
+
+// Backs /duplicates/merge/author/{idA}/{idB}. Loads both Author details with
+// work/alias counts + sample titles for the review cards, then calls
+// AuthorMergeService.MergeAsync when the user confirms a winner. Errors
+// (incompatible aliases, missing entities) flow back through ErrorMessage.
+public class AuthorMergeViewModel(IAuthorMergeService merger)
+{
+    public bool Loading { get; private set; } = true;
+    public bool Merging { get; private set; }
+
+    public AuthorMergeDetail? Lower { get; private set; }
+    public AuthorMergeDetail? Higher { get; private set; }
+
+    public string? IncompatibilityReason { get; private set; }
+    public string? ErrorMessage { get; private set; }
+
+    public int? SelectedWinnerId { get; set; }
+
+    public int? LoserId =>
+        SelectedWinnerId is null ? null
+        : SelectedWinnerId == Lower?.Id ? Higher?.Id
+        : SelectedWinnerId == Higher?.Id ? Lower?.Id
+        : null;
+
+    public AuthorMergeDetail? Loser =>
+        LoserId is null ? null
+        : LoserId == Lower?.Id ? Lower
+        : LoserId == Higher?.Id ? Higher
+        : null;
+
+    public bool CanMerge =>
+        !Loading && !Merging
+        && IncompatibilityReason is null
+        && Lower is not null && Higher is not null
+        && SelectedWinnerId is not null;
+
+    public async Task LoadAsync(int idA, int idB)
+    {
+        Loading = true;
+        ErrorMessage = null;
+        var result = await merger.LoadAsync(idA, idB);
+        Lower = result.Lower;
+        Higher = result.Higher;
+        IncompatibilityReason = result.IncompatibilityReason;
+        if (Lower is null || Higher is null)
+        {
+            ErrorMessage = "One or both authors could not be loaded — they may have been merged or deleted already.";
+        }
+        Loading = false;
+    }
+
+    public async Task<AuthorMergeResult?> MergeAsync()
+    {
+        if (!CanMerge || SelectedWinnerId is null || LoserId is null) return null;
+
+        Merging = true;
+        try
+        {
+            var result = await merger.MergeAsync(SelectedWinnerId.Value, LoserId.Value);
+            if (!result.Success)
+            {
+                ErrorMessage = result.ErrorMessage;
+            }
+            return result;
+        }
+        finally
+        {
+            Merging = false;
+        }
+    }
+}

--- a/TODO.md
+++ b/TODO.md
@@ -37,7 +37,7 @@ Outstanding work items for BookTracker. This is the single source of truth — c
 
 Detection + `/duplicates` listing shipped in PR 1 (this branch). Remaining PRs in the series:
 
-- [ ] **PR 2 — Author merge**: side-by-side review → pick winner, reassign `Work.AuthorId` + aliases from loser → delete loser. Transactional. User copy/pastes any fields from loser they want to keep before confirming.
+- [x] **PR 2 — Author merge** (shipped): side-by-side review at `/duplicates/merge/author/{a}/{b}`, reassigns works + aliases, auto-promotes winner to canonical when winner was an alias of loser, refuses when the two resolve to different canonicals.
 - [ ] **PR 3 — Work merge + Add-Work-to-Book via search** (bundled; shares the Work-search UI): reassign `BookWork` join rows, enrich winner from loser's populated fields (subtitle, genres, series, `FirstPublishedDate`), delete loser. Add "search existing Works" affordance on the Edit Book page to attach a story to an anthology.
 - [ ] **PR 4 — Edition merge**: reassign `Copy.EditionId`, enrich fields, delete loser. Same-Book only (cross-Book edition dupes imply the Books are dupes → handle those first).
 - [ ] **PR 5 — Book merge**: union Works/Tags, move all Editions, merge any duplicate Editions that result, delete loser.


### PR DESCRIPTION
Second PR in the dedup series. Adds /duplicates/merge/author/{a}/{b} —
side-by-side review with a winner radio, impact preview, transactional
merge, redirect back to /duplicates with a success banner.

Merge semantics:
- Reassigns Work.AuthorId from loser to winner.
- Reassigns external aliases' CanonicalAuthorId from loser to winner
  (the winner itself is excluded even when it was previously an alias
  of the loser — InMemory EF doesn't see the in-memory null).
- Promotes winner to canonical when winner was an alias of the loser
  (otherwise winner's CanonicalAuthorId would dangle at a deleted row).
- Clears any IgnoredDuplicate rows mentioning the loser.
- Deletes the loser row. All in one transaction.

Refusal path: if the two authors resolve to different canonicals, refuse
and point the user at /authors to fix the aliasing first. Direct
merge-across-aliases would silently drop a pen-name relationship.

Test infra: TestDbContextFactory now suppresses InMemory's
TransactionIgnoredWarning so services wrapping work in
BeginTransactionAsync run unchanged under tests (transactions are a
no-op on InMemory; production SQL Server still gets them).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
