### PR TITLE
feat(duplicates): work merge + attach-existing-work on Edit Book (PR 3)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -128,6 +128,7 @@ A short-lived context is created per operation. Never inject `DbContext` directl
 | `/assistant` | AI Assistant | Book advisor (Opus), genre cleanup, collection cataloguing, shopping suggestions (Sonnet). |
 | `/duplicates` | Duplicates | Tabs for Authors / Works / Books / Editions. Lists candidate duplicate pairs detected on-demand. Dismiss false positives (reversible via the "Dismissed" section). Author pairs have a Merge → button. Web-primary, desktop-first layout. |
 | `/duplicates/merge/author/{idA}/{idB}` | Merge authors | Side-by-side review of the pair, radio to pick a winner, preview of impact (N works + M aliases to reassign), transactional merge. Refuses when the two authors resolve to different canonicals — user resolves aliases on `/authors` first. |
+| `/duplicates/merge/work/{idA}/{idB}` | Merge works | Side-by-side review, radio to pick a winner, preview of impact (books to reassign + any books that already contain both → loser dropped). Transactional. Refuses if the two resolve to different authors (merge authors first). |
 
 ## Shared components
 
@@ -148,6 +149,12 @@ Scans the library for candidate duplicate pairs across Authors, Works, Books, an
 
 ### AuthorMergeService
 Merges two Author rows after user review. Refuses when the two authors resolve to different canonicals (user must resolve aliases on `/authors` first). Otherwise runs in one transaction: reassigns `Work.AuthorId`, reassigns external aliases' `CanonicalAuthorId`, clears any `IgnoredDuplicate` rows mentioning the loser, deletes the loser. One edge case: when the winner is itself an alias of the loser, winner is promoted to canonical before the delete so its `CanonicalAuthorId` doesn't dangle. Returns a result with reassignment counts + a flag for the promotion case.
+
+### WorkMergeService
+Merges two Work rows after user review. No auto-enrichment — strict replace, user copies any fields they want to keep (subtitle, series, genres) from loser manually before confirming. Refuses if the two Works have different `AuthorId` (detection already blocks by author, but the service guards direct-URL hits). Transactional: for each Book attached to the loser, adds the winner if not already present then clears `loser.Books`, which deletes the `BookWork` rows; clears any `IgnoredDuplicate` referencing the loser; deletes the loser Work. The "Book contains both" count is surfaced in `LoadAsync` preview + `MergeAsync` result so the UI can flag that those Books will just lose the loser attachment (winner stays).
+
+### WorkSearchService
+Typeahead-style substring search across Works. Min 2 chars; case-insensitive via `ToLower()` on both sides (keeps InMemory tests honest). Ranks starts-with matches above contains-anywhere, alphabetical within. `excludeBookId` filter lets the Edit Book "Attach existing Work" UI exclude Works already attached. Returns up to `maxResults` results (default 20).
 
 ### SeriesMatchService
 Local series detection after ISBN lookup. Strategies:

