### PR TITLE
feat(books): modal edits for Book + Work on View page (PR 3)

### DIFF
--- a/BookTracker.Tests/ViewModels/BookEditDialogViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/BookEditDialogViewModelTests.cs
@@ -1,0 +1,131 @@
+using BookTracker.Data.Models;
+using BookTracker.Web.ViewModels;
+
+namespace BookTracker.Tests.ViewModels;
+
+public class BookEditDialogViewModelTests
+{
+    [Fact]
+    public async Task InitializeAsync_MissingId_MarksNotFound()
+    {
+        var factory = new TestDbContextFactory();
+        var vm = new BookEditDialogViewModel(factory);
+
+        await vm.InitializeAsync(999);
+
+        Assert.True(vm.NotFound);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_LoadsCurrentValues()
+    {
+        var factory = new TestDbContextFactory();
+        int bookId;
+        using (var db = factory.CreateDbContext())
+        {
+            var book = new Book
+            {
+                Title = "Mort",
+                Category = BookCategory.Fiction,
+                DefaultCoverArtUrl = "https://example.com/mort.jpg",
+                Works = [new Work { Title = "Mort", Author = new Author { Name = "Pratchett" } }],
+            };
+            db.Books.Add(book);
+            await db.SaveChangesAsync();
+            bookId = book.Id;
+        }
+
+        var vm = new BookEditDialogViewModel(factory);
+        await vm.InitializeAsync(bookId);
+
+        Assert.False(vm.NotFound);
+        Assert.Equal("Mort", vm.Title);
+        Assert.Equal(BookCategory.Fiction, vm.Category);
+        Assert.Equal("https://example.com/mort.jpg", vm.CoverUrl);
+    }
+
+    [Fact]
+    public async Task SaveAsync_PersistsAllFields()
+    {
+        var factory = new TestDbContextFactory();
+        int bookId;
+        using (var db = factory.CreateDbContext())
+        {
+            var book = new Book
+            {
+                Title = "Old title",
+                Category = BookCategory.Fiction,
+                Works = [new Work { Title = "w", Author = new Author { Name = "a" } }],
+            };
+            db.Books.Add(book);
+            await db.SaveChangesAsync();
+            bookId = book.Id;
+        }
+
+        var vm = new BookEditDialogViewModel(factory);
+        await vm.InitializeAsync(bookId);
+        vm.Title = "  New title  ";
+        vm.Category = BookCategory.NonFiction;
+        vm.CoverUrl = "  https://example.com/new.jpg  ";
+        await vm.SaveAsync();
+
+        using var db2 = factory.CreateDbContext();
+        var saved = db2.Books.Single(b => b.Id == bookId);
+        Assert.Equal("New title", saved.Title);
+        Assert.Equal(BookCategory.NonFiction, saved.Category);
+        Assert.Equal("https://example.com/new.jpg", saved.DefaultCoverArtUrl);
+    }
+
+    [Fact]
+    public async Task SaveAsync_BlankCoverUrl_PersistsAsNull()
+    {
+        var factory = new TestDbContextFactory();
+        int bookId;
+        using (var db = factory.CreateDbContext())
+        {
+            var book = new Book
+            {
+                Title = "T",
+                DefaultCoverArtUrl = "https://old.example.com",
+                Works = [new Work { Title = "w", Author = new Author { Name = "a" } }],
+            };
+            db.Books.Add(book);
+            await db.SaveChangesAsync();
+            bookId = book.Id;
+        }
+
+        var vm = new BookEditDialogViewModel(factory);
+        await vm.InitializeAsync(bookId);
+        vm.CoverUrl = "   ";
+        await vm.SaveAsync();
+
+        using var db2 = factory.CreateDbContext();
+        Assert.Null(db2.Books.Single(b => b.Id == bookId).DefaultCoverArtUrl);
+    }
+
+    [Fact]
+    public async Task SaveAsync_BlankTitle_IsNoOp()
+    {
+        var factory = new TestDbContextFactory();
+        int bookId;
+        using (var db = factory.CreateDbContext())
+        {
+            var book = new Book
+            {
+                Title = "Untouched",
+                Works = [new Work { Title = "w", Author = new Author { Name = "a" } }],
+            };
+            db.Books.Add(book);
+            await db.SaveChangesAsync();
+            bookId = book.Id;
+        }
+
+        var vm = new BookEditDialogViewModel(factory);
+        await vm.InitializeAsync(bookId);
+        vm.Title = "   ";
+        await vm.SaveAsync();
+
+        using var db2 = factory.CreateDbContext();
+        Assert.Equal("Untouched", db2.Books.Single(b => b.Id == bookId).Title);
+    }
+}

--- a/BookTracker.Tests/ViewModels/WorkEditDialogViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/WorkEditDialogViewModelTests.cs
@@ -1,0 +1,196 @@
+using BookTracker.Data.Models;
+using BookTracker.Web.ViewModels;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookTracker.Tests.ViewModels;
+
+public class WorkEditDialogViewModelTests
+{
+    [Fact]
+    public async Task InitializeAsync_MissingId_MarksNotFound()
+    {
+        var factory = new TestDbContextFactory();
+        var vm = new WorkEditDialogViewModel(factory);
+
+        await vm.InitializeAsync(999);
+
+        Assert.True(vm.NotFound);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_LoadsCurrentValues()
+    {
+        var factory = new TestDbContextFactory();
+        int workId;
+        using (var db = factory.CreateDbContext())
+        {
+            var series = new Series { Name = "Discworld", Type = SeriesType.Collection };
+            var work = new Work
+            {
+                Title = "Mort",
+                Subtitle = "A Discworld Novel",
+                Author = new Author { Name = "Terry Pratchett" },
+                FirstPublishedDate = new DateOnly(1987, 11, 12),
+                FirstPublishedDatePrecision = DatePrecision.Day,
+                Series = series,
+                SeriesOrder = 4,
+            };
+            db.Books.Add(new Book { Title = "Mort", Works = [work] });
+            await db.SaveChangesAsync();
+            workId = work.Id;
+        }
+
+        var vm = new WorkEditDialogViewModel(factory);
+        await vm.InitializeAsync(workId);
+
+        Assert.False(vm.NotFound);
+        Assert.Equal("Mort", vm.Title);
+        Assert.Equal("A Discworld Novel", vm.Subtitle);
+        Assert.Equal("Terry Pratchett", vm.AuthorName);
+        Assert.Equal("12 Nov 1987", vm.FirstPublishedDate);
+        Assert.NotNull(vm.SelectedSeriesId);
+        Assert.Equal(4, vm.SeriesOrder);
+        Assert.Single(vm.AvailableSeries);
+    }
+
+    [Fact]
+    public async Task SaveAsync_PersistsBasicFields()
+    {
+        var factory = new TestDbContextFactory();
+        int workId;
+        using (var db = factory.CreateDbContext())
+        {
+            var work = new Work
+            {
+                Title = "Old",
+                Author = new Author { Name = "Old Author" },
+            };
+            db.Books.Add(new Book { Title = "B", Works = [work] });
+            await db.SaveChangesAsync();
+            workId = work.Id;
+        }
+
+        var vm = new WorkEditDialogViewModel(factory);
+        await vm.InitializeAsync(workId);
+        vm.Title = "  Mort  ";
+        vm.Subtitle = "A Discworld Novel";
+        vm.AuthorName = "Old Author";
+        vm.FirstPublishedDate = "1987";
+        await vm.SaveAsync();
+
+        using var db2 = factory.CreateDbContext();
+        var saved = db2.Works.Include(w => w.Author).Single(w => w.Id == workId);
+        Assert.Equal("Mort", saved.Title);
+        Assert.Equal("A Discworld Novel", saved.Subtitle);
+        Assert.Equal(new DateOnly(1987, 1, 1), saved.FirstPublishedDate);
+        Assert.Equal(DatePrecision.Year, saved.FirstPublishedDatePrecision);
+    }
+
+    [Fact]
+    public async Task SaveAsync_ReusesExistingAuthorByName()
+    {
+        var factory = new TestDbContextFactory();
+        int workId;
+        int existingAuthorId;
+        using (var db = factory.CreateDbContext())
+        {
+            var a1 = new Author { Name = "Terry Pratchett" };
+            var a2 = new Author { Name = "Placeholder" };
+            var work = new Work { Title = "w", Author = a2 };
+            db.Books.Add(new Book { Title = "B", Works = [work] });
+            db.Authors.Add(a1);
+            await db.SaveChangesAsync();
+            workId = work.Id;
+            existingAuthorId = a1.Id;
+        }
+
+        var vm = new WorkEditDialogViewModel(factory);
+        await vm.InitializeAsync(workId);
+        vm.AuthorName = "Terry Pratchett";
+        await vm.SaveAsync();
+
+        using var db2 = factory.CreateDbContext();
+        var saved = db2.Works.Include(w => w.Author).Single(w => w.Id == workId);
+        Assert.Equal(existingAuthorId, saved.Author.Id);
+        Assert.Equal(2, db2.Authors.Count());
+    }
+
+    [Fact]
+    public async Task SaveAsync_CreatesNewAuthorWhenNameIsNew()
+    {
+        var factory = new TestDbContextFactory();
+        int workId;
+        using (var db = factory.CreateDbContext())
+        {
+            var work = new Work { Title = "w", Author = new Author { Name = "Old Author" } };
+            db.Books.Add(new Book { Title = "B", Works = [work] });
+            await db.SaveChangesAsync();
+            workId = work.Id;
+        }
+
+        var vm = new WorkEditDialogViewModel(factory);
+        await vm.InitializeAsync(workId);
+        vm.AuthorName = "Brand New Author";
+        await vm.SaveAsync();
+
+        using var db2 = factory.CreateDbContext();
+        Assert.Contains(db2.Authors.ToList(), a => a.Name == "Brand New Author");
+    }
+
+    [Fact]
+    public async Task SaveAsync_ClearingSeriesAlsoClearsOrder()
+    {
+        var factory = new TestDbContextFactory();
+        int workId;
+        using (var db = factory.CreateDbContext())
+        {
+            var series = new Series { Name = "S", Type = SeriesType.Series };
+            var work = new Work
+            {
+                Title = "w",
+                Author = new Author { Name = "a" },
+                Series = series,
+                SeriesOrder = 3,
+            };
+            db.Books.Add(new Book { Title = "B", Works = [work] });
+            await db.SaveChangesAsync();
+            workId = work.Id;
+        }
+
+        var vm = new WorkEditDialogViewModel(factory);
+        await vm.InitializeAsync(workId);
+        vm.SelectedSeriesId = null;
+        await vm.SaveAsync();
+
+        using var db2 = factory.CreateDbContext();
+        var saved = db2.Works.Single(w => w.Id == workId);
+        Assert.Null(saved.SeriesId);
+        Assert.Null(saved.SeriesOrder);
+    }
+
+    [Fact]
+    public async Task SearchAuthorsAsync_MatchesSubstring()
+    {
+        var factory = new TestDbContextFactory();
+        int workId;
+        using (var db = factory.CreateDbContext())
+        {
+            db.Authors.AddRange(
+                new Author { Name = "Terry Pratchett" },
+                new Author { Name = "Neil Gaiman" },
+                new Author { Name = "Pratchett & Gaiman" });
+            var work = new Work { Title = "w", Author = new Author { Name = "Seed" } };
+            db.Books.Add(new Book { Title = "B", Works = [work] });
+            await db.SaveChangesAsync();
+            workId = work.Id;
+        }
+
+        var vm = new WorkEditDialogViewModel(factory);
+        await vm.InitializeAsync(workId);
+        var results = (await vm.SearchAuthorsAsync("Pratch", CancellationToken.None)).ToList();
+
+        Assert.Equal(2, results.Count);
+        Assert.Contains("Terry Pratchett", results);
+        Assert.Contains("Pratchett & Gaiman", results);
+    }
+}

--- a/BookTracker.Web/Components/Pages/Books/Detail.razor
+++ b/BookTracker.Web/Components/Pages/Books/Detail.razor
@@ -3,6 +3,7 @@
 @inject BookDetailViewModel VM
 @inject NavigationManager Nav
 @inject ISnackbar Snackbar
+@inject IDialogService DialogService
 
 @* Book detail / View page — browse-first, MudBlazor pilot continuation.
    PR 1 shipped read-only. PR 2 adds inline auto-save for rating, status,
@@ -84,12 +85,29 @@
                 </MudStack>
 
                 <MudStack Row="true" Spacing="2" Wrap="Wrap.Wrap" Class="mt-3">
-                    <MudButton Href="@($"/books/{book.Id}/edit")"
+                    <MudButton OnClick="OpenBookEditDialog"
                                Variant="Variant.Outlined"
                                Color="Color.Primary"
                                StartIcon="@Icons.Material.Filled.Edit"
                                Size="Size.Small">
-                        Edit all details
+                        Edit book details
+                    </MudButton>
+                    @if (VM.IsSingleWork && primary is not null)
+                    {
+                        <MudButton OnClick="@(() => OpenWorkEditDialog(primary.Id))"
+                                   Variant="Variant.Outlined"
+                                   Color="Color.Primary"
+                                   StartIcon="@Icons.Material.Filled.Edit"
+                                   Size="Size.Small">
+                            Edit work
+                        </MudButton>
+                    }
+                    <MudButton Href="@($"/books/{book.Id}/edit")"
+                               Variant="Variant.Text"
+                               Color="Color.Default"
+                               StartIcon="@Icons.Material.Filled.OpenInNew"
+                               Size="Size.Small">
+                        Full edit page
                     </MudButton>
                     @if (primary?.Series is not null)
                     {
@@ -197,32 +215,45 @@
                                             <MudText Typo="Typo.caption" Color="Color.Secondary">@w.AuthorName</MudText>
                                         </MudStack>
                                     </MudStack>
+                                    @* stopPropagation so clicks inside the expanded
+                                       region don't re-toggle the parent MudListItem. *@
                                     @if (expanded)
                                     {
-                                        <MudStack Spacing="1" Class="mt-2 ps-7">
-                                            @if (!string.IsNullOrEmpty(w.Subtitle))
-                                            {
-                                                <FieldRow Label="Subtitle" Value="@w.Subtitle" />
-                                            }
-                                            @if (!string.IsNullOrEmpty(w.FirstPublishedDisplay))
-                                            {
-                                                <FieldRow Label="First published" Value="@w.FirstPublishedDisplay" />
-                                            }
-                                            @if (w.Series is not null)
-                                            {
-                                                var seriesValue = w.Series.Order.HasValue ? $"{w.Series.Name} (#{w.Series.Order})" : w.Series.Name;
-                                                <FieldRow Label="@(w.Series.Type == SeriesType.Collection ? "Collection" : "Series")" Value="@seriesValue" />
-                                            }
-                                            @if (w.Genres.Count > 0)
-                                            {
-                                                <MudStack Row="true" Spacing="1" Wrap="Wrap.Wrap">
-                                                    @foreach (var g in w.Genres)
-                                                    {
-                                                        <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined">@g</MudChip>
-                                                    }
-                                                </MudStack>
-                                            }
-                                        </MudStack>
+                                        <div @onclick:stopPropagation="true">
+                                            <MudStack Spacing="1" Class="mt-2 ps-7">
+                                                @if (!string.IsNullOrEmpty(w.Subtitle))
+                                                {
+                                                    <FieldRow Label="Subtitle" Value="@w.Subtitle" />
+                                                }
+                                                @if (!string.IsNullOrEmpty(w.FirstPublishedDisplay))
+                                                {
+                                                    <FieldRow Label="First published" Value="@w.FirstPublishedDisplay" />
+                                                }
+                                                @if (w.Series is not null)
+                                                {
+                                                    var seriesValue = w.Series.Order.HasValue ? $"{w.Series.Name} (#{w.Series.Order})" : w.Series.Name;
+                                                    <FieldRow Label="@(w.Series.Type == SeriesType.Collection ? "Collection" : "Series")" Value="@seriesValue" />
+                                                }
+                                                @if (w.Genres.Count > 0)
+                                                {
+                                                    <MudStack Row="true" Spacing="1" Wrap="Wrap.Wrap">
+                                                        @foreach (var g in w.Genres)
+                                                        {
+                                                            <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined">@g</MudChip>
+                                                        }
+                                                    </MudStack>
+                                                }
+                                                <div class="mt-1">
+                                                    <MudButton OnClick="@(() => OpenWorkEditDialog(w.Id))"
+                                                               Variant="Variant.Outlined"
+                                                               Color="Color.Primary"
+                                                               StartIcon="@Icons.Material.Filled.Edit"
+                                                               Size="Size.Small">
+                                                        Edit work
+                                                    </MudButton>
+                                                </div>
+                                            </MudStack>
+                                        </div>
                                     }
                                 </MudListItem>
                             }
@@ -490,6 +521,40 @@
     {
         try { await VM.RemoveTagAsync(tagId); }
         catch (Exception ex) { Snackbar.Add($"Couldn't remove tag: {ex.Message}", Severity.Error); }
+    }
+
+    private async Task OpenBookEditDialog()
+    {
+        if (VM.Book is null) return;
+        var parameters = new DialogParameters<BookEditDialog> { { x => x.BookId, VM.Book.Id } };
+        var options = new DialogOptions { MaxWidth = MaxWidth.Small, FullWidth = true, CloseButton = true };
+        var dialog = await DialogService.ShowAsync<BookEditDialog>("Edit book details", parameters, options);
+        var result = await dialog.Result;
+        if (result is not null && !result.Canceled)
+        {
+            Snackbar.Add("Book saved", Severity.Success);
+            await VM.InitializeAsync(BookId);
+            StateHasChanged();
+        }
+    }
+
+    private async Task OpenWorkEditDialog(int workId)
+    {
+        if (VM.Book is null) return;
+        var parameters = new DialogParameters<WorkEditDialog>
+        {
+            { x => x.WorkId, workId },
+            { x => x.BookId, VM.Book.Id },
+        };
+        var options = new DialogOptions { MaxWidth = MaxWidth.Small, FullWidth = true, CloseButton = true };
+        var dialog = await DialogService.ShowAsync<WorkEditDialog>("Edit work", parameters, options);
+        var result = await dialog.Result;
+        if (result is not null && !result.Canceled)
+        {
+            Snackbar.Add("Work saved", Severity.Success);
+            await VM.InitializeAsync(BookId);
+            StateHasChanged();
+        }
     }
 
     private static Color StatusColor(BookStatus status) => status switch

--- a/BookTracker.Web/Components/Shared/BookEditDialog.razor
+++ b/BookTracker.Web/Components/Shared/BookEditDialog.razor
@@ -1,0 +1,74 @@
+@* Modal dialog for editing Book-level fields (title, category, cover URL)
+   from the View page. Notes are edited inline on the View page and are
+   intentionally absent here. Triggered via IDialogService. *@
+
+@inject BookEditDialogViewModel VM
+
+<MudDialog>
+    <DialogContent>
+        @if (VM.NotFound)
+        {
+            <MudAlert Severity="Severity.Warning">Book not found.</MudAlert>
+        }
+        else
+        {
+            <MudStack Spacing="3" Style="min-width: 280px;">
+                <MudTextField T="string"
+                              @bind-Value="VM.Title"
+                              Label="Title"
+                              Required="true"
+                              RequiredError="Title is required."
+                              Variant="Variant.Outlined"
+                              Margin="Margin.Dense" />
+                <MudSelect T="BookCategory"
+                           @bind-Value="VM.Category"
+                           Label="Category"
+                           Variant="Variant.Outlined"
+                           Margin="Margin.Dense">
+                    <MudSelectItem T="BookCategory" Value="BookCategory.Fiction">Fiction</MudSelectItem>
+                    <MudSelectItem T="BookCategory" Value="BookCategory.NonFiction">Non-Fiction</MudSelectItem>
+                </MudSelect>
+                <MudTextField T="string"
+                              @bind-Value="VM.CoverUrl"
+                              Label="Cover image URL"
+                              Variant="Variant.Outlined"
+                              Margin="Margin.Dense"
+                              HelperText="Optional. Shown on the Library list and View page header." />
+            </MudStack>
+        }
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Cancel">Cancel</MudButton>
+        <MudButton Color="Color.Primary"
+                   Variant="Variant.Filled"
+                   Disabled="@(VM.NotFound || string.IsNullOrWhiteSpace(VM.Title) || saving)"
+                   OnClick="SaveAsync">
+            @(saving ? "Saving..." : "Save")
+        </MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] private IMudDialogInstance MudDialog { get; set; } = default!;
+    [Parameter] public int BookId { get; set; }
+
+    private bool saving;
+
+    protected override async Task OnInitializedAsync() => await VM.InitializeAsync(BookId);
+
+    private async Task SaveAsync()
+    {
+        saving = true;
+        try
+        {
+            await VM.SaveAsync();
+            MudDialog.Close(DialogResult.Ok(true));
+        }
+        finally
+        {
+            saving = false;
+        }
+    }
+
+    private void Cancel() => MudDialog.Cancel();
+}

