### PR TITLE
feat(books): inline auto-save on View page (PR 2)

### DIFF
--- a/BookTracker.Tests/ViewModels/BookDetailViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/BookDetailViewModelTests.cs
@@ -1,5 +1,6 @@
 using BookTracker.Data.Models;
 using BookTracker.Web.ViewModels;
+using Microsoft.EntityFrameworkCore;
 
 namespace BookTracker.Tests.ViewModels;
 
@@ -144,6 +145,237 @@ public class BookDetailViewModelTests
         Assert.Equal(2, vm.Book!.Editions.Count);
         Assert.Contains(vm.Book.Editions, e => e.Copies.Count == 2);
         Assert.Contains(vm.Book.Editions, e => e.Copies.Count == 1);
+    }
+
+    [Fact]
+    public async Task SetRatingAsync_PersistsAndUpdatesCurrent()
+    {
+        var factory = new TestDbContextFactory();
+        var bookId = await SeedSimpleBookAsync(factory, rating: 2);
+
+        var vm = new BookDetailViewModel(factory);
+        await vm.InitializeAsync(bookId);
+        await vm.SetRatingAsync(5);
+
+        Assert.Equal(5, vm.CurrentRating);
+        using var db = factory.CreateDbContext();
+        Assert.Equal(5, db.Books.Single(b => b.Id == bookId).Rating);
+    }
+
+    [Fact]
+    public async Task SetStatusAsync_PersistsAndUpdatesCurrent()
+    {
+        var factory = new TestDbContextFactory();
+        var bookId = await SeedSimpleBookAsync(factory, status: BookStatus.Unread);
+
+        var vm = new BookDetailViewModel(factory);
+        await vm.InitializeAsync(bookId);
+        await vm.SetStatusAsync(BookStatus.Reading);
+
+        Assert.Equal(BookStatus.Reading, vm.CurrentStatus);
+        using var db = factory.CreateDbContext();
+        Assert.Equal(BookStatus.Reading, db.Books.Single(b => b.Id == bookId).Status);
+    }
+
+    [Fact]
+    public async Task SaveNotesAsync_OnlyPersistsWhenDirty()
+    {
+        var factory = new TestDbContextFactory();
+        var bookId = await SeedSimpleBookAsync(factory, notes: "original");
+
+        var vm = new BookDetailViewModel(factory);
+        await vm.InitializeAsync(bookId);
+
+        // Not dirty yet — save should be a no-op even if CurrentNotes changed.
+        vm.CurrentNotes = "changed without marking dirty";
+        await vm.SaveNotesAsync();
+        using (var db = factory.CreateDbContext())
+        {
+            Assert.Equal("original", db.Books.Single(b => b.Id == bookId).Notes);
+        }
+
+        // Now mark dirty and save.
+        vm.CurrentNotes = "updated properly";
+        vm.MarkNotesDirty();
+        Assert.True(vm.NotesDirty);
+        await vm.SaveNotesAsync();
+        Assert.False(vm.NotesDirty);
+        using (var db = factory.CreateDbContext())
+        {
+            Assert.Equal("updated properly", db.Books.Single(b => b.Id == bookId).Notes);
+        }
+    }
+
+    [Fact]
+    public async Task SaveNotesAsync_BlankInputPersistsAsNull()
+    {
+        var factory = new TestDbContextFactory();
+        var bookId = await SeedSimpleBookAsync(factory, notes: "will be cleared");
+
+        var vm = new BookDetailViewModel(factory);
+        await vm.InitializeAsync(bookId);
+        vm.CurrentNotes = "   ";
+        vm.MarkNotesDirty();
+        await vm.SaveNotesAsync();
+
+        using var db = factory.CreateDbContext();
+        Assert.Null(db.Books.Single(b => b.Id == bookId).Notes);
+    }
+
+    [Fact]
+    public async Task AddTagAsync_CreatesNewTagAndAssigns()
+    {
+        var factory = new TestDbContextFactory();
+        var bookId = await SeedSimpleBookAsync(factory);
+
+        var vm = new BookDetailViewModel(factory);
+        await vm.InitializeAsync(bookId);
+        var added = await vm.AddTagAsync("Signed");
+
+        Assert.NotNull(added);
+        Assert.Equal("signed", added!.Name); // normalised to lowercase
+        Assert.Contains(vm.CurrentTags, t => t.Name == "signed");
+
+        using var db = factory.CreateDbContext();
+        var book = db.Books.Include(b => b.Tags).Single(b => b.Id == bookId);
+        Assert.Contains(book.Tags, t => t.Name == "signed");
+    }
+
+    [Fact]
+    public async Task AddTagAsync_ReusesExistingTagCaseInsensitively()
+    {
+        var factory = new TestDbContextFactory();
+        int bookId;
+        using (var db = factory.CreateDbContext())
+        {
+            db.Tags.Add(new Tag { Name = "follow-up" }); // pre-existing tag
+            var book = new Book
+            {
+                Title = "T",
+                Works = [new Work { Title = "T", Author = new Author { Name = "A" } }],
+            };
+            db.Books.Add(book);
+            await db.SaveChangesAsync();
+            bookId = book.Id;
+        }
+
+        var vm = new BookDetailViewModel(factory);
+        await vm.InitializeAsync(bookId);
+        await vm.AddTagAsync("FOLLOW-UP");
+
+        using var db2 = factory.CreateDbContext();
+        var tagCount = db2.Tags.Count(t => t.Name == "follow-up");
+        Assert.Equal(1, tagCount); // not duplicated
+    }
+
+    [Fact]
+    public async Task AddTagAsync_IgnoresAlreadyAssignedTag()
+    {
+        var factory = new TestDbContextFactory();
+        int bookId;
+        using (var db = factory.CreateDbContext())
+        {
+            var tag = new Tag { Name = "gift" };
+            var book = new Book
+            {
+                Title = "T",
+                Works = [new Work { Title = "T", Author = new Author { Name = "A" } }],
+                Tags = [tag],
+            };
+            db.Books.Add(book);
+            await db.SaveChangesAsync();
+            bookId = book.Id;
+        }
+
+        var vm = new BookDetailViewModel(factory);
+        await vm.InitializeAsync(bookId);
+        var second = await vm.AddTagAsync("gift");
+
+        Assert.Null(second);
+        Assert.Single(vm.CurrentTags);
+    }
+
+    [Fact]
+    public async Task RemoveTagAsync_DetachesFromBookKeepsTagRow()
+    {
+        var factory = new TestDbContextFactory();
+        int bookId;
+        int tagId;
+        using (var db = factory.CreateDbContext())
+        {
+            var tag = new Tag { Name = "gift" };
+            var book = new Book
+            {
+                Title = "T",
+                Works = [new Work { Title = "T", Author = new Author { Name = "A" } }],
+                Tags = [tag],
+            };
+            db.Books.Add(book);
+            await db.SaveChangesAsync();
+            bookId = book.Id;
+            tagId = tag.Id;
+        }
+
+        var vm = new BookDetailViewModel(factory);
+        await vm.InitializeAsync(bookId);
+        await vm.RemoveTagAsync(tagId);
+
+        Assert.Empty(vm.CurrentTags);
+        using var db2 = factory.CreateDbContext();
+        var book2 = db2.Books.Include(b => b.Tags).Single(b => b.Id == bookId);
+        Assert.Empty(book2.Tags);
+        // Tag row itself survives — other books may still reference it.
+        Assert.Equal(1, db2.Tags.Count(t => t.Id == tagId));
+    }
+
+    [Fact]
+    public async Task SearchTagsAsync_ExcludesAlreadyAssigned()
+    {
+        var factory = new TestDbContextFactory();
+        int bookId;
+        using (var db = factory.CreateDbContext())
+        {
+            var assigned = new Tag { Name = "signed" };
+            db.Tags.Add(new Tag { Name = "follow-up" });
+            db.Tags.Add(new Tag { Name = "gift" });
+            var book = new Book
+            {
+                Title = "T",
+                Works = [new Work { Title = "T", Author = new Author { Name = "A" } }],
+                Tags = [assigned],
+            };
+            db.Books.Add(book);
+            await db.SaveChangesAsync();
+            bookId = book.Id;
+        }
+
+        var vm = new BookDetailViewModel(factory);
+        await vm.InitializeAsync(bookId);
+        var results = (await vm.SearchTagsAsync("", CancellationToken.None)).ToList();
+
+        Assert.Contains("follow-up", results);
+        Assert.Contains("gift", results);
+        Assert.DoesNotContain("signed", results);
+    }
+
+    private static async Task<int> SeedSimpleBookAsync(
+        TestDbContextFactory factory,
+        int rating = 0,
+        BookStatus status = BookStatus.Unread,
+        string? notes = null)
+    {
+        using var db = factory.CreateDbContext();
+        var book = new Book
+        {
+            Title = "Seed",
+            Status = status,
+            Rating = rating,
+            Notes = notes,
+            Works = [new Work { Title = "Seed", Author = new Author { Name = "Seed Author" } }],
+        };
+        db.Books.Add(book);
+        await db.SaveChangesAsync();
+        return book.Id;
     }
 
     [Fact]