--- a/BookTracker.Tests/Services/WorkMergeServiceTests.cs
+++ b/BookTracker.Tests/Services/WorkMergeServiceTests.cs
@@ -1,0 +1,220 @@
+using BookTracker.Data.Models;
+using BookTracker.Web.Services;
+
+namespace BookTracker.Tests.Services;
+
+public class WorkMergeServiceTests
+{
+    private readonly TestDbContextFactory _factory = new();
+
+    private WorkMergeService CreateService() => new(_factory);
+
+    // ─── LoadAsync ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task LoadAsync_returns_both_details_with_book_samples()
+    {
+        var (winnerId, loserId, _) = await SeedTwoWorksInSeparateBooksAsync(
+            "The Hobbit", ["Hobbit HB"],
+            "Hobbit", ["Hobbit PB"]);
+
+        var result = await CreateService().LoadAsync(winnerId, loserId);
+
+        Assert.NotNull(result.Lower);
+        Assert.NotNull(result.Higher);
+        Assert.Null(result.IncompatibilityReason);
+        Assert.Equal(0, result.SharedBookCount);
+    }
+
+    [Fact]
+    public async Task LoadAsync_reports_different_authors_as_incompatibility()
+    {
+        using var db = _factory.CreateDbContext();
+        var tolkien = new Author { Name = "J.R.R. Tolkien" };
+        var notTolkien = new Author { Name = "Imposter" };
+        var w1 = new Work { Title = "The Hobbit", Author = tolkien };
+        var w2 = new Work { Title = "The Hobbit", Author = notTolkien };
+        db.Books.Add(new Book { Title = "A", Works = [w1] });
+        db.Books.Add(new Book { Title = "B", Works = [w2] });
+        await db.SaveChangesAsync();
+
+        var result = await CreateService().LoadAsync(w1.Id, w2.Id);
+
+        Assert.NotNull(result.IncompatibilityReason);
+    }
+
+    [Fact]
+    public async Task LoadAsync_counts_books_that_contain_both_works()
+    {
+        // A compendium book attaches both works; the LoadAsync preview must
+        // flag that so the merge confirmation surfaces the overlap.
+        using var db = _factory.CreateDbContext();
+        var author = new Author { Name = "Agatha Christie" };
+        var w1 = new Work { Title = "A", Author = author };
+        var w2 = new Work { Title = "A", Author = author };
+        db.Books.Add(new Book { Title = "Solo W1", Works = [w1] });
+        db.Books.Add(new Book { Title = "Solo W2", Works = [w2] });
+        db.Books.Add(new Book { Title = "Compendium", Works = [w1, w2] });
+        await db.SaveChangesAsync();
+
+        var result = await CreateService().LoadAsync(w1.Id, w2.Id);
+
+        Assert.Equal(1, result.SharedBookCount);
+    }
+
+    // ─── MergeAsync — reassignments ───────────────────────────────────
+
+    [Fact]
+    public async Task MergeAsync_reassigns_solo_book_to_winner()
+    {
+        var (winnerId, loserId, _) = await SeedTwoWorksInSeparateBooksAsync(
+            "The Hobbit", ["Hobbit HB"],
+            "Hobbit", ["Hobbit PB"]);
+
+        var result = await CreateService().MergeAsync(winnerId, loserId);
+
+        Assert.True(result.Success);
+        Assert.Equal(1, result.BooksReassigned);
+        Assert.Equal(0, result.BooksAlreadyShared);
+
+        using var db = _factory.CreateDbContext();
+        Assert.Null(db.Works.FirstOrDefault(w => w.Id == loserId));
+        var pb = db.Books.Single(b => b.Title == "Hobbit PB");
+        var pbWorks = db.Books.Where(b => b.Id == pb.Id).SelectMany(b => b.Works).ToList();
+        Assert.Single(pbWorks);
+        Assert.Equal(winnerId, pbWorks[0].Id);
+    }
+
+    [Fact]
+    public async Task MergeAsync_drops_loser_from_books_that_already_contain_winner()
+    {
+        // Book C contains both works. Post-merge it should contain only the
+        // winner — the loser-side BookWork row gets dropped. No PK violation.
+        using var db = _factory.CreateDbContext();
+        var author = new Author { Name = "Agatha Christie" };
+        var winner = new Work { Title = "Style", Author = author };
+        var loser = new Work { Title = "Style", Author = author };
+        db.Books.Add(new Book { Title = "Solo W2", Works = [loser] });
+        db.Books.Add(new Book { Title = "Compendium", Works = [winner, loser] });
+        await db.SaveChangesAsync();
+
+        var result = await CreateService().MergeAsync(winner.Id, loser.Id);
+
+        Assert.True(result.Success);
+        Assert.Equal(1, result.BooksReassigned);
+        Assert.Equal(1, result.BooksAlreadyShared);
+
+        using var verify = _factory.CreateDbContext();
+        var compendium = verify.Books.Single(b => b.Title == "Compendium");
+        var compWorks = verify.Books.Where(b => b.Id == compendium.Id).SelectMany(b => b.Works).ToList();
+        Assert.Single(compWorks);
+        Assert.Equal(winner.Id, compWorks[0].Id);
+    }
+
+    [Fact]
+    public async Task MergeAsync_clears_ignored_duplicates_referencing_loser()
+    {
+        var (winnerId, loserId, otherId) = await SeedThreeWorksAsync();
+
+        using (var db = _factory.CreateDbContext())
+        {
+            db.IgnoredDuplicates.Add(new IgnoredDuplicate
+            {
+                EntityType = DuplicateEntityType.Work,
+                LowerId = Math.Min(winnerId, loserId),
+                HigherId = Math.Max(winnerId, loserId)
+            });
+            db.IgnoredDuplicates.Add(new IgnoredDuplicate
+            {
+                EntityType = DuplicateEntityType.Work,
+                LowerId = Math.Min(winnerId, otherId),
+                HigherId = Math.Max(winnerId, otherId)
+            });
+            await db.SaveChangesAsync();
+        }
+
+        await CreateService().MergeAsync(winnerId, loserId);
+
+        using var verify = _factory.CreateDbContext();
+        Assert.Single(verify.IgnoredDuplicates);
+    }
+
+    // ─── MergeAsync — refusals ────────────────────────────────────────
+
+    [Fact]
+    public async Task MergeAsync_rejects_self_merge()
+    {
+        var (winnerId, _, _) = await SeedTwoWorksInSeparateBooksAsync(
+            "The Hobbit", ["Hobbit HB"],
+            "Hobbit", ["Hobbit PB"]);
+
+        var result = await CreateService().MergeAsync(winnerId, winnerId);
+
+        Assert.False(result.Success);
+    }
+
+    [Fact]
+    public async Task MergeAsync_rejects_missing_entities()
+    {
+        var (winnerId, _, _) = await SeedTwoWorksInSeparateBooksAsync(
+            "The Hobbit", ["Hobbit HB"],
+            "Hobbit", ["Hobbit PB"]);
+
+        var result = await CreateService().MergeAsync(winnerId, loserId: 9999);
+
+        Assert.False(result.Success);
+    }
+
+    [Fact]
+    public async Task MergeAsync_rejects_different_authors()
+    {
+        using var db = _factory.CreateDbContext();
+        var tolkien = new Author { Name = "J.R.R. Tolkien" };
+        var notTolkien = new Author { Name = "Imposter" };
+        var w1 = new Work { Title = "The Hobbit", Author = tolkien };
+        var w2 = new Work { Title = "The Hobbit", Author = notTolkien };
+        db.Books.Add(new Book { Title = "A", Works = [w1] });
+        db.Books.Add(new Book { Title = "B", Works = [w2] });
+        await db.SaveChangesAsync();
+
+        var result = await CreateService().MergeAsync(w1.Id, w2.Id);
+
+        Assert.False(result.Success);
+    }
+
+    // ─── Helpers ──────────────────────────────────────────────────────
+
+    private async Task<(int winnerId, int loserId, int otherId)> SeedTwoWorksInSeparateBooksAsync(
+        string winnerTitle, string[] winnerBooks,
+        string loserTitle, string[] loserBooks)
+    {
+        using var db = _factory.CreateDbContext();
+        var author = new Author { Name = "Shared Author" };
+        var winner = new Work { Title = winnerTitle, Author = author };
+        var loser = new Work { Title = loserTitle, Author = author };
+        foreach (var t in winnerBooks)
+        {
+            db.Books.Add(new Book { Title = t, Works = [winner] });
+        }
+        foreach (var t in loserBooks)
+        {
+            db.Books.Add(new Book { Title = t, Works = [loser] });
+        }
+        await db.SaveChangesAsync();
+        return (winner.Id, loser.Id, 0);
+    }
+
+    private async Task<(int winnerId, int loserId, int otherId)> SeedThreeWorksAsync()
+    {
+        using var db = _factory.CreateDbContext();
+        var author = new Author { Name = "Shared Author" };
+        var winner = new Work { Title = "W", Author = author };
+        var loser = new Work { Title = "L", Author = author };
+        var other = new Work { Title = "O", Author = author };
+        db.Books.Add(new Book { Title = "BW", Works = [winner] });
+        db.Books.Add(new Book { Title = "BL", Works = [loser] });
+        db.Books.Add(new Book { Title = "BO", Works = [other] });
+        await db.SaveChangesAsync();
+        return (winner.Id, loser.Id, other.Id);
+    }
+}

