### PR TITLE
chore(todo): log PWA apple-mobile-web-app-capable deprecation

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -27,6 +27,7 @@ Outstanding work items for BookTracker. This is the single source of truth — c
 - [x] **Progressive Web App** (shipped): installable on mobile + desktop via manifest + icons + service worker. Network-first-with-cache-fallback for static assets; `/_blazor/*` passes through. Icons reproducible via `scripts/generate-pwa-icons.ps1`.
 - [ ] Evaluate Blazor component library (MudBlazor, Radzen, FluentUI) to replace hand-rolled Bootstrap (`Program.cs:9`) — **next up: pilot in MudBlazor on `/duplicates/merge/book` + `/` Home**, decide from there
 - [ ] Manage publishers UI — rename/merge duplicates, delete unused (`Publisher.cs:5`)
+- [ ] PWA meta-tag deprecation — add `<meta name="mobile-web-app-capable" content="yes">` alongside the existing `apple-mobile-web-app-capable` in `Components/App.razor` (Chrome dev console warns that the Apple-specific tag is deprecated; keep both so Safari install-to-home-screen still works). Low priority, no functional impact.
 - [ ] Accessibility review — screen reader support, keyboard nav, ARIA labels, colour contrast, focus management
 - [ ] UI testing approach — evaluate bUnit (component-level) and/or Playwright (browser-level) for testing screens and views
 


### PR DESCRIPTION
Chrome dev console warns that the Apple-specific meta tag is deprecated
in favour of the standard `mobile-web-app-capable`. Low priority — no
functional impact — but worth fixing with the next PWA-adjacent patch.
Both tags should remain so Safari install-to-home-screen still works.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