--- a/BookTracker.Web/Components/Pages/Books/Detail.razor
+++ b/BookTracker.Web/Components/Pages/Books/Detail.razor
@@ -1,12 +1,14 @@
 @page "/books/{BookId:int}"
+@implements IAsyncDisposable
 @inject BookDetailViewModel VM
 @inject NavigationManager Nav
+@inject ISnackbar Snackbar
 
 @* Book detail / View page — browse-first, MudBlazor pilot continuation.
-   PR 1 ships read-only; edit surfaces (inline auto-save + modals) land
-   in subsequent PRs. Single-Work books collapse into one "Details" panel;
-   multi-Work compendiums render a searchable list. Mobile-first single
-   column, capped at MaxWidth.Medium on desktop. *@
+   PR 1 shipped read-only. PR 2 adds inline auto-save for rating, status,
+   notes (debounced), and tags (autocomplete + closeable chips). Structural
+   edits (Work, Edition, Copy) land in modal dialogs in PR 3+.
+   Mobile-first single column, capped at MaxWidth.Medium on desktop. *@
 
 <PageTitle>@(VM.Book?.Title ?? "Book") - BookTracker</PageTitle>
 
@@ -62,9 +64,21 @@
                             <MudText Typo="Typo.subtitle1">@primary.AuthorName@(VM.IsSingleWork ? "" : $" (+ {book.Works.Count - 1} more)")</MudText>
                         }
                         <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center" Wrap="Wrap.Wrap" Class="mt-1">