--- a/BookTracker.Web/Components/Shared/WorkEditDialog.razor
+++ b/BookTracker.Web/Components/Shared/WorkEditDialog.razor
@@ -1,0 +1,111 @@
+@* Modal dialog for editing a single Work's fields (title, subtitle,
+   author with typeahead, first-published date, series + order) from
+   the View page. Genres are deliberately not in this dialog — the
+   hierarchical MudBlazor genre picker is its own future PR, so this
+   dialog links users to /edit for that one field. *@
+
+@inject WorkEditDialogViewModel VM
+
+<MudDialog>
+    <DialogContent>
+        @if (VM.NotFound)
+        {
+            <MudAlert Severity="Severity.Warning">Work not found.</MudAlert>
+        }
+        else
+        {
+            <MudStack Spacing="3" Style="min-width: 280px;">
+                <MudTextField T="string"
+                              @bind-Value="VM.Title"
+                              Label="Title"
+                              Required="true"
+                              RequiredError="Title is required."
+                              Variant="Variant.Outlined"
+                              Margin="Margin.Dense" />
+                <MudTextField T="string"
+                              @bind-Value="VM.Subtitle"
+                              Label="Subtitle"
+                              Variant="Variant.Outlined"
+                              Margin="Margin.Dense" />
+                <MudAutocomplete T="string"
+                                 @bind-Value="VM.AuthorName"
+                                 SearchFunc="VM.SearchAuthorsAsync"
+                                 Label="Author"
+                                 Required="true"
+                                 RequiredError="Author is required."
+                                 Variant="Variant.Outlined"
+                                 Margin="Margin.Dense"
+                                 CoerceValue="true"
+                                 CoerceText="true"
+                                 ResetValueOnEmptyText="false"
+                                 MinCharacters="0"
+                                 HelperText="Type to find existing or create new." />
+                <MudTextField T="string"
+                              @bind-Value="VM.FirstPublishedDate"
+                              Label="First published"
+                              Variant="Variant.Outlined"
+                              Margin="Margin.Dense"
+                              HelperText="Year, 'Month Year', or full date (e.g. 1973, Oct 1973, 1973-10-12)." />
+                <MudSelect T="int?"
+                           @bind-Value="VM.SelectedSeriesId"
+                           Label="Series / Collection"
+                           Variant="Variant.Outlined"
+                           Margin="Margin.Dense"
+                           Clearable="true">
+                    <MudSelectItem T="int?" Value="@((int?)null)">None</MudSelectItem>
+                    @foreach (var s in VM.AvailableSeries)
+                    {
+                        <MudSelectItem T="int?" Value="@((int?)s.Id)">@s.Name (@s.Type)</MudSelectItem>
+                    }
+                </MudSelect>
+                @if (VM.SelectedSeriesId.HasValue)
+                {
+                    <MudNumericField T="int?"
+                                     @bind-Value="VM.SeriesOrder"
+                                     Label="Order / position"
+                                     Variant="Variant.Outlined"
+                                     Margin="Margin.Dense"
+                                     Min="1" />
+                }
+                <MudText Typo="Typo.caption" Color="Color.Secondary">
+                    Genres are edited on the <MudLink Href="@($"/books/{BookId}/edit")">full edit page</MudLink>.
+                </MudText>
+            </MudStack>
+        }
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Cancel">Cancel</MudButton>
+        <MudButton Color="Color.Primary"
+                   Variant="Variant.Filled"
+                   Disabled="@(VM.NotFound || string.IsNullOrWhiteSpace(VM.Title) || string.IsNullOrWhiteSpace(VM.AuthorName) || saving)"
+                   OnClick="SaveAsync">
+            @(saving ? "Saving..." : "Save")
+        </MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] private IMudDialogInstance MudDialog { get; set; } = default!;
+    [Parameter] public int WorkId { get; set; }
+    [Parameter] public int BookId { get; set; }
+
+    private bool saving;
+
+    protected override async Task OnInitializedAsync() => await VM.InitializeAsync(WorkId);
+
+    private async Task SaveAsync()
+    {
+        saving = true;
+        try
+        {
+            await VM.SaveAsync();
+            MudDialog.Close(DialogResult.Ok(true));
+        }
+        finally
+        {
+            saving = false;
+        }
+    }
+
+    private void Cancel() => MudDialog.Cancel();
+}