--- a/BookTracker.Tests/Services/WorkSearchServiceTests.cs
+++ b/BookTracker.Tests/Services/WorkSearchServiceTests.cs
@@ -1,0 +1,97 @@
+using BookTracker.Data.Models;
+using BookTracker.Web.Services;
+
+namespace BookTracker.Tests.Services;
+
+public class WorkSearchServiceTests
+{
+    private readonly TestDbContextFactory _factory = new();
+
+    private WorkSearchService CreateService() => new(_factory);
+
+    [Fact]
+    public async Task SearchAsync_returns_empty_when_query_too_short()
+    {
+        await SeedWorksAsync(("The Hobbit", "Tolkien"), ("Hamlet", "Shakespeare"));
+
+        var result = await CreateService().SearchAsync("h");
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task SearchAsync_matches_substring_case_insensitive()
+    {
+        await SeedWorksAsync(
+            ("The Hobbit", "Tolkien"),
+            ("A Hobbit's Tale", "Other"),
+            ("Macbeth", "Shakespeare"));
+
+        var result = await CreateService().SearchAsync("hobbit");
+
+        Assert.Equal(2, result.Count);
+        Assert.All(result, r => Assert.Contains("Hobbit", r.Title, StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task SearchAsync_prefers_starts_with_matches()
+    {
+        await SeedWorksAsync(
+            ("The Hobbit", "A"),
+            ("Hobbit Encyclopaedia", "B"));
+
+        var result = await CreateService().SearchAsync("hobbit");
+
+        // "Hobbit Encyclopaedia" starts with "hobbit" → should come first.
+        Assert.Equal("Hobbit Encyclopaedia", result[0].Title);
+        Assert.Equal("The Hobbit", result[1].Title);
+    }
+
+    [Fact]
+    public async Task SearchAsync_excludes_works_already_attached_to_given_book()
+    {
+        using var db = _factory.CreateDbContext();
+        var author = new Author { Name = "Tolkien" };
+        var hobbit = new Work { Title = "The Hobbit", Author = author };
+        var fellowship = new Work { Title = "Fellowship", Author = author };
+        db.Books.Add(new Book { Title = "Compendium", Works = [hobbit] });
+        db.Books.Add(new Book { Title = "Other", Works = [fellowship] });
+        await db.SaveChangesAsync();
+
+        var compendiumId = db.Books.Single(b => b.Title == "Compendium").Id;
+
+        var result = await CreateService().SearchAsync("the hobbit", excludeBookId: compendiumId);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task SearchAsync_honours_maxResults()
+    {
+        await SeedWorksAsync(
+            ("Hobbit 1", "A"),
+            ("Hobbit 2", "A"),
+            ("Hobbit 3", "A"),
+            ("Hobbit 4", "A"));
+
+        var result = await CreateService().SearchAsync("hobbit", maxResults: 2);
+
+        Assert.Equal(2, result.Count);
+    }
+
+    private async Task SeedWorksAsync(params (string Title, string AuthorName)[] data)
+    {
+        using var db = _factory.CreateDbContext();
+        foreach (var (title, authorName) in data)
+        {
+            var author = db.Authors.FirstOrDefault(a => a.Name == authorName)
+                         ?? new Author { Name = authorName };
+            db.Books.Add(new Book
+            {
+                Title = title,
+                Works = [new Work { Title = title, Author = author }]
+            });
+        }
+        await db.SaveChangesAsync();
+    }
+}

--- a/BookTracker.Tests/ViewModels/WorkMergeViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/WorkMergeViewModelTests.cs
@@ -1,0 +1,93 @@
+using BookTracker.Web.Services;
+using BookTracker.Web.ViewModels;
+using NSubstitute;
+
+namespace BookTracker.Tests.ViewModels;
+
+public class WorkMergeViewModelTests
+{
+    private readonly IWorkMergeService _merger = Substitute.For<IWorkMergeService>();
+
+    private WorkMergeViewModel CreateVm() => new(_merger);
+
+    private static WorkMergeDetail Detail(int id, string title) =>
+        new(id, title, null, "A", null, null, null, [], 0, []);
+
+    [Fact]
+    public async Task LoadAsync_populates_details_and_shared_book_count()
+    {
+        _merger.LoadAsync(1, 2, Arg.Any<CancellationToken>())
+            .Returns(new WorkMergeLoadResult(Detail(1, "A"), Detail(2, "B"), null, SharedBookCount: 3));
+
+        var vm = CreateVm();
+        await vm.LoadAsync(1, 2);
+
+        Assert.False(vm.Loading);
+        Assert.Equal(3, vm.SharedBookCount);
+        Assert.Null(vm.IncompatibilityReason);
+    }
+
+    [Fact]
+    public async Task LoadAsync_surfaces_incompatibility_reason()
+    {
+        _merger.LoadAsync(1, 2, Arg.Any<CancellationToken>())
+            .Returns(new WorkMergeLoadResult(Detail(1, "A"), Detail(2, "B"), "different authors", 0));
+
+        var vm = CreateVm();
+        await vm.LoadAsync(1, 2);
+
+        Assert.Equal("different authors", vm.IncompatibilityReason);
+        Assert.False(vm.CanMerge);
+    }
+
+    [Fact]
+    public async Task MergeAsync_delegates_to_service_and_reports_success()
+    {
+        _merger.LoadAsync(1, 2, Arg.Any<CancellationToken>())
+            .Returns(new WorkMergeLoadResult(Detail(1, "A"), Detail(2, "B"), null, 0));
+        _merger.MergeAsync(1, 2, Arg.Any<CancellationToken>())
+            .Returns(new WorkMergeResult(true, null, 3, 0, "A", "B"));
+
+        var vm = CreateVm();
+        await vm.LoadAsync(1, 2);
+        vm.SelectedWinnerId = 1;
+
+        var result = await vm.MergeAsync();
+
+        Assert.NotNull(result);
+        Assert.True(result!.Success);
+        await _merger.Received(1).MergeAsync(1, 2, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task MergeAsync_surfaces_error_on_failure()
+    {
+        _merger.LoadAsync(1, 2, Arg.Any<CancellationToken>())
+            .Returns(new WorkMergeLoadResult(Detail(1, "A"), Detail(2, "B"), null, 0));
+        _merger.MergeAsync(1, 2, Arg.Any<CancellationToken>())
+            .Returns(new WorkMergeResult(false, "boom", 0, 0, null, null));
+
+        var vm = CreateVm();
+        await vm.LoadAsync(1, 2);
+        vm.SelectedWinnerId = 1;
+
+        await vm.MergeAsync();
+
+        Assert.Equal("boom", vm.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task MergeAsync_noop_without_winner_selection()
+    {
+        _merger.LoadAsync(1, 2, Arg.Any<CancellationToken>())
+            .Returns(new WorkMergeLoadResult(Detail(1, "A"), Detail(2, "B"), null, 0));
+
+        var vm = CreateVm();
+        await vm.LoadAsync(1, 2);
+
+        var result = await vm.MergeAsync();
+
+        Assert.Null(result);
+        await _merger.DidNotReceiveWithAnyArgs().MergeAsync(default, default, default);
+    }
+}

--- a/BookTracker.Web/Components/Pages/Books/Edit.razor
+++ b/BookTracker.Web/Components/Pages/Books/Edit.razor
@@ -109,7 +109,53 @@ else
                                 }
                             </ul>
                         }
+                        <div class="mb-3">
+                            <label class="form-label small text-muted mb-1">Attach an existing Work (for stories already entered in another compendium)</label>
+                            <div class="row g-2">
+                                <div class="col-md-10">
+                                    <input type="search" class="form-control form-control-sm"
+                                           placeholder="Search Works by title (min 2 characters)"
+                                           @bind="VM.AttachWorkQuery"
+                                           @bind:event="oninput"
+                                           @onkeyup="() => VM.SearchWorksToAttachAsync(BookId)" />
+                                </div>
+                                <div class="col-md-2 d-grid">
+                                    <button type="button" class="btn btn-outline-secondary btn-sm"
+                                            @onclick="() => VM.SearchWorksToAttachAsync(BookId)">
+                                        @(VM.Searching ? "Searching..." : "Search")
+                                    </button>
+                                </div>
+                            </div>
+                            @if (VM.AttachWorkResults.Count > 0)
+                            {
+                                <ul class="list-group list-group-flush border mt-2" style="max-height: 220px; overflow-y: auto;">
+                                    @foreach (var r in VM.AttachWorkResults)
+                                    {
+                                        <li class="list-group-item d-flex justify-content-between align-items-center">
+                                            <div>
+                                                <div class="fw-semibold">@r.Title</div>
+                                                @if (!string.IsNullOrWhiteSpace(r.Subtitle))
+                                                {
+                                                    <div class="small text-muted fst-italic">@r.Subtitle</div>
+                                                }
+                                                <div class="small text-muted">by @r.AuthorName · in @r.BookCount book@(r.BookCount == 1 ? "" : "s")</div>
+                                            </div>
+                                            <button type="button" class="btn btn-outline-success btn-sm"
+                                                    @onclick="() => VM.AttachWorkAsync(BookId, r.Id)">
+                                                Attach
+                                            </button>
+                                        </li>
+                                    }
+                                </ul>
+                            }
+                            else if (!string.IsNullOrWhiteSpace(VM.AttachWorkQuery) && VM.AttachWorkQuery.Trim().Length >= 2 && !VM.Searching)
+                            {
+                                <div class="small text-muted mt-2">No matching Works. (Not attached here already? Create a new one below.)</div>
+                            }
+                        </div>
+
                         <div class="row g-2">
+                            <div class="col-12"><small class="text-muted">Or create a new Work:</small></div>
                             <div class="col-md-5">
                                 <input type="text" class="form-control form-control-sm" placeholder="Work title" @bind="VM.NewWorkTitle" />
                             </div>

--- a/BookTracker.Web/Components/Pages/Duplicates/Index.razor
+++ b/BookTracker.Web/Components/Pages/Duplicates/Index.razor
@@ -92,7 +92,8 @@ else
             @foreach (var pair in VM.ActiveWorkPairs)
             {
                 <PairCard MatchReason="@pair.MatchReason"
-                          OnDismiss="() => VM.DismissAsync(DuplicateEntityType.Work, pair.Lower.Id, pair.Higher.Id)">
+                          OnDismiss="() => VM.DismissAsync(DuplicateEntityType.Work, pair.Lower.Id, pair.Higher.Id)"
+                          MergeHref="@($"/duplicates/merge/work/{pair.Lower.Id}/{pair.Higher.Id}")">
                     <Left><WorkSide Snap="pair.Lower" /></Left>
                     <Right><WorkSide Snap="pair.Higher" /></Right>
                 </PairCard>
@@ -213,6 +214,12 @@ else
     [SupplyParameterFromQuery(Name = "aliasesReassigned")] public int? AliasesReassigned { get; set; }
     [SupplyParameterFromQuery(Name = "promoted")] public string? Promoted { get; set; }
 
+    // Same pattern for the Work-merge redirect (from /duplicates/merge/work/*).
+    [SupplyParameterFromQuery(Name = "mergedWorkWinner")] public string? MergedWorkWinner { get; set; }
+    [SupplyParameterFromQuery(Name = "mergedWorkLoser")] public string? MergedWorkLoser { get; set; }
+    [SupplyParameterFromQuery(Name = "booksReassigned")] public int? BooksReassigned { get; set; }
+    [SupplyParameterFromQuery(Name = "booksAlreadyShared")] public int? BooksAlreadyShared { get; set; }
+
     protected override async Task OnInitializedAsync()
     {
         await VM.LoadAsync();
@@ -226,6 +233,15 @@ else
             VM.SuccessMessage = $"Merged \"{MergedAuthorLoser}\" into \"{MergedAuthorWinner}\" — "
                 + $"{works} work{(works == 1 ? "" : "s")}, {aliases} alias{(aliases == 1 ? "" : "es")} reassigned."
                 + (promoted ? $" \"{MergedAuthorWinner}\" was promoted to canonical." : "");
+        }
+        else if (!string.IsNullOrEmpty(MergedWorkWinner) && !string.IsNullOrEmpty(MergedWorkLoser))
+        {
+            VM.ActiveTab = DuplicateEntityType.Work;
+            var reassigned = BooksReassigned ?? 0;
+            var shared = BooksAlreadyShared ?? 0;
+            VM.SuccessMessage = $"Merged \"{MergedWorkLoser}\" into \"{MergedWorkWinner}\" — "
+                + $"{reassigned} book{(reassigned == 1 ? "" : "s")} reassigned"
+                + (shared > 0 ? $", {shared} already contained both (winner kept, loser dropped)." : ".");
         }
     }
 }

--- a/BookTracker.Web/Components/Pages/Duplicates/MergeWork.razor
+++ b/BookTracker.Web/Components/Pages/Duplicates/MergeWork.razor
@@ -1,0 +1,172 @@
+@page "/duplicates/merge/work/{idA:int}/{idB:int}"
+@using BookTracker.Web.Services
+@inject WorkMergeViewModel VM
+@inject NavigationManager Nav
+
+<PageTitle>Merge works - BookTracker</PageTitle>
+
+<h1 class="mb-3">Merge works</h1>
+<p class="text-muted">
+    Pick a winner. The other Work will be deleted, and any Books containing
+    the loser will be reassigned to the winner. This cannot be undone — if
+    you want to keep any fields from the loser (subtitle, series, genres),
+    copy them across to the winner on the relevant
+    <a href="/books" target="_blank" rel="noopener">Book edit page</a>
+    before confirming.
+</p>
+
+@if (!string.IsNullOrEmpty(VM.ErrorMessage))
+{
+    <div class="alert alert-danger">@VM.ErrorMessage</div>
+}
+
+@if (VM.Loading)
+{
+    <div class="text-center py-5">
+        <div class="spinner-border" role="status"><span class="visually-hidden">Loading...</span></div>
+    </div>
+}
+else if (VM.Lower is null || VM.Higher is null)
+{
+    <a href="/duplicates" class="btn btn-outline-secondary">Back to duplicates</a>
+}
+else if (!string.IsNullOrEmpty(VM.IncompatibilityReason))
+{
+    <div class="alert alert-warning">
+        <strong>Can't merge these two directly.</strong>
+        <p class="mb-0">@VM.IncompatibilityReason</p>
+    </div>
+    <a href="/duplicates" class="btn btn-outline-secondary">Back to duplicates</a>
+}
+else
+{
+    <div class="row g-3 mb-3">
+        <div class="col-md-6">@WorkCard(VM.Lower)</div>
+        <div class="col-md-6">@WorkCard(VM.Higher)</div>
+    </div>
+
+    @if (VM.SharedBookCount > 0)
+    {
+        <div class="alert alert-secondary">
+            <strong>Heads up:</strong> @VM.SharedBookCount
+            book@(VM.SharedBookCount == 1 ? "" : "s") currently contain@(VM.SharedBookCount == 1 ? "s" : "")
+            <em>both</em> of these Works. Post-merge each of those Books will contain only the winner — the loser-side attachment is dropped. That's usually what you want (the compendium thought it had two separate stories, but they were the same Work), but it does reduce the Works-count on those Books by one.
+        </div>
+    }
+
+    @if (VM.SelectedWinnerId is not null && VM.Loser is not null)
+    {
+        var loser = VM.Loser;
+        <div class="alert alert-info">
+            <div class="mb-2">
+                <strong>Winner:</strong> @(VM.SelectedWinnerId == VM.Lower.Id ? VM.Lower.Title : VM.Higher.Title)
+            </div>
+            <div class="small">
+                Will delete "@loser.Title" (@loser.BookCount book@(loser.BookCount == 1 ? "" : "s")).
+                @{
+                    var newlyAttached = Math.Max(0, loser.BookCount - VM.SharedBookCount);
+                }
+                @if (newlyAttached > 0)
+                {
+                    <span>
+                        @newlyAttached book@(newlyAttached == 1 ? "" : "s") that only contained the loser will be attached to the winner.
+                    </span>
+                }
+                @if (VM.SharedBookCount > 0)
+                {
+                    <span>
+                        @VM.SharedBookCount book@(VM.SharedBookCount == 1 ? "" : "s") that already contain the winner will simply lose the loser attachment.
+                    </span>
+                }
+            </div>
+        </div>
+    }
+
+    <div class="d-flex gap-2">
+        <button type="button" class="btn btn-primary"
+                disabled="@(!VM.CanMerge || VM.Merging)"
+                @onclick="OnMergeClickAsync">
+            @(VM.Merging ? "Merging..." : "Merge")
+        </button>
+        <a href="/duplicates" class="btn btn-outline-secondary">Cancel</a>
+    </div>
+}
+
+@code {
+    [Parameter] public int IdA { get; set; }
+    [Parameter] public int IdB { get; set; }
+
+    protected override async Task OnInitializedAsync() => await VM.LoadAsync(IdA, IdB);
+
+    private async Task OnMergeClickAsync()
+    {
+        var result = await VM.MergeAsync();
+        if (result is { Success: true })
+        {
+            var winner = Uri.EscapeDataString(result.WinnerTitle ?? "winner");
+            var loser = Uri.EscapeDataString(result.LoserTitle ?? "loser");
+            Nav.NavigateTo($"/duplicates?mergedWorkWinner={winner}&mergedWorkLoser={loser}&booksReassigned={result.BooksReassigned}&booksAlreadyShared={result.BooksAlreadyShared}");
+        }
+    }
+
+    private RenderFragment WorkCard(WorkMergeDetail detail) =>
+        @<div class="card @(VM.SelectedWinnerId == detail.Id ? "border-primary" : "")">
+            <div class="card-body">
+                <div class="form-check mb-2">
+                    <input class="form-check-input" type="radio"
+                           name="winner" id="@($"winner-{detail.Id}")"
+                           checked="@(VM.SelectedWinnerId == detail.Id)"
+                           @onchange="() => VM.SelectedWinnerId = detail.Id" />
+                    <label class="form-check-label fw-semibold" for="@($"winner-{detail.Id}")">
+                        Make "@detail.Title" the winner
+                    </label>
+                </div>
+                @if (!string.IsNullOrWhiteSpace(detail.Subtitle))
+                {
+                    <div class="small text-muted fst-italic mb-1">@detail.Subtitle</div>
+                }
+                <div class="small mb-1">by @detail.AuthorName</div>
+                <div class="small text-muted mb-2">
+                    @if (detail.FirstPublishedYear.HasValue)
+                    {
+                        <span>first pub. @detail.FirstPublishedYear</span>
+                        <span class="mx-1">·</span>
+                    }
+                    @detail.BookCount book@(detail.BookCount == 1 ? "" : "s")
+                    <span class="mx-1">·</span>
+                    id @detail.Id
+                </div>
+                @if (!string.IsNullOrEmpty(detail.SeriesName))
+                {
+                    <div class="small mb-2">
+                        <span class="badge bg-light text-dark border">
+                            Series: @detail.SeriesName@(detail.SeriesOrder.HasValue ? $" #{detail.SeriesOrder}" : "")
+                        </span>
+                    </div>
+                }
+                @if (detail.GenreNames.Count > 0)
+                {
+                    <div class="small mb-2">
+                        Genres:
+                        @string.Join(", ", detail.GenreNames)
+                    </div>
+                }
+                @if (detail.SampleBookTitles.Count > 0)
+                {
+                    <div class="small">
+                        <div class="text-muted mb-1">Sample books:</div>
+                        <ul class="mb-0 ps-3">
+                            @foreach (var title in detail.SampleBookTitles)
+                            {
+                                <li>@title</li>
+                            }
+                            @if (detail.BookCount > detail.SampleBookTitles.Count)
+                            {
+                                <li class="text-muted">…and @(detail.BookCount - detail.SampleBookTitles.Count) more</li>
+                            }
+                        </ul>
+                    </div>
+                }
+            </div>
+        </div>;
+}

--- a/BookTracker.Web/Program.cs
+++ b/BookTracker.Web/Program.cs
@@ -38,6 +38,8 @@ builder.Services.AddTransient<SeriesMatchService>();
 
 builder.Services.AddScoped<IDuplicateDetectionService, DuplicateDetectionService>();
 builder.Services.AddScoped<IAuthorMergeService, AuthorMergeService>();
+builder.Services.AddScoped<IWorkMergeService, WorkMergeService>();
+builder.Services.AddScoped<IWorkSearchService, WorkSearchService>();
 
 // One-shot startup task that re-classifies existing Editions using the
 // richer BookFormat enum (populated from upstream metadata). Idempotent via
@@ -74,6 +76,7 @@ builder.Services.AddTransient<AuthorListViewModel>();
 builder.Services.AddTransient<ShoppingViewModel>();
 builder.Services.AddTransient<DuplicatesViewModel>();
 builder.Services.AddTransient<AuthorMergeViewModel>();
+builder.Services.AddTransient<WorkMergeViewModel>();
 builder.Services.AddScoped<AIAssistantViewModel>();
 
 var app = builder.Build();

--- a/BookTracker.Web/Services/WorkMergeService.cs
+++ b/BookTracker.Web/Services/WorkMergeService.cs
@@ -1,0 +1,186 @@
+using BookTracker.Data;
+using BookTracker.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookTracker.Web.Services;
+
+public interface IWorkMergeService
+{
+    Task<WorkMergeLoadResult> LoadAsync(int idA, int idB, CancellationToken ct = default);
+    Task<WorkMergeResult> MergeAsync(int winnerId, int loserId, CancellationToken ct = default);
+}
+
+public record WorkMergeLoadResult(
+    WorkMergeDetail? Lower,
+    WorkMergeDetail? Higher,
+    string? IncompatibilityReason,
+    // How many Books currently contain BOTH works. Post-merge those Books
+    // will just contain the winner — the loser-side BookWork row gets
+    // dropped. Surfaced on the preview so the user isn't surprised by a
+    // Works-count drop on any compendium that had both.
+    int SharedBookCount);
+
+public record WorkMergeDetail(
+    int Id,
+    string Title,
+    string? Subtitle,
+    string AuthorName,
+    int? FirstPublishedYear,
+    string? SeriesName,
+    int? SeriesOrder,
+    IReadOnlyList<string> GenreNames,
+    int BookCount,
+    IReadOnlyList<string> SampleBookTitles);
+
+public record WorkMergeResult(
+    bool Success,
+    string? ErrorMessage,
+    int BooksReassigned,
+    int BooksAlreadyShared,
+    string? WinnerTitle,
+    string? LoserTitle);
+
+public class WorkMergeService(IDbContextFactory<BookTrackerDbContext> dbFactory) : IWorkMergeService
+{
+    private const int SampleBookLimit = 5;
+
+    public async Task<WorkMergeLoadResult> LoadAsync(int idA, int idB, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+
+        var (lowerId, higherId) = idA < idB ? (idA, idB) : (idB, idA);
+
+        var lower = await LoadDetailAsync(db, lowerId, ct);
+        var higher = await LoadDetailAsync(db, higherId, ct);
+
+        string? incompatibility = null;
+        var sharedBookCount = 0;
+
+        if (lower is not null && higher is not null)
+        {
+            // Detection already blocks by AuthorId so this is mostly a
+            // defensive check for direct URL hits.
+            var lowerRaw = await db.Works.AsNoTracking().FirstAsync(w => w.Id == lowerId, ct);
+            var higherRaw = await db.Works.AsNoTracking().FirstAsync(w => w.Id == higherId, ct);
+            if (lowerRaw.AuthorId != higherRaw.AuthorId)
+            {
+                incompatibility = "Works belong to different authors. Merge the authors on /duplicates first, then come back.";
+            }
+            else
+            {
+                sharedBookCount = await CountSharedBooksAsync(db, lowerId, higherId, ct);
+            }
+        }
+
+        return new WorkMergeLoadResult(lower, higher, incompatibility, sharedBookCount);
+    }
+
+    public async Task<WorkMergeResult> MergeAsync(int winnerId, int loserId, CancellationToken ct = default)
+    {
+        if (winnerId == loserId)
+        {
+            return Failure("Winner and loser cannot be the same Work.");
+        }
+
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+
+        var winner = await db.Works.Include(w => w.Books).FirstOrDefaultAsync(w => w.Id == winnerId, ct);
+        var loser = await db.Works.Include(w => w.Books).FirstOrDefaultAsync(w => w.Id == loserId, ct);
+        if (winner is null || loser is null)
+        {
+            return Failure("One or both Works could not be found — they may already have been merged or deleted.");
+        }
+
+        if (winner.AuthorId != loser.AuthorId)
+        {
+            return Failure("Works belong to different authors. Merge the authors first on /duplicates.");
+        }
+
+        await using var tx = await db.Database.BeginTransactionAsync(ct);
+
+        // Book-contains-both case: for each Book in loser.Books where winner
+        // is NOT already attached, add winner; otherwise skip (winner stays,
+        // loser just gets removed when we clear loser.Books). EF's many-to-
+        // many PK is (BookId, WorkId) so a duplicate add would throw — the
+        // explicit guard is safer and gives us the overlap count for the
+        // result record.
+        var winnerBookIds = winner.Books.Select(b => b.Id).ToHashSet();
+
+        var booksReassigned = 0;
+        var booksAlreadyShared = 0;
+        foreach (var book in loser.Books.ToList())
+        {
+            if (winnerBookIds.Contains(book.Id))
+            {
+                booksAlreadyShared++;
+            }
+            else
+            {
+                book.Works.Add(winner);
+                winnerBookIds.Add(book.Id);
+                booksReassigned++;
+            }
+        }
+
+        // Clearing loser.Books deletes the BookWork rows; Books themselves
+        // stay (their other Works — including winner, which we just added —
+        // hold them in place).
+        loser.Books.Clear();
+
+        var staleIgnores = await db.IgnoredDuplicates
+            .Where(d => d.EntityType == DuplicateEntityType.Work
+                    && (d.LowerId == loser.Id || d.HigherId == loser.Id))
+            .ToListAsync(ct);
+        db.IgnoredDuplicates.RemoveRange(staleIgnores);
+
+        db.Works.Remove(loser);
+
+        await db.SaveChangesAsync(ct);
+        await tx.CommitAsync(ct);
+
+        return new WorkMergeResult(
+            Success: true,
+            ErrorMessage: null,
+            BooksReassigned: booksReassigned,
+            BooksAlreadyShared: booksAlreadyShared,
+            WinnerTitle: winner.Title,
+            LoserTitle: loser.Title);
+    }
+
+    private static async Task<WorkMergeDetail?> LoadDetailAsync(BookTrackerDbContext db, int id, CancellationToken ct)
+    {
+        var work = await db.Works
+            .Include(w => w.Author)
+            .Include(w => w.Series)
+            .Include(w => w.Genres)
+            .FirstOrDefaultAsync(w => w.Id == id, ct);
+        if (work is null) return null;
+
+        var bookCount = await db.Books.CountAsync(b => b.Works.Any(w => w.Id == id), ct);
+        var sampleBookTitles = await db.Books
+            .Where(b => b.Works.Any(w => w.Id == id))
+            .OrderBy(b => b.Title)
+            .Take(SampleBookLimit)
+            .Select(b => b.Title)
+            .ToListAsync(ct);
+
+        return new WorkMergeDetail(
+            work.Id, work.Title, work.Subtitle,
+            work.Author.Name,
+            work.FirstPublishedDate?.Year,
+            work.Series?.Name,
+            work.SeriesOrder,
+            work.Genres.Select(g => g.Name).OrderBy(n => n).ToList(),
+            bookCount, sampleBookTitles);
+    }
+
+    private static async Task<int> CountSharedBooksAsync(BookTrackerDbContext db, int lowerId, int higherId, CancellationToken ct)
+    {
+        return await db.Books
+            .CountAsync(b => b.Works.Any(w => w.Id == lowerId)
+                          && b.Works.Any(w => w.Id == higherId), ct);
+    }
+
+    private static WorkMergeResult Failure(string message) =>
+        new(false, message, 0, 0, null, null);
+}

--- a/BookTracker.Web/Services/WorkSearchService.cs
+++ b/BookTracker.Web/Services/WorkSearchService.cs
@@ -1,0 +1,74 @@
+using BookTracker.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookTracker.Web.Services;
+
+public interface IWorkSearchService
+{
+    Task<IReadOnlyList<WorkSearchResult>> SearchAsync(
+        string query,
+        int? excludeBookId = null,
+        int maxResults = 20,
+        CancellationToken ct = default);
+}
+
+public record WorkSearchResult(
+    int Id,
+    string Title,
+    string? Subtitle,
+    string AuthorName,
+    int BookCount);
+
+public class WorkSearchService(IDbContextFactory<BookTrackerDbContext> dbFactory) : IWorkSearchService
+{
+    public async Task<IReadOnlyList<WorkSearchResult>> SearchAsync(
+        string query,
+        int? excludeBookId = null,
+        int maxResults = 20,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(query) || query.Trim().Length < 2)
+        {
+            return [];
+        }
+
+        var q = query.Trim().ToLower();
+
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+
+        // Exclude Works already attached to the given Book so the caller
+        // doesn't get "attach this Work that's already here" options in
+        // the dropdown.
+        var worksQuery = db.Works.AsNoTracking();
+        if (excludeBookId is int excludeId)
+        {
+            worksQuery = worksQuery.Where(w => !w.Books.Any(b => b.Id == excludeId));
+        }
+
+        // Server-evaluable substring + case filter. SQL Server default
+        // collations are case-insensitive, but ToLower() + Contains keeps
+        // the InMemory provider honest under tests.
+        var matches = await worksQuery
+            .Where(w => w.Title.ToLower().Contains(q))
+            .Select(w => new
+            {
+                w.Id,
+                w.Title,
+                w.Subtitle,
+                AuthorName = w.Author.Name,
+                BookCount = w.Books.Count,
+                TitleLower = w.Title.ToLower()
+            })
+            .Take(maxResults * 3)
+            .ToListAsync(ct);
+
+        // Rank in memory: starts-with first, then contains anywhere,
+        // alphabetical within each group.
+        return matches
+            .OrderByDescending(m => m.TitleLower.StartsWith(q))
+            .ThenBy(m => m.Title, StringComparer.OrdinalIgnoreCase)
+            .Take(maxResults)
+            .Select(m => new WorkSearchResult(m.Id, m.Title, m.Subtitle, m.AuthorName, m.BookCount))
+            .ToList();
+    }
+}

--- a/BookTracker.Web/ViewModels/BookEditViewModel.cs
+++ b/BookTracker.Web/ViewModels/BookEditViewModel.cs
@@ -7,7 +7,8 @@ namespace BookTracker.Web.ViewModels;
 
 public class BookEditViewModel(
     IDbContextFactory<BookTrackerDbContext> dbFactory,
-    IBookLookupService lookup)
+    IBookLookupService lookup,
+    IWorkSearchService workSearch)
 {
     public BookFormViewModel.BookFormInput? BookInput { get; private set; }
 
@@ -25,6 +26,13 @@ public class BookEditViewModel(
     public List<WorkSummary> OtherWorks { get; private set; } = [];
     public string? NewWorkTitle { get; set; }
     public string? NewWorkAuthor { get; set; }
+
+    // "Attach existing Work" typeahead state — lets the user find an
+    // existing Work (e.g. a story from another compendium) and add it to
+    // this Book without creating a duplicate.
+    public string AttachWorkQuery { get; set; } = "";
+    public IReadOnlyList<WorkSearchResult> AttachWorkResults { get; private set; } = [];
+    public bool Searching { get; private set; }
 
     public bool NotFound { get; private set; }
     public bool Saving { get; private set; }
@@ -396,6 +404,40 @@ public class BookEditViewModel(
         OtherWorks.Add(new WorkSummary(work.Id, work.Title, author.Name, 0));
         NewWorkTitle = null;
         NewWorkAuthor = null;
+    }
+
+    public async Task SearchWorksToAttachAsync(int bookId)
+    {
+        Searching = true;
+        try
+        {
+            AttachWorkResults = await workSearch.SearchAsync(AttachWorkQuery, excludeBookId: bookId);
+        }
+        finally
+        {
+            Searching = false;
+        }
+    }
+
+    public async Task AttachWorkAsync(int bookId, int workId)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync();
+        var book = await db.Books.Include(b => b.Works).FirstOrDefaultAsync(b => b.Id == bookId);
+        var work = await db.Works.Include(w => w.Author).Include(w => w.Genres).FirstOrDefaultAsync(w => w.Id == workId);
+        if (book is null || work is null) return;
+
+        // Defensive: exclude-by-bookId already filters attached Works out of
+        // search results, but if the page was stale this prevents the EF
+        // many-to-many PK violation.
+        if (book.Works.Any(w => w.Id == workId)) return;
+
+        book.Works.Add(work);
+        await db.SaveChangesAsync();
+
+        OtherWorks.Add(new WorkSummary(work.Id, work.Title, work.Author.Name, work.Genres.Count));
+        AttachWorkQuery = "";
+        AttachWorkResults = [];
+        SuccessMessage = $"Attached \"{work.Title}\" to this book.";
     }
 
     public async Task RemoveOtherWorkAsync(int workId)

--- a/BookTracker.Web/ViewModels/WorkMergeViewModel.cs
+++ b/BookTracker.Web/ViewModels/WorkMergeViewModel.cs
@@ -1,0 +1,77 @@
+using BookTracker.Web.Services;
+
+namespace BookTracker.Web.ViewModels;
+
+// Backs /duplicates/merge/work/{idA}/{idB}. Mirrors AuthorMergeViewModel
+// shape — load preview, user picks winner, commit via service. No
+// auto-enrichment on merge: if user wants subtitle / series / genres
+// from the loser they copy manually before confirming.
+public class WorkMergeViewModel(IWorkMergeService merger)
+{
+    public bool Loading { get; private set; } = true;
+    public bool Merging { get; private set; }
+
+    public WorkMergeDetail? Lower { get; private set; }
+    public WorkMergeDetail? Higher { get; private set; }
+
+    public string? IncompatibilityReason { get; private set; }
+    public string? ErrorMessage { get; private set; }
+
+    public int SharedBookCount { get; private set; }
+
+    public int? SelectedWinnerId { get; set; }
+
+    public int? LoserId =>
+        SelectedWinnerId is null ? null
+        : SelectedWinnerId == Lower?.Id ? Higher?.Id
+        : SelectedWinnerId == Higher?.Id ? Lower?.Id
+        : null;
+
+    public WorkMergeDetail? Loser =>
+        LoserId is null ? null
+        : LoserId == Lower?.Id ? Lower
+        : LoserId == Higher?.Id ? Higher
+        : null;
+
+    public bool CanMerge =>
+        !Loading && !Merging
+        && IncompatibilityReason is null
+        && Lower is not null && Higher is not null
+        && SelectedWinnerId is not null;
+
+    public async Task LoadAsync(int idA, int idB)
+    {
+        Loading = true;
+        ErrorMessage = null;
+        var result = await merger.LoadAsync(idA, idB);
+        Lower = result.Lower;
+        Higher = result.Higher;
+        IncompatibilityReason = result.IncompatibilityReason;
+        SharedBookCount = result.SharedBookCount;
+        if (Lower is null || Higher is null)
+        {
+            ErrorMessage = "One or both Works could not be loaded — they may have been merged or deleted already.";
+        }
+        Loading = false;
+    }
+
+    public async Task<WorkMergeResult?> MergeAsync()
+    {
+        if (!CanMerge || SelectedWinnerId is null || LoserId is null) return null;
+
+        Merging = true;
+        try
+        {
+            var result = await merger.MergeAsync(SelectedWinnerId.Value, LoserId.Value);
+            if (!result.Success)
+            {
+                ErrorMessage = result.ErrorMessage;
+            }
+            return result;
+        }
+        finally
+        {
+            Merging = false;
+        }
+    }
+}

--- a/TODO.md
+++ b/TODO.md
@@ -38,7 +38,7 @@ Outstanding work items for BookTracker. This is the single source of truth — c
 Detection + `/duplicates` listing shipped in PR 1 (this branch). Remaining PRs in the series:
 
 - [x] **PR 2 — Author merge** (shipped): side-by-side review at `/duplicates/merge/author/{a}/{b}`, reassigns works + aliases, auto-promotes winner to canonical when winner was an alias of loser, refuses when the two resolve to different canonicals.
-- [ ] **PR 3 — Work merge + Add-Work-to-Book via search** (bundled; shares the Work-search UI): reassign `BookWork` join rows, enrich winner from loser's populated fields (subtitle, genres, series, `FirstPublishedDate`), delete loser. Add "search existing Works" affordance on the Edit Book page to attach a story to an anthology.
+- [x] **PR 3 — Work merge + Add-Work-to-Book via search** (shipped): `/duplicates/merge/work/{a}/{b}` transactional merge with "Book contains both" handling and surfacing in preview + success banner. Edit Book page gains an "Attach existing Work" typeahead row above the create-new row. No field auto-enrichment — user copies anything they want to keep (subtitle, series, genres) manually before confirming.
 - [ ] **PR 4 — Edition merge**: reassign `Copy.EditionId`, enrich fields, delete loser. Same-Book only (cross-Book edition dupes imply the Books are dupes → handle those first).
 - [ ] **PR 5 — Book merge**: union Works/Tags, move all Editions, merge any duplicate Editions that result, delete loser.
 - [ ] **PR 6 (audit first, possibly drop)** — gap-fill on Edit Book's "add Edition by ISBN". Partial implementation already exists via `BookEditViewModel.NewEditionLookupIsbn`; only open a PR if the audit shows a real gap.


### PR DESCRIPTION
Two bundled pieces:

1. Work merge: /duplicates/merge/work/{a}/{b} with side-by-side review,
   winner radio, impact preview. Strict replace — no auto-enrichment from
   loser. The "Book contains both" edge case is handled cleanly and
   surfaced explicitly in the preview and success banner so the user
   isn't surprised when a compendium's Works count drops.

2. Attach existing Work: Edit Book "Other works" section gains a
   typeahead row above the existing create-new row. Searches Works by
   title (substring, case-insensitive), excludes Works already attached
   to the current book, and attaches the picked Work to the Book.

Design notes:
- Merge refuses when the two Works have different AuthorId. Detection
  already blocks by author but this guards direct-URL hits.
- loser.Books.Clear() deletes the BookWork rows via EF's many-to-many;
  for Books that contained both, winner is added first (so the Book
  still references the merged identity), then the clear drops the
  loser-side row.
- WorkSearchService ranks starts-with above contains-anywhere,
  alphabetical within. Min 2 chars to search.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
