### PR TITLE
docs(arch): note MudBlazor pilot + coexistence strategy

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -200,6 +200,16 @@ ISBN barcodes (EAN-13/EAN-8) are scanned via the `html5-qrcode` library (v2.3.8,
 ### Photo ISBN OCR
 For older books without barcodes, `photo-capture.js` opens the camera for a still photo. The image is scaled to max 800px, compressed to 70% JPEG, and sent to the active AI provider's `ExtractIsbnFromImageAsync` for vision OCR. SignalR max message size increased to 512KB for image transfer.
 
+## UI component library
+
+Mid-migration from Bootstrap to **MudBlazor 9** (`BookTracker.Web.csproj`). Current state:
+
+- **Pilot pages using MudBlazor:** Home, Duplicates/MergeBook. These use `MudCard`, `MudButton`, `MudText`, `MudContainer`, etc.
+- **All other pages use Bootstrap** (hand-rolled cards, `.container`, `.btn`, etc.). The navbar in `MainLayout.razor` is still Bootstrap.
+- **Rollout strategy:** no migration deadline — pages convert as they're touched for other reasons. Low-traffic pages may stay Bootstrap indefinitely; that's fine.
+- **Coexistence:** both stylesheets are loaded in `App.razor`. MudBlazor's four root providers (`MudThemeProvider`, `MudPopoverProvider`, `MudDialogProvider`, `MudSnackbarProvider`) sit in `MainLayout.razor` — harmless on Bootstrap-only pages. Each page picks one lane.
+- **Theme:** custom "warm library" palette in `BookTracker.Web/Theme/BookTrackerTheme.cs` (oxblood / antique brass / forest / parchment / espresso). Applied globally via `<MudThemeProvider Theme="BookTrackerTheme.Default" />`. Dark mode not wired yet.
+
 ## Mobile responsiveness
 
 Key mobile workflows: barcode scanning, library search, shopping mode. Pages use Bootstrap responsive utilities:


### PR DESCRIPTION
Add a "UI component library" section to ARCHITECTURE.md describing the
mid-migration state: MudBlazor pilot on Home + MergeBook, Bootstrap on
everything else, "convert as we touch" rollout, and the custom warm
library theme. Should have been part of PR #93; follow-up per the
architecture-doc discipline.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