--- a/BookTracker.Web/Program.cs
+++ b/BookTracker.Web/Program.cs
@@ -79,6 +79,8 @@ builder.Services.AddTransient<BookListViewModel>();
 builder.Services.AddTransient<BookAddViewModel>();
 builder.Services.AddTransient<BookEditViewModel>();
 builder.Services.AddTransient<BookDetailViewModel>();
+builder.Services.AddTransient<BookEditDialogViewModel>();
+builder.Services.AddTransient<WorkEditDialogViewModel>();
 builder.Services.AddTransient<BulkAddViewModel>();
 builder.Services.AddTransient<SeriesListViewModel>();
 builder.Services.AddTransient<SeriesEditViewModel>();

--- a/BookTracker.Web/ViewModels/BookEditDialogViewModel.cs
+++ b/BookTracker.Web/ViewModels/BookEditDialogViewModel.cs
@@ -1,0 +1,47 @@
+using BookTracker.Data;
+using BookTracker.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookTracker.Web.ViewModels;
+
+// Dialog-scoped VM for "Edit book details" on the View page. Covers
+// Book-level fields that sit apart from the Work (title, category,
+// cover URL). Notes have inline auto-save on the View page and are
+// deliberately absent here. Genres and series live on the Work and
+// are edited via WorkEditDialogViewModel.
+public class BookEditDialogViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory)
+{
+    public bool NotFound { get; private set; }
+    public int BookId { get; private set; }
+
+    public string Title { get; set; } = "";
+    public BookCategory Category { get; set; }
+    public string? CoverUrl { get; set; }
+
+    public async Task InitializeAsync(int bookId)
+    {
+        BookId = bookId;
+        await using var db = await dbFactory.CreateDbContextAsync();
+        var book = await db.Books.FindAsync(bookId);
+        if (book is null) { NotFound = true; return; }
+
+        Title = book.Title;
+        Category = book.Category;
+        CoverUrl = book.DefaultCoverArtUrl;
+    }
+
+    public async Task SaveAsync()
+    {
+        if (NotFound || string.IsNullOrWhiteSpace(Title)) return;
+
+        await using var db = await dbFactory.CreateDbContextAsync();
+        var book = await db.Books.FindAsync(BookId);
+        if (book is null) return;
+
+        book.Title = Title.Trim();
+        book.Category = Category;
+        book.DefaultCoverArtUrl = string.IsNullOrWhiteSpace(CoverUrl) ? null : CoverUrl.Trim();
+
+        await db.SaveChangesAsync();
+    }
+}