-                            <MudChip T="string" Size="Size.Small" Color="@StatusColor(book.Status)" Variant="Variant.Filled">@StatusLabel(book.Status)</MudChip>
+                            @* Status: three filter-chip buttons, single-selection, auto-save on change. *@
+                            <MudChipSet T="BookStatus"
+                                        SelectionMode="SelectionMode.SingleSelection"
+                                        CheckMark="false"
+                                        SelectedValue="VM.CurrentStatus"
+                                        SelectedValueChanged="OnStatusChanged">
+                                @foreach (var s in new[] { BookStatus.Unread, BookStatus.Reading, BookStatus.Read })
+                                {
+                                    <MudChip T="BookStatus" Value="s" Size="Size.Small" Color="@StatusColor(s)">@StatusLabel(s)</MudChip>
+                                }
+                            </MudChipSet>
                             <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined">@(book.Category == BookCategory.Fiction ? "Fiction" : "Non-Fiction")</MudChip>
-                            <MudRating ReadOnly="true" SelectedValue="@book.Rating" Size="Size.Small" />
+                            <MudRating SelectedValue="VM.CurrentRating"
+                                       SelectedValueChanged="OnRatingChanged"
+                                       Size="Size.Small" />
                         </MudStack>
                     </MudStack>
                 </MudStack>
@@ -126,13 +140,7 @@
                                 </MudStack>
                             </div>
                         }
-                        @if (!string.IsNullOrEmpty(book.Notes))
-                        {
-                            <div>
-                                <MudText Typo="Typo.caption" Color="Color.Secondary">Notes</MudText>
-                                <MudText Typo="Typo.body2" Style="white-space: pre-wrap;">@book.Notes</MudText>
-                            </div>
-                        }
+                        <NotesEditor VM="VM" OnSaveRequested="SaveNotesImmediateAsync" OnDirty="OnNotesDirty" />
                     </MudStack>
                 </MudCardContent>
             </MudCard>
@@ -161,12 +169,10 @@
                                       Class="mb-2" />
                     }
 
