### PR TITLE
feat(books): read-only View page (PR 1 — scaffold)

### DIFF
--- a/BookTracker.Tests/ViewModels/BookDetailViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/BookDetailViewModelTests.cs
@@ -1,0 +1,180 @@
+using BookTracker.Data.Models;
+using BookTracker.Web.ViewModels;
+
+namespace BookTracker.Tests.ViewModels;
+
+public class BookDetailViewModelTests
+{
+    [Fact]
+    public async Task InitializeAsync_MissingId_MarksNotFound()
+    {
+        var factory = new TestDbContextFactory();
+        var vm = new BookDetailViewModel(factory);
+
+        await vm.InitializeAsync(999);
+
+        Assert.True(vm.NotFound);
+        Assert.Null(vm.Book);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_SingleWorkBook_ShapesBasicDetails()
+    {
+        var factory = new TestDbContextFactory();
+
+        int bookId;
+        using (var db = factory.CreateDbContext())
+        {
+            var author = new Author { Name = "Ursula K. Le Guin" };
+            var genre = new Genre { Name = "Fantasy" };
+            var book = new Book
+            {
+                Title = "A Wizard of Earthsea",
+                Status = BookStatus.Read,
+                Rating = 5,
+                Notes = "Gorgeous prose.",
+                Works =
+                [
+                    new Work
+                    {
+                        Title = "A Wizard of Earthsea",
+                        Author = author,
+                        Genres = [genre],
+                    }
+                ],
+            };
+            db.Books.Add(book);
+            await db.SaveChangesAsync();
+            bookId = book.Id;
+        }
+
+        var vm = new BookDetailViewModel(factory);
+        await vm.InitializeAsync(bookId);
+
+        Assert.False(vm.NotFound);
+        Assert.NotNull(vm.Book);
+        Assert.True(vm.IsSingleWork);
+        Assert.Equal("A Wizard of Earthsea", vm.Book!.Title);
+        Assert.Equal(BookStatus.Read, vm.Book.Status);
+        Assert.Equal(5, vm.Book.Rating);
+        Assert.Single(vm.Book.Works);
+        Assert.Equal("Ursula K. Le Guin", vm.Book.Works[0].AuthorName);
+        Assert.Contains("Fantasy", vm.Book.Works[0].Genres);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_MultiWorkBook_FlagsCompendiumAndOrdersBySeries()
+    {
+        var factory = new TestDbContextFactory();
+
+        int bookId;
+        using (var db = factory.CreateDbContext())
+        {
+            var author = new Author { Name = "William Shakespeare" };
+            var series = new Series { Name = "Shakespeare's Plays", Type = SeriesType.Collection };
+            var book = new Book
+            {
+                Title = "Complete Works",
+                Works =
+                [
+                    // Intentionally out of order — VM should sort by SeriesOrder.
+                    new Work { Title = "Macbeth", Author = author, Series = series, SeriesOrder = 3 },
+                    new Work { Title = "Hamlet", Author = author, Series = series, SeriesOrder = 1 },
+                    new Work { Title = "Othello", Author = author, Series = series, SeriesOrder = 2 },
+                ],
+            };
+            db.Books.Add(book);
+            await db.SaveChangesAsync();
+            bookId = book.Id;
+        }
+
+        var vm = new BookDetailViewModel(factory);
+        await vm.InitializeAsync(bookId);
+
+        Assert.False(vm.IsSingleWork);
+        Assert.Equal(3, vm.Book!.Works.Count);
+        Assert.Equal("Hamlet", vm.Book.Works[0].Title);
+        Assert.Equal("Othello", vm.Book.Works[1].Title);
+        Assert.Equal("Macbeth", vm.Book.Works[2].Title);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_EditionsAndCopies_CountsAndNests()
+    {
+        var factory = new TestDbContextFactory();
+
+        int bookId;
+        using (var db = factory.CreateDbContext())
+        {
+            var author = new Author { Name = "Terry Pratchett" };
+            var book = new Book
+            {
+                Title = "Mort",
+                Works = [new Work { Title = "Mort", Author = author }],
+                Editions =
+                [
+                    new Edition
+                    {
+                        Isbn = "9780552131063",
+                        Format = BookFormat.MassMarketPaperback,
+                        Copies =
+                        [
+                            new Copy { Condition = BookCondition.Good },
+                            new Copy { Condition = BookCondition.Fair },
+                        ],
+                    },
+                    new Edition
+                    {
+                        Isbn = "9780061020681",
+                        Format = BookFormat.Hardcover,
+                        Copies = [new Copy { Condition = BookCondition.Fine }],
+                    },
+                ],
+            };
+            db.Books.Add(book);
+            await db.SaveChangesAsync();
+            bookId = book.Id;
+        }
+
+        var vm = new BookDetailViewModel(factory);
+        await vm.InitializeAsync(bookId);
+
+        Assert.Equal(2, vm.TotalEditions);
+        Assert.Equal(3, vm.TotalCopies);
+        Assert.Equal(2, vm.Book!.Editions.Count);
+        Assert.Contains(vm.Book.Editions, e => e.Copies.Count == 2);
+        Assert.Contains(vm.Book.Editions, e => e.Copies.Count == 1);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_Tags_SortedByName()
+    {
+        var factory = new TestDbContextFactory();
+
+        int bookId;
+        using (var db = factory.CreateDbContext())
+        {
+            var author = new Author { Name = "Author" };
+            var book = new Book
+            {
+                Title = "Tagged",
+                Works = [new Work { Title = "Tagged", Author = author }],
+                Tags =
+                [
+                    new Tag { Name = "signed" },
+                    new Tag { Name = "follow-up" },
+                    new Tag { Name = "gift" },
+                ],
+            };
+            db.Books.Add(book);
+            await db.SaveChangesAsync();
+            bookId = book.Id;
+        }
+
+        var vm = new BookDetailViewModel(factory);
+        await vm.InitializeAsync(bookId);
+
+        var names = vm.Book!.Tags.Select(t => t.Name).ToList();
+        Assert.Equal(new[] { "follow-up", "gift", "signed" }, names);
+    }
+}

--- a/BookTracker.Web/Components/Pages/Books/Detail.razor
+++ b/BookTracker.Web/Components/Pages/Books/Detail.razor
@@ -1,0 +1,381 @@
+@page "/books/{BookId:int}"
+@inject BookDetailViewModel VM
+@inject NavigationManager Nav
+
+@* Book detail / View page — browse-first, MudBlazor pilot continuation.
+   PR 1 ships read-only; edit surfaces (inline auto-save + modals) land
+   in subsequent PRs. Single-Work books collapse into one "Details" panel;
+   multi-Work compendiums render a searchable list. Mobile-first single
+   column, capped at MaxWidth.Medium on desktop. *@
+
+<PageTitle>@(VM.Book?.Title ?? "Book") - BookTracker</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.Medium" Class="py-3">
+
+    @if (VM.NotFound)
+    {
+        <MudAlert Severity="Severity.Warning" Class="mb-3">
+            No book with ID @BookId exists.
+        </MudAlert>
+        <MudButton Href="/books" Variant="Variant.Outlined" StartIcon="@Icons.Material.Filled.ArrowBack">
+            Back to library
+        </MudButton>
+    }
+    else if (VM.Book is null)
+    {
+        <MudStack AlignItems="AlignItems.Center" Class="py-5">
+            <MudProgressCircular Indeterminate="true" />
+        </MudStack>
+    }
+    else
+    {
+        var book = VM.Book;
+        var primary = book.Works.FirstOrDefault();
+
+        @* Header — cover, title, author, status, rating, primary actions. *@
+        <MudCard Elevation="1" Class="mb-3">
+            <MudCardContent>
+                <MudStack Row="true" Spacing="3" Wrap="Wrap.NoWrap" AlignItems="AlignItems.Start">
+                    @if (!string.IsNullOrEmpty(book.CoverUrl))
+                    {
+                        <MudImage Src="@book.CoverUrl"
+                                  Alt="@($"Cover of {book.Title}")"
+                                  Width="120"
+                                  Style="max-width: 120px; width: 100%; height: auto; border-radius: 4px; flex: 0 0 auto;" />
+                    }
+                    else
+                    {
+                        <MudPaper Elevation="0" Class="d-flex align-items-center justify-content-center"
+                                  Style="width: 96px; height: 140px; background: var(--mud-palette-background-gray); flex: 0 0 auto; border-radius: 4px;">
+                            <MudIcon Icon="@Icons.Material.Filled.MenuBook" Size="Size.Large" Color="Color.Secondary" />
+                        </MudPaper>
+                    }
+
+                    <MudStack Spacing="1" Class="flex-grow-1" Style="min-width: 0;">
+                        <MudText Typo="Typo.h5" Style="word-break: break-word;">@book.Title</MudText>
+                        @if (primary is not null)
+                        {
+                            @if (!string.IsNullOrEmpty(primary.Subtitle) && VM.IsSingleWork)
+                            {
+                                <MudText Typo="Typo.subtitle2" Color="Color.Secondary" Style="word-break: break-word;">@primary.Subtitle</MudText>
+                            }
+                            <MudText Typo="Typo.subtitle1">@primary.AuthorName@(VM.IsSingleWork ? "" : $" (+ {book.Works.Count - 1} more)")</MudText>
+                        }
+                        <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center" Wrap="Wrap.Wrap" Class="mt-1">
+                            <MudChip T="string" Size="Size.Small" Color="@StatusColor(book.Status)" Variant="Variant.Filled">@StatusLabel(book.Status)</MudChip>
+                            <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined">@(book.Category == BookCategory.Fiction ? "Fiction" : "Non-Fiction")</MudChip>
+                            <MudRating ReadOnly="true" SelectedValue="@book.Rating" Size="Size.Small" />
+                        </MudStack>
+                    </MudStack>
+                </MudStack>
+
+                <MudStack Row="true" Spacing="2" Wrap="Wrap.Wrap" Class="mt-3">
+                    <MudButton Href="@($"/books/{book.Id}/edit")"
+                               Variant="Variant.Outlined"
+                               Color="Color.Primary"
+                               StartIcon="@Icons.Material.Filled.Edit"
+                               Size="Size.Small">
+                        Edit all details
+                    </MudButton>
+                    @if (primary?.Series is not null)
+                    {
+                        <MudTooltip Text="Coming soon — browse all books in this series">
+                            <MudButton Disabled="true"
+                                       Variant="Variant.Text"
+                                       StartIcon="@Icons.Material.Filled.Collections"
+                                       Size="Size.Small">
+                                Browse @primary.Series.Name
+                            </MudButton>
+                        </MudTooltip>
+                    }
+                </MudStack>
+            </MudCardContent>
+        </MudCard>
+
+        @* Details panel — single-Work collapse vs multi-Work list. *@
+        @if (VM.IsSingleWork && primary is not null)
+        {
+            <MudCard Elevation="1" Class="mb-3">
+                <MudCardHeader>
+                    <CardHeaderContent>
+                        <MudText Typo="Typo.h6">Details</MudText>
+                    </CardHeaderContent>
+                </MudCardHeader>
+                <MudCardContent>
+                    <MudStack Spacing="2">
+                        @if (!string.IsNullOrEmpty(primary.FirstPublishedDisplay))
+                        {
+                            <FieldRow Label="First published" Value="@primary.FirstPublishedDisplay" />
+                        }
+                        @if (primary.Series is not null)
+                        {
+                            var seriesValue = primary.Series.Order.HasValue
+                                ? $"{primary.Series.Name} (#{primary.Series.Order})"
+                                : primary.Series.Name;
+                            <FieldRow Label="@(primary.Series.Type == SeriesType.Collection ? "Collection" : "Series")" Value="@seriesValue" />
+                        }
+                        @if (primary.Genres.Count > 0)
+                        {
+                            <div>
+                                <MudText Typo="Typo.caption" Color="Color.Secondary">Genres</MudText>
+                                <MudStack Row="true" Spacing="1" Wrap="Wrap.Wrap" Class="mt-1">
+                                    @foreach (var g in primary.Genres)
+                                    {
+                                        <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined">@g</MudChip>
+                                    }
+                                </MudStack>
+                            </div>
+                        }
+                        @if (!string.IsNullOrEmpty(book.Notes))
+                        {
+                            <div>
+                                <MudText Typo="Typo.caption" Color="Color.Secondary">Notes</MudText>
+                                <MudText Typo="Typo.body2" Style="white-space: pre-wrap;">@book.Notes</MudText>
+                            </div>
+                        }
+                    </MudStack>
+                </MudCardContent>
+            </MudCard>
+        }
+        else
+        {
+            <MudCard Elevation="1" Class="mb-3">
+                <MudCardHeader>
+                    <CardHeaderContent>
+                        <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
+                            <MudText Typo="Typo.h6">Works in this book</MudText>
+                            <MudText Typo="Typo.body2" Color="Color.Secondary">@book.Works.Count</MudText>
+                        </MudStack>
+                    </CardHeaderContent>
+                </MudCardHeader>
+                <MudCardContent>
+                    @if (book.Works.Count > 10)
+                    {
+                        <MudTextField @bind-Value="workFilter"
+                                      Placeholder="Filter by title or author..."
+                                      Variant="Variant.Outlined"
+                                      Margin="Margin.Dense"
+                                      Adornment="Adornment.Start"
+                                      AdornmentIcon="@Icons.Material.Filled.Search"
+                                      Clearable="true"
+                                      Class="mb-2" />
+                    }
+
+                    @if (!string.IsNullOrEmpty(book.Notes))
+                    {
+                        <MudText Typo="Typo.caption" Color="Color.Secondary">Book notes</MudText>
+                        <MudText Typo="Typo.body2" Class="mb-3" Style="white-space: pre-wrap;">@book.Notes</MudText>
+                        <MudDivider Class="mb-2" />
+                    }
+
+                    @{
+                        var filtered = FilteredWorks(book.Works);
+                    }
+                    @if (filtered.Count == 0)
+                    {
+                        <MudText Typo="Typo.body2" Color="Color.Secondary">No works match "@workFilter".</MudText>
+                    }
+                    else
+                    {
+                        <MudList T="int" Dense="true" Class="pa-0">
+                            @foreach (var w in filtered)
+                            {
+                                var expanded = expandedWorkIds.Contains(w.Id);
+                                <MudListItem T="int" OnClick="@(() => ToggleWork(w.Id))" Class="px-2">
+                                    <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
+                                        <MudIcon Icon="@(expanded ? Icons.Material.Filled.ExpandLess : Icons.Material.Filled.ExpandMore)" Size="Size.Small" />
+                                        <MudStack Spacing="0" Class="flex-grow-1" Style="min-width: 0;">
+                                            <MudText Typo="Typo.body1" Style="word-break: break-word;">
+                                                @(w.Series?.Order is int o ? $"{o}. " : "")@w.Title
+                                            </MudText>
+                                            <MudText Typo="Typo.caption" Color="Color.Secondary">@w.AuthorName</MudText>
+                                        </MudStack>
+                                    </MudStack>
+                                    @if (expanded)
+                                    {
+                                        <MudStack Spacing="1" Class="mt-2 ps-7">
+                                            @if (!string.IsNullOrEmpty(w.Subtitle))
+                                            {
+                                                <FieldRow Label="Subtitle" Value="@w.Subtitle" />
+                                            }
+                                            @if (!string.IsNullOrEmpty(w.FirstPublishedDisplay))
+                                            {
+                                                <FieldRow Label="First published" Value="@w.FirstPublishedDisplay" />
+                                            }
+                                            @if (w.Series is not null)
+                                            {
+                                                var seriesValue = w.Series.Order.HasValue ? $"{w.Series.Name} (#{w.Series.Order})" : w.Series.Name;
+                                                <FieldRow Label="@(w.Series.Type == SeriesType.Collection ? "Collection" : "Series")" Value="@seriesValue" />
+                                            }
+                                            @if (w.Genres.Count > 0)
+                                            {
+                                                <MudStack Row="true" Spacing="1" Wrap="Wrap.Wrap">
+                                                    @foreach (var g in w.Genres)
+                                                    {
+                                                        <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined">@g</MudChip>
+                                                    }
+                                                </MudStack>
+                                            }
+                                        </MudStack>
+                                    }
+                                </MudListItem>
+                            }
+                        </MudList>
+                    }
+                </MudCardContent>
+            </MudCard>
+        }
+
+        @* Editions & copies. *@
+        <MudCard Elevation="1" Class="mb-3">
+            <MudCardHeader>
+                <CardHeaderContent>
+                    <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center" Wrap="Wrap.Wrap">
+                        <MudText Typo="Typo.h6">Editions &amp; copies</MudText>
+                        <MudText Typo="Typo.body2" Color="Color.Secondary">
+                            @VM.TotalEditions @(VM.TotalEditions == 1 ? "edition" : "editions") · @VM.TotalCopies @(VM.TotalCopies == 1 ? "copy" : "copies")
+                        </MudText>
+                    </MudStack>
+                </CardHeaderContent>
+            </MudCardHeader>
+            <MudCardContent>
+                @if (book.Editions.Count == 0)
+                {
+                    <MudText Typo="Typo.body2" Color="Color.Secondary">No editions recorded yet.</MudText>
+                }
+                else
+                {
+                    <MudExpansionPanels MultiExpansion="true" Elevation="0">
+                        @foreach (var edition in book.Editions)
+                        {
+                            <MudExpansionPanel>
+                                <TitleContent>
+                                    <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center" Wrap="Wrap.Wrap" Class="flex-grow-1" Style="min-width: 0;">
+                                        <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined">@edition.FormatDisplay</MudChip>
+                                        <MudText Typo="Typo.body2" Style="font-family: var(--mud-typography-default-family); word-break: break-all;">
+                                            @(edition.Isbn ?? "no ISBN")
+                                        </MudText>
+                                        <MudSpacer />
+                                        <MudText Typo="Typo.caption" Color="Color.Secondary">
+                                            @edition.Copies.Count @(edition.Copies.Count == 1 ? "copy" : "copies")
+                                        </MudText>
+                                    </MudStack>
+                                </TitleContent>
+                                <ChildContent>
+                                    <MudStack Spacing="2">
+                                        @if (!string.IsNullOrEmpty(edition.Publisher))
+                                        {
+                                            <FieldRow Label="Publisher" Value="@edition.Publisher" />
+                                        }
+                                        @if (!string.IsNullOrEmpty(edition.DatePrintedDisplay))
+                                        {
+                                            <FieldRow Label="Printed" Value="@edition.DatePrintedDisplay" />
+                                        }
+
+                                        <MudDivider />
+
+                                        @foreach (var (copy, idx) in edition.Copies.Select((c, i) => (c, i)))
+                                        {
+                                            <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Start" Wrap="Wrap.Wrap">
+                                                <MudText Typo="Typo.body2" Style="min-width: 70px;">
+                                                    <b>Copy @(idx + 1)</b>
+                                                </MudText>
+                                                <MudStack Spacing="0" Class="flex-grow-1">
+                                                    <MudText Typo="Typo.body2">@ConditionLabel(copy.Condition)</MudText>
+                                                    @if (copy.DateAcquired.HasValue)
+                                                    {
+                                                        <MudText Typo="Typo.caption" Color="Color.Secondary">
+                                                            Acquired @copy.DateAcquired.Value.ToString("d MMM yyyy")
+                                                        </MudText>
+                                                    }
+                                                    @if (!string.IsNullOrEmpty(copy.Notes))
+                                                    {
+                                                        <MudText Typo="Typo.caption" Color="Color.Secondary" Style="white-space: pre-wrap;">@copy.Notes</MudText>
+                                                    }
+                                                </MudStack>
+                                            </MudStack>
+                                        }
+                                    </MudStack>
+                                </ChildContent>
+                            </MudExpansionPanel>
+                        }
+                    </MudExpansionPanels>
+                }
+            </MudCardContent>
+        </MudCard>
+
+        @* Tags. *@
+        @if (book.Tags.Count > 0)
+        {
+            <MudCard Elevation="1" Class="mb-3">
+                <MudCardHeader>
+                    <CardHeaderContent>
+                        <MudText Typo="Typo.h6">Tags</MudText>
+                    </CardHeaderContent>
+                </MudCardHeader>
+                <MudCardContent>
+                    <MudStack Row="true" Spacing="1" Wrap="Wrap.Wrap">
+                        @foreach (var t in book.Tags)
+                        {
+                            <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined">@t.Name</MudChip>
+                        }
+                    </MudStack>
+                </MudCardContent>
+            </MudCard>
+        }
+
+        <MudStack Row="true" Spacing="2" Class="mt-3">
+            <MudButton Href="/books" Variant="Variant.Text" StartIcon="@Icons.Material.Filled.ArrowBack">
+                Back to library
+            </MudButton>
+        </MudStack>
+    }
+
+</MudContainer>
+
+@code {
+    [Parameter] public int BookId { get; set; }
+
+    private string workFilter = "";
+    private readonly HashSet<int> expandedWorkIds = [];
+
+    protected override async Task OnInitializedAsync() => await VM.InitializeAsync(BookId);
+
+    private void ToggleWork(int id)
+    {
+        if (!expandedWorkIds.Add(id)) expandedWorkIds.Remove(id);
+    }
+
+    private List<BookDetailViewModel.WorkDetail> FilteredWorks(IReadOnlyList<BookDetailViewModel.WorkDetail> works)
+    {
+        if (string.IsNullOrWhiteSpace(workFilter)) return works.ToList();
+        var f = workFilter.Trim();
+        return works
+            .Where(w => w.Title.Contains(f, StringComparison.OrdinalIgnoreCase)
+                     || w.AuthorName.Contains(f, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+    }
+
+    private static Color StatusColor(BookStatus status) => status switch
+    {
+        BookStatus.Read => Color.Success,
+        BookStatus.Reading => Color.Info,
+        BookStatus.Unread => Color.Default,
+        _ => Color.Default,
+    };
+
+    private static string StatusLabel(BookStatus status) => status switch
+    {
+        BookStatus.Read => "Read",
+        BookStatus.Reading => "Reading",
+        BookStatus.Unread => "Unread",
+        _ => status.ToString(),
+    };
+
+    private static string ConditionLabel(BookCondition c) => c switch
+    {
+        BookCondition.AsNew => "As New",
+        BookCondition.VeryGood => "Very Good",
+        _ => c.ToString(),
+    };
+}

--- a/BookTracker.Web/Components/Pages/Books/Edit.razor
+++ b/BookTracker.Web/Components/Pages/Books/Edit.razor
@@ -20,7 +20,10 @@ else if (VM.BookInput is null)
 }
 else
 {
-    <h1 class="mb-3">Edit book</h1>
+    <div class="d-flex justify-content-between align-items-center mb-3 flex-wrap gap-2">
+        <h1 class="mb-0">Edit book</h1>
+        <a href="@($"/books/{BookId}")" class="btn btn-outline-secondary btn-sm">View (preview)</a>
+    </div>
 
     @if (!string.IsNullOrEmpty(VM.SuccessMessage))
     {

--- a/BookTracker.Web/Components/Shared/FieldRow.razor
+++ b/BookTracker.Web/Components/Shared/FieldRow.razor
@@ -1,0 +1,12 @@
+@* Compact label/value row for read-only detail pages. Stacks the label
+   above the value so long values wrap cleanly on mobile. *@
+
+<div>
+    <MudText Typo="Typo.caption" Color="Color.Secondary">@Label</MudText>
+    <MudText Typo="Typo.body2" Style="word-break: break-word;">@Value</MudText>
+</div>
+
+@code {
+    [Parameter, EditorRequired] public string Label { get; set; } = "";
+    [Parameter, EditorRequired] public string? Value { get; set; }
+}

--- a/BookTracker.Web/Program.cs
+++ b/BookTracker.Web/Program.cs
@@ -78,6 +78,7 @@ builder.Services.AddTransient<GenrePickerViewModel>();
 builder.Services.AddTransient<BookListViewModel>();
 builder.Services.AddTransient<BookAddViewModel>();
 builder.Services.AddTransient<BookEditViewModel>();
+builder.Services.AddTransient<BookDetailViewModel>();
 builder.Services.AddTransient<BulkAddViewModel>();
 builder.Services.AddTransient<SeriesListViewModel>();
 builder.Services.AddTransient<SeriesEditViewModel>();

--- a/BookTracker.Web/ViewModels/BookDetailViewModel.cs
+++ b/BookTracker.Web/ViewModels/BookDetailViewModel.cs
@@ -1,0 +1,134 @@
+using BookTracker.Data;
+using BookTracker.Data.Models;
+using BookTracker.Web.Services;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookTracker.Web.ViewModels;
+
+// Read-only view model for the book detail page (View page, /books/{id}).
+// Deliberately flat display shape — no form inputs, no edit state — so the
+// page can focus on browsing. Edit surfaces will land in later PRs via
+// inline auto-save (rating/status/notes/tags) and modal dialogs
+// (work/edition/copy edits).
+public class BookDetailViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory)
+{
+    public bool NotFound { get; private set; }
+    public BookDetail? Book { get; private set; }
+
+    public bool IsSingleWork => Book is not null && Book.Works.Count == 1;
+    public int TotalEditions => Book?.Editions.Count ?? 0;
+    public int TotalCopies => Book?.Editions.Sum(e => e.Copies.Count) ?? 0;
+
+    public async Task InitializeAsync(int bookId)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync();
+
+        var book = await db.Books
+            .Include(b => b.Tags)
+            .Include(b => b.Editions)
+                .ThenInclude(e => e.Copies)
+            .Include(b => b.Editions)
+                .ThenInclude(e => e.Publisher)
+            .Include(b => b.Works)
+                .ThenInclude(w => w.Author)
+            .Include(b => b.Works)
+                .ThenInclude(w => w.Genres)
+            .Include(b => b.Works)
+                .ThenInclude(w => w.Series)
+            .AsSplitQuery()
+            .FirstOrDefaultAsync(b => b.Id == bookId);
+
+        if (book is null)
+        {
+            NotFound = true;
+            return;
+        }
+
+        Book = new BookDetail(
+            book.Id,
+            book.Title,
+            book.Category,
+            book.Status,
+            book.Rating,
+            book.Notes,
+            book.DefaultCoverArtUrl,
+            book.DateAdded,
+            book.Works
+                .OrderBy(w => w.SeriesOrder ?? int.MaxValue)
+                .ThenBy(w => w.Title)
+                .Select(ToWorkDetail)
+                .ToList(),
+            book.Editions
+                .OrderBy(e => e.DatePrinted ?? DateOnly.MaxValue)
+                .ThenBy(e => e.Id)
+                .Select(ToEditionDetail)
+                .ToList(),
+            book.Tags
+                .OrderBy(t => t.Name)
+                .Select(t => new TagDetail(t.Id, t.Name))
+                .ToList());
+    }
+
+    private static WorkDetail ToWorkDetail(Work w) => new(
+        w.Id,
+        w.Title,
+        w.Subtitle,
+        w.Author.Name,
+        w.AuthorId,
+        PartialDateParser.Format(w.FirstPublishedDate, w.FirstPublishedDatePrecision),
+        w.Genres.OrderBy(g => g.Name).Select(g => g.Name).ToList(),
+        w.Series is null ? null : new SeriesInfo(w.Series.Id, w.Series.Name, w.Series.Type, w.SeriesOrder));
+
+    private static EditionDetail ToEditionDetail(Edition e) => new(
+        e.Id,
+        e.Isbn,
+        e.Format,
+        e.Format.DisplayName(),
+        e.Publisher?.Name,
+        PartialDateParser.Format(e.DatePrinted, e.DatePrintedPrecision),
+        e.CoverUrl,
+        e.Copies
+            .OrderBy(c => c.DateAcquired ?? DateTime.MaxValue)
+            .ThenBy(c => c.Id)
+            .Select(c => new CopyDetail(c.Id, c.Condition, c.DateAcquired, c.Notes))
+            .ToList());
+
+    public record BookDetail(
+        int Id,
+        string Title,
+        BookCategory Category,
+        BookStatus Status,
+        int Rating,
+        string? Notes,
+        string? CoverUrl,
+        DateTime DateAdded,
+        IReadOnlyList<WorkDetail> Works,
+        IReadOnlyList<EditionDetail> Editions,
+        IReadOnlyList<TagDetail> Tags);
+
+    public record WorkDetail(
+        int Id,
+        string Title,
+        string? Subtitle,
+        string AuthorName,
+        int AuthorId,
+        string FirstPublishedDisplay,
+        IReadOnlyList<string> Genres,
+        SeriesInfo? Series);
+
+    public record SeriesInfo(int Id, string Name, SeriesType Type, int? Order);
+
+    public record EditionDetail(
+        int Id,
+        string? Isbn,
+        BookFormat Format,
+        string FormatDisplay,
+        string? Publisher,
+        string DatePrintedDisplay,
+        string? CoverUrl,
+        IReadOnlyList<CopyDetail> Copies);
+
+    public record CopyDetail(int Id, BookCondition Condition, DateTime? DateAcquired, string? Notes);
+
+    public record TagDetail(int Id, string Name);
+}


### PR DESCRIPTION
Introduces a browse-first detail page at /books/{id} so the primary
"what do I have, what's this book" flow isn't routed through the full
Edit form. Single-Work books collapse into a unified "Details" panel;
multi-Work compendiums render a searchable/expandable list (filter
input when Works > 10 — lines up with Complete Works compilations).
Editions and copies render as a MudExpansionPanels list with a summary
chip ("N editions · M copies") at the top.

Wiring for this PR deliberately conservative:
- Library list click target is unchanged (still goes to /edit). Users
  reach the new page via a temporary "View (preview)" link in the
  Edit page header so it can be clicked through without the rest of
  the app committing to it yet.
- Read-only. Inline auto-save (rating/status/notes/tags) is PR 2;
  modal edits (work/edition/copy) are PR 3; add-edition/add-copy is
  PR 4; browse flows (series/author/occurrences) are PR 5.
- MudBlazor pilot continuation — theme applies automatically.
- Mobile-first single column, capped at MaxWidth.Medium on desktop.

Tests cover the VM projection shape (not-found, single-work,
multi-work ordering by SeriesOrder, edition/copy counts, tag sort).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