--- a/BookTracker.Web/ViewModels/WorkEditDialogViewModel.cs
+++ b/BookTracker.Web/ViewModels/WorkEditDialogViewModel.cs
@@ -1,0 +1,88 @@
+using BookTracker.Data;
+using BookTracker.Data.Models;
+using BookTracker.Web.Services;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookTracker.Web.ViewModels;
+
+// Dialog-scoped VM for "Edit work" on the View page. Edits a single
+// Work's title, subtitle, author (find-or-create with typeahead), first
+// published date (PartialDateParser), and series membership + order.
+// Genres stay on the full /edit page in this PR — the hierarchical
+// MudBlazor rebuild is tracked separately.
+public class WorkEditDialogViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory)
+{
+    public bool NotFound { get; private set; }
+    public int WorkId { get; private set; }
+
+    public string Title { get; set; } = "";
+    public string? Subtitle { get; set; }
+    public string AuthorName { get; set; } = "";
+    public string FirstPublishedDate { get; set; } = "";
+    public int? SelectedSeriesId { get; set; }
+    public int? SeriesOrder { get; set; }
+
+    public List<SeriesOption> AvailableSeries { get; private set; } = [];
+
+    public async Task InitializeAsync(int workId)
+    {
+        WorkId = workId;
+
+        await using var db = await dbFactory.CreateDbContextAsync();
+        var work = await db.Works.Include(w => w.Author).FirstOrDefaultAsync(w => w.Id == workId);
+        if (work is null) { NotFound = true; return; }
+
+        Title = work.Title;
+        Subtitle = work.Subtitle;
+        AuthorName = work.Author.Name;
+        FirstPublishedDate = PartialDateParser.Format(work.FirstPublishedDate, work.FirstPublishedDatePrecision);
+        SelectedSeriesId = work.SeriesId;
+        SeriesOrder = work.SeriesOrder;
+
+        AvailableSeries = await db.Series
+            .OrderBy(s => s.Name)
+            .Select(s => new SeriesOption(s.Id, s.Name, s.Type))
+            .ToListAsync();
+    }
+
+    public async Task<IEnumerable<string>> SearchAuthorsAsync(string query, CancellationToken ct)
+    {
+        var q = (query ?? "").Trim();
+        await using var db = await dbFactory.CreateDbContextAsync();
+        var matches = db.Authors.AsQueryable();
+        if (!string.IsNullOrEmpty(q))
+        {
+            matches = matches.Where(a => a.Name.Contains(q));
+        }
+
+        return await matches
+            .OrderBy(a => a.Name)
+            .Select(a => a.Name)
+            .Take(20)
+            .ToListAsync(ct);
+    }
+
+    public async Task SaveAsync()
+    {
+        if (NotFound || string.IsNullOrWhiteSpace(Title) || string.IsNullOrWhiteSpace(AuthorName)) return;
+
+        await using var db = await dbFactory.CreateDbContextAsync();
+        var work = await db.Works.Include(w => w.Author).FirstOrDefaultAsync(w => w.Id == WorkId);
+        if (work is null) return;
+
+        work.Title = Title.Trim();
+        work.Subtitle = string.IsNullOrWhiteSpace(Subtitle) ? null : Subtitle.Trim();
+        work.Author = await AuthorResolver.FindOrCreateAsync(AuthorName, db);
+
+        var parsed = PartialDateParser.TryParse(FirstPublishedDate) ?? PartialDate.Empty;
+        work.FirstPublishedDate = parsed.Date;
+        work.FirstPublishedDatePrecision = parsed.Precision;
+
+        work.SeriesId = SelectedSeriesId;
+        work.SeriesOrder = SelectedSeriesId.HasValue ? SeriesOrder : null;
+
+        await db.SaveChangesAsync();
+    }
+
+    public record SeriesOption(int Id, string Name, SeriesType Type);
+}