-                    @if (!string.IsNullOrEmpty(book.Notes))
-                    {
-                        <MudText Typo="Typo.caption" Color="Color.Secondary">Book notes</MudText>
-                        <MudText Typo="Typo.body2" Class="mb-3" Style="white-space: pre-wrap;">@book.Notes</MudText>
-                        <MudDivider Class="mb-2" />
-                    }
+                    <div class="mb-3">
+                        <NotesEditor VM="VM" OnSaveRequested="SaveNotesImmediateAsync" OnDirty="OnNotesDirty" />
+                    </div>
+                    <MudDivider Class="mb-2" />
 
                     @{
                         var filtered = FilteredWorks(book.Works);
@@ -304,25 +310,45 @@
             </MudCardContent>
         </MudCard>
 
-        @* Tags. *@
-        @if (book.Tags.Count > 0)
-        {
-            <MudCard Elevation="1" Class="mb-3">
-                <MudCardHeader>
-                    <CardHeaderContent>
-                        <MudText Typo="Typo.h6">Tags</MudText>
-                    </CardHeaderContent>
-                </MudCardHeader>
-                <MudCardContent>
-                    <MudStack Row="true" Spacing="1" Wrap="Wrap.Wrap">
-                        @foreach (var t in book.Tags)
+        @* Tags — inline add via autocomplete, closeable chips. *@
+        <MudCard Elevation="1" Class="mb-3">
+            <MudCardHeader>
+                <CardHeaderContent>
+                    <MudText Typo="Typo.h6">Tags</MudText>
+                </CardHeaderContent>
+            </MudCardHeader>
+            <MudCardContent>
+                @if (VM.CurrentTags.Count > 0)
+                {
+                    <MudStack Row="true" Spacing="1" Wrap="Wrap.Wrap" Class="mb-2">
+                        @foreach (var t in VM.CurrentTags)
                         {
-                            <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined">@t.Name</MudChip>
+                            <MudChip T="string"
+                                     Size="Size.Small"
+                                     Variant="Variant.Outlined"
+                                     OnClose="@(() => OnRemoveTagAsync(t.Id))">@t.Name</MudChip>
                         }
                     </MudStack>
-                </MudCardContent>
-            </MudCard>
-        }
+                }
+                <MudAutocomplete T="string"
+                                 @bind-Value="newTagText"
+                                 SearchFunc="SearchTagsAsync"
+                                 Placeholder="Add a tag..."
+                                 Variant="Variant.Outlined"
+                                 Margin="Margin.Dense"
+                                 Clearable="true"
+                                 CoerceText="true"
+                                 CoerceValue="true"
+                                 OnKeyDown="OnTagKeyDown"
+                                 OnBlur="OnTagBlur"
+                                 ResetValueOnEmptyText="true"
+                                 Adornment="Adornment.Start"
+                                 AdornmentIcon="@Icons.Material.Filled.Add" />
+                <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mt-1">
+                    Press Enter or pick a suggestion. New tags are created automatically.
+                </MudText>
+            </MudCardContent>
+        </MudCard>
 
         <MudStack Row="true" Spacing="2" Class="mt-3">
             <MudButton Href="/books" Variant="Variant.Text" StartIcon="@Icons.Material.Filled.ArrowBack">
@@ -338,8 +364,25 @@
 
     private string workFilter = "";
     private readonly HashSet<int> expandedWorkIds = [];
+    private string? newTagText;
+
+    // Notes debounce: 800ms after the last keystroke OR immediate on blur.
+    // CTS is re-created per keystroke so the previous pending save is
+    // cancelled. Disposed on component teardown so we don't trigger a
+    // save against a torn-down circuit.
+    private CancellationTokenSource? notesCts;
+    private const int NotesDebounceMs = 800;
 
     protected override async Task OnInitializedAsync() => await VM.InitializeAsync(BookId);
+
+    public async ValueTask DisposeAsync()
+    {
+        if (notesCts is not null)
+        {
+            await notesCts.CancelAsync();
+            notesCts.Dispose();
+        }
+    }
 
     private void ToggleWork(int id)
     {
@@ -354,6 +397,99 @@
             .Where(w => w.Title.Contains(f, StringComparison.OrdinalIgnoreCase)
                      || w.AuthorName.Contains(f, StringComparison.OrdinalIgnoreCase))
             .ToList();
+    }
+
+    private async Task OnRatingChanged(int value)
+    {
+        try { await VM.SetRatingAsync(value); }
+        catch (Exception ex) { Snackbar.Add($"Couldn't save rating: {ex.Message}", Severity.Error); }
+    }
+
+    private async Task OnStatusChanged(BookStatus value)
+    {
+        try { await VM.SetStatusAsync(value); }
+        catch (Exception ex) { Snackbar.Add($"Couldn't save status: {ex.Message}", Severity.Error); }
+    }
+
+    private void OnNotesDirty()
+    {
+        VM.MarkNotesDirty();
+        ScheduleNotesSave();
+    }
+
+    private void ScheduleNotesSave()
+    {
+        notesCts?.Cancel();
+        notesCts?.Dispose();
+        notesCts = new CancellationTokenSource();
+        var token = notesCts.Token;
+        _ = DelayedSaveAsync(token);
+    }
+
+    private async Task DelayedSaveAsync(CancellationToken ct)
+    {
+        try
+        {
+            await Task.Delay(NotesDebounceMs, ct);
+            await SaveNotesImmediateAsync();
+        }
+        catch (TaskCanceledException) { /* superseded by a newer keystroke */ }
+    }
+
+    private async Task SaveNotesImmediateAsync()
+    {
+        try
+        {
+            await VM.SaveNotesAsync();
+            await InvokeAsync(StateHasChanged);
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Couldn't save notes: {ex.Message}", Severity.Error);
+        }
+    }
+
+    private async Task<IEnumerable<string>> SearchTagsAsync(string query, CancellationToken ct)
+    {
+        try { return await VM.SearchTagsAsync(query ?? "", ct); }
+        catch { return []; }
+    }
+
+    private async Task OnTagKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key == "Enter" && !string.IsNullOrWhiteSpace(newTagText))
+        {
+            await AddCurrentTagAsync();
+        }
+    }
+
+    private async Task OnTagBlur(FocusEventArgs _)
+    {
+        if (!string.IsNullOrWhiteSpace(newTagText))
+        {
+            await AddCurrentTagAsync();
+        }
+    }
+
+    private async Task AddCurrentTagAsync()
+    {
+        var name = newTagText;
+        if (string.IsNullOrWhiteSpace(name)) return;
+        try
+        {
+            await VM.AddTagAsync(name);
+            newTagText = null;
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Couldn't add tag: {ex.Message}", Severity.Error);
+        }
+    }
+
+    private async Task OnRemoveTagAsync(int tagId)
+    {
+        try { await VM.RemoveTagAsync(tagId); }
+        catch (Exception ex) { Snackbar.Add($"Couldn't remove tag: {ex.Message}", Severity.Error); }
     }
 
     private static Color StatusColor(BookStatus status) => status switch