### PR DESCRIPTION
Two MudDialog-backed edit surfaces reachable from /books/{id}:

- Edit book details — title, category, cover URL. Small 3-field form.
- Edit work — title, subtitle, author (typeahead against existing +
  create-on-the-fly via AuthorResolver), first-published date (free-text
  parsed by PartialDateParser), series + order.

Button placement:
- Always-visible header action row: "Edit book details". On single-Work
  books, "Edit work" sits alongside it. Plus a "Full edit page" link
  (replaces the old "Edit all details") as the route to fields not
  covered by the modals.
- Multi-Work compendiums: per-Work "Edit work" button inside the
  expanded row in the Works list. stopPropagation on the expanded
  region keeps clicks inside the form from re-toggling the parent
  MudListItem.

Each modal owns its own VM (BookEditDialogViewModel,
WorkEditDialogViewModel) so BookDetailViewModel stays focused on the
page's display state — per the rule noted in PR 2's retro (>50 lines
of modal logic → its own VM). On save: persist → close dialog → parent
re-initialises VM + shows success Snackbar.

Deliberately deferred:
- Genres stay on /edit (rebuilding the hierarchical picker in MudBlazor
  is its own chunk).
- "Add other works" / "Attach existing Work" still live on /edit.
- Editions and copies remain read-only on the View page (modal edits
  for them are PR 4).

Author typeahead: MudAutocomplete<string> with SearchFunc against the
Authors table. CoerceValue=true lets free-typed names persist through
to save, where AuthorResolver.FindOrCreateAsync decides reuse vs new.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