--- a/BookTracker.Web/Components/Shared/NotesEditor.razor
+++ b/BookTracker.Web/Components/Shared/NotesEditor.razor
@@ -1,0 +1,49 @@
+@* Inline notes editor for the Book Detail page. Binds to VM.CurrentNotes;
+   fires OnDirty on every change (parent schedules the debounced save) and
+   OnSaveRequested on blur for immediate flush. Save-state indicator sits
+   next to the label so the user can see "Saving..." / "Saved". *@
+
+<div>
+    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+        <MudText Typo="Typo.caption" Color="Color.Secondary">Notes</MudText>
+        @if (VM.NotesSaving)
+        {
+            <MudText Typo="Typo.caption" Color="Color.Secondary">— saving…</MudText>
+        }
+        else if (VM.NotesDirty)
+        {
+            <MudText Typo="Typo.caption" Color="Color.Warning">— unsaved</MudText>
+        }
+        else
+        {
+            <MudText Typo="Typo.caption" Color="Color.Success">— saved</MudText>
+        }
+    </MudStack>
+    <MudTextField T="string"
+                  Value="VM.CurrentNotes"
+                  ValueChanged="HandleChanged"
+                  Immediate="true"
+                  DebounceInterval="200"
+                  Lines="3"
+                  Variant="Variant.Outlined"
+                  Margin="Margin.Dense"
+                  Placeholder="Notes about this book..."
+                  OnBlur="HandleBlur" />
+</div>
+
+@code {
+    [Parameter, EditorRequired] public BookDetailViewModel VM { get; set; } = default!;
+    [Parameter] public EventCallback OnDirty { get; set; }
+    [Parameter] public EventCallback OnSaveRequested { get; set; }
+
+    private async Task HandleChanged(string? value)
+    {
+        VM.CurrentNotes = value ?? "";
+        await OnDirty.InvokeAsync();
+    }
+
+    private async Task HandleBlur(FocusEventArgs _)
+    {
+        if (VM.NotesDirty) await OnSaveRequested.InvokeAsync();
+    }
+}

--- a/BookTracker.Web/ViewModels/BookDetailViewModel.cs
+++ b/BookTracker.Web/ViewModels/BookDetailViewModel.cs
@@ -5,15 +5,30 @@ using Microsoft.EntityFrameworkCore;
 
 namespace BookTracker.Web.ViewModels;
 
-// Read-only view model for the book detail page (View page, /books/{id}).
-// Deliberately flat display shape — no form inputs, no edit state — so the
-// page can focus on browsing. Edit surfaces will land in later PRs via
-// inline auto-save (rating/status/notes/tags) and modal dialogs
-// (work/edition/copy edits).
+// View model for the book detail page (/books/{id}). The initial load
+// projects the Book into a flat display shape (BookDetail record). Inline
+// auto-save surfaces for the "browse-and-tweak" fields (rating, status,
+// notes, tags) mutate the Current* properties + persist in the same call,
+// keeping the page focused on one value at a time. Larger structural
+// edits (Work, Edition, Copy) happen in modal dialogs in a later PR.
 public class BookDetailViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory)
 {
     public bool NotFound { get; private set; }
     public BookDetail? Book { get; private set; }
+
+    // Inline-editable state — initialised from Book in InitializeAsync and
+    // kept as the source of truth once the page starts mutating. The Book
+    // record is the initial snapshot; display binds to Current*.
+    public int CurrentRating { get; private set; }
+    public BookStatus CurrentStatus { get; private set; }
+    public string CurrentNotes { get; set; } = "";
+    public List<TagDetail> CurrentTags { get; private set; } = [];
+
+    // Notes-field state: the textbox binds here; a debounced save fires on
+    // change + explicit save on blur. The page drives the timing; the VM
+    // just persists on demand and tracks saved-ness for the UI indicator.
+    public bool NotesDirty { get; private set; }
+    public bool NotesSaving { get; private set; }
 
     public bool IsSingleWork => Book is not null && Book.Works.Count == 1;
     public int TotalEditions => Book?.Editions.Count ?? 0;
@@ -67,6 +82,128 @@ public class BookDetailViewModel(IDbContextFactory<BookTrackerDbContext> dbFacto
                 .OrderBy(t => t.Name)
                 .Select(t => new TagDetail(t.Id, t.Name))
                 .ToList());
+
+        CurrentRating = book.Rating;
+        CurrentStatus = book.Status;
+        CurrentNotes = book.Notes ?? "";
+        CurrentTags = Book.Tags.ToList();
+    }
+
+    public async Task SetRatingAsync(int rating)
+    {
+        if (Book is null) return;
+        if (rating < 0 || rating > 5) return;
+
+        await using var db = await dbFactory.CreateDbContextAsync();
+        var book = await db.Books.FindAsync(Book.Id);
+        if (book is null) return;
+        book.Rating = rating;
+        await db.SaveChangesAsync();
+        CurrentRating = rating;
+    }
+
+    public async Task SetStatusAsync(BookStatus status)
+    {
+        if (Book is null) return;
+
+        await using var db = await dbFactory.CreateDbContextAsync();
+        var book = await db.Books.FindAsync(Book.Id);
+        if (book is null) return;
+        book.Status = status;
+        await db.SaveChangesAsync();
+        CurrentStatus = status;
+    }
+
+    public void MarkNotesDirty() => NotesDirty = true;
+
+    public async Task SaveNotesAsync()
+    {
+        if (Book is null || !NotesDirty) return;
+
+        NotesSaving = true;
+        try
+        {
+            await using var db = await dbFactory.CreateDbContextAsync();
+            var book = await db.Books.FindAsync(Book.Id);
+            if (book is null) return;
+            book.Notes = string.IsNullOrWhiteSpace(CurrentNotes) ? null : CurrentNotes.Trim();
+            await db.SaveChangesAsync();
+            NotesDirty = false;
+        }
+        finally
+        {
+            NotesSaving = false;
+        }
+    }
+
+    /// <summary>Returns the added (or existing, re-attached) tag. Null if the name was blank.</summary>
+    public async Task<TagDetail?> AddTagAsync(string name)
+    {
+        if (Book is null || string.IsNullOrWhiteSpace(name)) return null;
+
+        var normalized = name.Trim().ToLowerInvariant();
+        if (CurrentTags.Any(t => t.Name.Equals(normalized, StringComparison.OrdinalIgnoreCase)))
+        {
+            return null;
+        }
+
+        await using var db = await dbFactory.CreateDbContextAsync();
+        var book = await db.Books.Include(b => b.Tags).FirstOrDefaultAsync(b => b.Id == Book.Id);
+        if (book is null) return null;
+
+        var tag = await db.Tags.FirstOrDefaultAsync(t => t.Name == normalized);
+        if (tag is null)
+        {
+            tag = new Tag { Name = normalized };
+            db.Tags.Add(tag);
+        }
+
+        if (book.Tags.All(t => t.Id != tag.Id || tag.Id == 0))
+        {
+            book.Tags.Add(tag);
+        }
+
+        await db.SaveChangesAsync();
+
+        var detail = new TagDetail(tag.Id, tag.Name);
+        CurrentTags.Add(detail);
+        CurrentTags = CurrentTags.OrderBy(t => t.Name).ToList();
+        return detail;
+    }
+
+    public async Task RemoveTagAsync(int tagId)
+    {
+        if (Book is null) return;
+
+        await using var db = await dbFactory.CreateDbContextAsync();
+        var book = await db.Books.Include(b => b.Tags).FirstOrDefaultAsync(b => b.Id == Book.Id);
+        if (book is null) return;
+
+        var tag = book.Tags.FirstOrDefault(t => t.Id == tagId);
+        if (tag is not null)
+        {
+            book.Tags.Remove(tag);
+            await db.SaveChangesAsync();
+        }
+
+        CurrentTags.RemoveAll(t => t.Id == tagId);
+    }
+
+    /// <summary>Tag autocomplete — returns existing tags not already assigned, filtered by substring.</summary>
+    public async Task<IEnumerable<string>> SearchTagsAsync(string query, CancellationToken ct)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync();
+        var assigned = CurrentTags.Select(t => t.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var q = (query ?? "").Trim().ToLowerInvariant();
+
+        var names = await db.Tags
+            .Where(t => string.IsNullOrEmpty(q) || t.Name.Contains(q))
+            .OrderBy(t => t.Name)
+            .Select(t => t.Name)
+            .Take(20)
+            .ToListAsync(ct);
+
+        return names.Where(n => !assigned.Contains(n));
     }
 
     private static WorkDetail ToWorkDetail(Work w) => new(


### PR DESCRIPTION
Rating, status, notes, and tags are now editable directly from the
browse page without leaving for the full Edit form:

- Rating: MudRating, saves on click.
- Status: three-chip MudChipSet (Unread/Reading/Read), saves on select.
- Notes: MudTextField multiline bound to VM.CurrentNotes. Debounced save
  800ms after the last keystroke; immediate save on blur. Save-state
  indicator ("saved" / "saving..." / "unsaved") sits beside the label.
  CancellationTokenSource drives the debounce — each keystroke cancels
  the pending save and queues a new one. CTS disposed on IAsyncDisposable
  so a torn-down circuit doesn't fire a save.
- Tags: MudAutocomplete against existing tags (substring match, excludes
  already-assigned). Enter or blur commits a new tag; case-insensitive
  normalisation reuses an existing Tag row rather than duplicating.
  Closeable chips remove a tag with one click.

Errors from any save surface via ISnackbar. Successful saves are silent
except for the notes indicator — aiming for "frictionless adjustment
during browsing" rather than a confirmation loop.

Still read-only in this PR: work details, editions, and copies. Those
get modal edit dialogs in PR 3.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
