### PR TITLE
feat(books): Edition + Copy modals on View page (PR 4)

### DIFF
--- a/BookTracker.Tests/ViewModels/BookDetailViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/BookDetailViewModelTests.cs
@@ -329,6 +329,77 @@ public class BookDetailViewModelTests
     }
 
     [Fact]
+    public async Task DeleteCopyAsync_KeepsEditionWhenOtherCopiesRemain()
+    {
+        var factory = new TestDbContextFactory();
+        int bookId;
+        int copyToDelete;
+        int editionId;
+        using (var db = factory.CreateDbContext())
+        {
+            var edition = new Edition
+            {
+                Isbn = "x",
+                Copies = [
+                    new Copy { Condition = BookCondition.Good },
+                    new Copy { Condition = BookCondition.Fair },
+                ],
+            };
+            var book = new Book
+            {
+                Title = "B",
+                Works = [new Work { Title = "B", Author = new Author { Name = "A" } }],
+                Editions = [edition],
+            };
+            db.Books.Add(book);
+            await db.SaveChangesAsync();
+            bookId = book.Id;
+            editionId = edition.Id;
+            copyToDelete = edition.Copies[0].Id;
+        }
+
+        var vm = new BookDetailViewModel(factory);
+        await vm.InitializeAsync(bookId);
+        await vm.DeleteCopyAsync(copyToDelete);
+
+        using var db2 = factory.CreateDbContext();
+        Assert.Equal(1, db2.Editions.Count(e => e.Id == editionId));
+        Assert.Equal(1, db2.Copies.Count(c => c.EditionId == editionId));
+    }
+
+    [Fact]
+    public async Task DeleteCopyAsync_CascadesEditionRemovalWhenLastCopy()
+    {
+        var factory = new TestDbContextFactory();
+        int bookId;
+        int copyToDelete;
+        int editionId;
+        using (var db = factory.CreateDbContext())
+        {
+            var edition = new Edition { Isbn = "x", Copies = [new Copy { Condition = BookCondition.Good }] };
+            var book = new Book
+            {
+                Title = "B",
+                Works = [new Work { Title = "B", Author = new Author { Name = "A" } }],
+                Editions = [edition],
+            };
+            db.Books.Add(book);
+            await db.SaveChangesAsync();
+            bookId = book.Id;
+            editionId = edition.Id;
+            copyToDelete = edition.Copies[0].Id;
+        }
+
+        var vm = new BookDetailViewModel(factory);
+        await vm.InitializeAsync(bookId);
+        await vm.DeleteCopyAsync(copyToDelete);
+
+        using var db2 = factory.CreateDbContext();
+        Assert.Equal(0, db2.Editions.Count(e => e.Id == editionId));
+        Assert.Equal(0, db2.Copies.Count(c => c.Id == copyToDelete));
+    }
+
+    [Fact]
     public async Task SearchTagsAsync_ExcludesAlreadyAssigned()
     {
         var factory = new TestDbContextFactory();

--- a/BookTracker.Tests/ViewModels/CopyFormDialogViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/CopyFormDialogViewModelTests.cs
@@ -1,0 +1,131 @@
+using BookTracker.Data.Models;
+using BookTracker.Web.ViewModels;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookTracker.Tests.ViewModels;
+
+public class CopyFormDialogViewModelTests
+{
+    [Fact]
+    public void InitializeForAdd_SetsIsNewAndDefaults()
+    {
+        var factory = new TestDbContextFactory();
+        var vm = new CopyFormDialogViewModel(factory);
+
+        vm.InitializeForAdd(42);
+
+        Assert.True(vm.IsNew);
+        Assert.Equal(42, vm.EditionId);
+        Assert.Null(vm.CopyId);
+        Assert.NotNull(vm.DateAcquired); // today, by default
+    }
+
+    [Fact]
+    public async Task InitializeForEditAsync_MissingId_MarksNotFound()
+    {
+        var factory = new TestDbContextFactory();
+        var vm = new CopyFormDialogViewModel(factory);
+
+        await vm.InitializeForEditAsync(999);
+
+        Assert.True(vm.NotFound);
+    }
+
+    [Fact]
+    public async Task InitializeForEditAsync_LoadsCopyFields()
+    {
+        var factory = new TestDbContextFactory();
+        int copyId;
+        using (var db = factory.CreateDbContext())
+        {
+            var copy = new Copy
+            {
+                Condition = BookCondition.VeryGood,
+                DateAcquired = new DateTime(2024, 3, 15),
+                Notes = "From a charity shop",
+            };
+            var edition = new Edition { Isbn = "x", Copies = [copy] };
+            db.Books.Add(new Book
+            {
+                Title = "B",
+                Works = [new Work { Title = "B", Author = new Author { Name = "A" } }],
+                Editions = [edition],
+            });
+            await db.SaveChangesAsync();
+            copyId = copy.Id;
+        }
+
+        var vm = new CopyFormDialogViewModel(factory);
+        await vm.InitializeForEditAsync(copyId);
+
+        Assert.False(vm.IsNew);
+        Assert.False(vm.NotFound);
+        Assert.Equal(BookCondition.VeryGood, vm.Condition);
+        Assert.Equal(new DateTime(2024, 3, 15), vm.DateAcquired);
+        Assert.Equal("From a charity shop", vm.Notes);
+    }
+
+    [Fact]
+    public async Task SaveAsync_Add_AttachesCopyToEdition()
+    {
+        var factory = new TestDbContextFactory();
+        int editionId;
+        using (var db = factory.CreateDbContext())
+        {
+            var seedEdition = new Edition { Isbn = "x", Copies = [new Copy { Condition = BookCondition.Good }] };
+            db.Books.Add(new Book
+            {
+                Title = "B",
+                Works = [new Work { Title = "B", Author = new Author { Name = "A" } }],
+                Editions = [seedEdition],
+            });
+            await db.SaveChangesAsync();
+            editionId = seedEdition.Id;
+        }
+
+        var vm = new CopyFormDialogViewModel(factory);
+        vm.InitializeForAdd(editionId);
+        vm.Condition = BookCondition.Fine;
+        vm.Notes = "  signed  ";
+        var id = await vm.SaveAsync();
+
+        Assert.NotNull(id);
+        using var db2 = factory.CreateDbContext();
+        var edition = db2.Editions.Include(e => e.Copies).Single(e => e.Id == editionId);
+        Assert.Equal(2, edition.Copies.Count);
+        var added = edition.Copies.Single(c => c.Id == id);
+        Assert.Equal(BookCondition.Fine, added.Condition);
+        Assert.Equal("signed", added.Notes);
+    }
+
+    [Fact]
+    public async Task SaveAsync_Edit_UpdatesFields()
+    {
+        var factory = new TestDbContextFactory();
+        int copyId;
+        using (var db = factory.CreateDbContext())
+        {
+            var seedCopy = new Copy { Condition = BookCondition.Good, Notes = "old" };
+            var edition = new Edition { Isbn = "x", Copies = [seedCopy] };
+            db.Books.Add(new Book
+            {
+                Title = "B",
+                Works = [new Work { Title = "B", Author = new Author { Name = "A" } }],
+                Editions = [edition],
+            });
+            await db.SaveChangesAsync();
+            copyId = seedCopy.Id;
+        }
+
+        var vm = new CopyFormDialogViewModel(factory);
+        await vm.InitializeForEditAsync(copyId);
+        vm.Condition = BookCondition.Fair;
+        vm.Notes = "";
+        await vm.SaveAsync();
+
+        using var db2 = factory.CreateDbContext();
+        var copy = db2.Copies.Single(c => c.Id == copyId);
+        Assert.Equal(BookCondition.Fair, copy.Condition);
+        Assert.Null(copy.Notes); // blank → null
+    }
+}

--- a/BookTracker.Tests/ViewModels/EditionFormDialogViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/EditionFormDialogViewModelTests.cs
@@ -1,0 +1,269 @@
+using BookTracker.Data.Models;
+using BookTracker.Web.Services;
+using BookTracker.Web.ViewModels;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+
+namespace BookTracker.Tests.ViewModels;
+
+public class EditionFormDialogViewModelTests
+{
+    private readonly IBookLookupService _lookup = Substitute.For<IBookLookupService>();
+
+    [Fact]
+    public async Task InitializeForAdd_SetsIsNewAndBookId()
+    {
+        var factory = new TestDbContextFactory();
+        var vm = new EditionFormDialogViewModel(factory, _lookup);
+
+        await vm.InitializeForAddAsync(42);
+
+        Assert.True(vm.IsNew);
+        Assert.Equal(42, vm.BookId);
+        Assert.Null(vm.EditionId);
+    }
+
+    [Fact]
+    public async Task InitializeForEditAsync_MissingId_MarksNotFound()
+    {
+        var factory = new TestDbContextFactory();
+        var vm = new EditionFormDialogViewModel(factory, _lookup);
+
+        await vm.InitializeForEditAsync(999);
+
+        Assert.True(vm.NotFound);
+    }
+
+    [Fact]
+    public async Task InitializeForEditAsync_LoadsEditionFields()
+    {
+        var factory = new TestDbContextFactory();
+        int editionId;
+        using (var db = factory.CreateDbContext())
+        {
+            var publisher = new Publisher { Name = "Corgi" };
+            var edition = new Edition
+            {
+                Isbn = "9780552131063",
+                Format = BookFormat.MassMarketPaperback,
+                Publisher = publisher,
+                DatePrinted = new DateOnly(1987, 1, 1),
+                DatePrintedPrecision = DatePrecision.Year,
+                Copies = [new Copy { Condition = BookCondition.Good }],
+            };
+            db.Books.Add(new Book
+            {
+                Title = "Mort",
+                Works = [new Work { Title = "Mort", Author = new Author { Name = "Pratchett" } }],
+                Editions = [edition],
+            });
+            await db.SaveChangesAsync();
+            editionId = edition.Id;
+        }
+
+        var vm = new EditionFormDialogViewModel(factory, _lookup);
+        await vm.InitializeForEditAsync(editionId);
+
+        Assert.False(vm.IsNew);
+        Assert.False(vm.NotFound);
+        Assert.Equal("9780552131063", vm.Isbn);
+        Assert.Equal(BookFormat.MassMarketPaperback, vm.Format);
+        Assert.Equal("Corgi", vm.Publisher);
+        Assert.Equal("1987", vm.FirstPublishedOrPrintedDate);
+    }
+
+    [Fact]
+    public async Task SaveAsync_Add_CreatesEditionAndFirstCopy()
+    {
+        var factory = new TestDbContextFactory();
+        int bookId;
+        using (var db = factory.CreateDbContext())
+        {
+            var book = new Book
+            {
+                Title = "B",
+                Works = [new Work { Title = "B", Author = new Author { Name = "A" } }],
+            };
+            db.Books.Add(book);
+            await db.SaveChangesAsync();
+            bookId = book.Id;
+        }
+
+        var vm = new EditionFormDialogViewModel(factory, _lookup);
+        await vm.InitializeForAddAsync(bookId);
+        vm.Isbn = "9780552131063";
+        vm.Format = BookFormat.MassMarketPaperback;
+        vm.Publisher = "Corgi";
+        vm.FirstPublishedOrPrintedDate = "1987";
+        vm.FirstCopyCondition = BookCondition.VeryGood;
+        var id = await vm.SaveAsync();
+
+        Assert.NotNull(id);
+        using var db2 = factory.CreateDbContext();
+        var edition = db2.Editions.Include(e => e.Copies).Include(e => e.Publisher).Single(e => e.Id == id);
+        Assert.Equal("9780552131063", edition.Isbn);
+        Assert.Equal(BookFormat.MassMarketPaperback, edition.Format);
+        Assert.Equal("Corgi", edition.Publisher!.Name);
+        Assert.Single(edition.Copies);
+        Assert.Equal(BookCondition.VeryGood, edition.Copies[0].Condition);
+    }
+
+    [Fact]
+    public async Task SaveAsync_Add_NoIsbnPersistsAsNull()
+    {
+        var factory = new TestDbContextFactory();
+        int bookId;
+        using (var db = factory.CreateDbContext())
+        {
+            var book = new Book
+            {
+                Title = "B",
+                Works = [new Work { Title = "B", Author = new Author { Name = "A" } }],
+            };
+            db.Books.Add(book);
+            await db.SaveChangesAsync();
+            bookId = book.Id;
+        }
+
+        var vm = new EditionFormDialogViewModel(factory, _lookup);
+        await vm.InitializeForAddAsync(bookId);
+        vm.Isbn = "   ";
+        vm.Format = BookFormat.Hardcover;
+        var id = await vm.SaveAsync();
+
+        Assert.NotNull(id);
+        using var db2 = factory.CreateDbContext();
+        var edition = db2.Editions.Single(e => e.Id == id);
+        Assert.Null(edition.Isbn);
+    }
+
+    [Fact]
+    public async Task SaveAsync_Add_ReusesExistingPublisherByName()
+    {
+        var factory = new TestDbContextFactory();
+        int bookId;
+        int existingPublisherId;
+        using (var db = factory.CreateDbContext())
+        {
+            var corgi = new Publisher { Name = "Corgi" };
+            db.Publishers.Add(corgi);
+            var book = new Book
+            {
+                Title = "B",
+                Works = [new Work { Title = "B", Author = new Author { Name = "A" } }],
+            };
+            db.Books.Add(book);
+            await db.SaveChangesAsync();
+            bookId = book.Id;
+            existingPublisherId = corgi.Id;
+        }
+
+        var vm = new EditionFormDialogViewModel(factory, _lookup);
+        await vm.InitializeForAddAsync(bookId);
+        vm.Isbn = "x";
+        vm.Publisher = "Corgi";
+        var id = await vm.SaveAsync();
+
+        using var db2 = factory.CreateDbContext();
+        var edition = db2.Editions.Single(e => e.Id == id);
+        Assert.Equal(existingPublisherId, edition.PublisherId);
+        Assert.Equal(1, db2.Publishers.Count());
+    }
+
+    [Fact]
+    public async Task SaveAsync_Edit_UpdatesFieldsInPlace()
+    {
+        var factory = new TestDbContextFactory();
+        int editionId;
+        using (var db = factory.CreateDbContext())
+        {
+            var seedEdition = new Edition
+            {
+                Isbn = "old",
+                Format = BookFormat.Hardcover,
+                Copies = [new Copy { Condition = BookCondition.Good }],
+            };
+            db.Books.Add(new Book
+            {
+                Title = "B",
+                Works = [new Work { Title = "B", Author = new Author { Name = "A" } }],
+                Editions = [seedEdition],
+            });
+            await db.SaveChangesAsync();
+            editionId = seedEdition.Id;
+        }
+
+        var vm = new EditionFormDialogViewModel(factory, _lookup);
+        await vm.InitializeForEditAsync(editionId);
+        vm.Isbn = "9780000000001";
+        vm.Format = BookFormat.TradePaperback;
+        vm.Publisher = "NewPub";
+        await vm.SaveAsync();
+
+        using var db2 = factory.CreateDbContext();
+        var edition = db2.Editions.Include(e => e.Publisher).Include(e => e.Copies).Single(e => e.Id == editionId);
+        Assert.Equal("9780000000001", edition.Isbn);
+        Assert.Equal(BookFormat.TradePaperback, edition.Format);
+        Assert.Equal("NewPub", edition.Publisher!.Name);
+        Assert.Single(edition.Copies); // Edit doesn't duplicate the copy
+    }
+
+    [Fact]
+    public async Task SearchPublishersAsync_MatchesSubstring()
+    {
+        var factory = new TestDbContextFactory();
+        int bookId;
+        using (var db = factory.CreateDbContext())
+        {
+            db.Publishers.AddRange(
+                new Publisher { Name = "Corgi" },
+                new Publisher { Name = "Gollancz" },
+                new Publisher { Name = "Orbit" });
+            var book = new Book
+            {
+                Title = "B",
+                Works = [new Work { Title = "B", Author = new Author { Name = "A" } }],
+            };
+            db.Books.Add(book);
+            await db.SaveChangesAsync();
+            bookId = book.Id;
+        }
+
+        var vm = new EditionFormDialogViewModel(factory, _lookup);
+        await vm.InitializeForAddAsync(bookId);
+        var results = (await vm.SearchPublishersAsync("or", CancellationToken.None)).ToList();
+
+        Assert.Contains("Corgi", results);
+        Assert.Contains("Orbit", results);
+        Assert.DoesNotContain("Gollancz", results);
+    }
+
+    [Fact]
+    public async Task LookupAsync_PopulatesEmptyFieldsFromResult()
+    {
+        var factory = new TestDbContextFactory();
+        _lookup.LookupByIsbnAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new BookLookupResult(
+                Isbn: "9780552131063",
+                Title: "Mort",
+                Subtitle: null,
+                Author: "Pratchett",
+                Publisher: "Corgi",
+                GenreCandidates: [],
+                DatePrinted: new DateOnly(1987, 11, 12),
+                CoverUrl: "https://example.com/mort.jpg",
+                Source: "OpenLibrary",
+                Format: BookFormat.MassMarketPaperback,
+                DatePrintedPrecision: DatePrecision.Day));
+
+        var vm = new EditionFormDialogViewModel(factory, _lookup);
+        await vm.InitializeForAddAsync(1);
+        vm.Isbn = "9780552131063";
+        await vm.LookupAsync();
+
+        Assert.Equal("Corgi", vm.Publisher);
+        Assert.Equal("https://example.com/mort.jpg", vm.CoverUrl);
+        Assert.Equal(BookFormat.MassMarketPaperback, vm.Format);
+        Assert.NotEmpty(vm.FirstPublishedOrPrintedDate);
+    }
+}

--- a/BookTracker.Web/Components/Pages/Books/Detail.razor
+++ b/BookTracker.Web/Components/Pages/Books/Detail.razor
@@ -278,7 +278,7 @@
             <MudCardContent>
                 @if (book.Editions.Count == 0)
                 {
-                    <MudText Typo="Typo.body2" Color="Color.Secondary">No editions recorded yet.</MudText>
+                    <MudText Typo="Typo.body2" Color="Color.Secondary" Class="mb-3">No editions recorded yet.</MudText>
                 }
                 else
                 {
@@ -309,10 +309,27 @@
                                             <FieldRow Label="Printed" Value="@edition.DatePrintedDisplay" />
                                         }
 
+                                        <MudStack Row="true" Spacing="1" Wrap="Wrap.Wrap">
+                                            <MudButton OnClick="@(() => OpenEditEditionDialog(edition.Id))"
+                                                       Variant="Variant.Outlined"
+                                                       Size="Size.Small"
+                                                       StartIcon="@Icons.Material.Filled.Edit">
+                                                Edit edition
+                                            </MudButton>
+                                            <MudButton OnClick="@(() => OpenAddCopyDialog(edition.Id))"
+                                                       Variant="Variant.Outlined"
+                                                       Size="Size.Small"
+                                                       StartIcon="@Icons.Material.Filled.Add">
+                                                Add copy
+                                            </MudButton>
+                                        </MudStack>
+
                                         <MudDivider />
 
                                         @foreach (var (copy, idx) in edition.Copies.Select((c, i) => (c, i)))
                                         {
+                                            var copyId = copy.Id;
+                                            var confirming = confirmingDeleteCopyId == copyId;
                                             <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Start" Wrap="Wrap.Wrap">
                                                 <MudText Typo="Typo.body2" Style="min-width: 70px;">
                                                     <b>Copy @(idx + 1)</b>
@@ -329,6 +346,39 @@
                                                     {
                                                         <MudText Typo="Typo.caption" Color="Color.Secondary" Style="white-space: pre-wrap;">@copy.Notes</MudText>
                                                     }
+                                                    <MudStack Row="true" Spacing="1" Wrap="Wrap.Wrap" Class="mt-1">
+                                                        @if (!confirming)
+                                                        {
+                                                            <MudButton OnClick="@(() => OpenEditCopyDialog(copyId))"
+                                                                       Variant="Variant.Text"
+                                                                       Size="Size.Small"
+                                                                       StartIcon="@Icons.Material.Filled.Edit">
+                                                                Edit
+                                                            </MudButton>
+                                                            <MudButton OnClick="@(() => confirmingDeleteCopyId = copyId)"
+                                                                       Variant="Variant.Text"
+                                                                       Color="Color.Error"
+                                                                       Size="Size.Small"
+                                                                       StartIcon="@Icons.Material.Filled.Delete">
+                                                                Delete
+                                                            </MudButton>
+                                                        }
+                                                        else
+                                                        {
+                                                            <MudText Typo="Typo.caption" Color="Color.Warning" Class="align-self-center">Delete this copy?</MudText>
+                                                            <MudButton OnClick="@(() => ConfirmDeleteCopyAsync(copyId))"
+                                                                       Variant="Variant.Filled"
+                                                                       Color="Color.Error"
+                                                                       Size="Size.Small">
+                                                                Delete
+                                                            </MudButton>
+                                                            <MudButton OnClick="@(() => confirmingDeleteCopyId = null)"
+                                                                       Variant="Variant.Text"
+                                                                       Size="Size.Small">
+                                                                Cancel
+                                                            </MudButton>
+                                                        }
+                                                    </MudStack>
                                                 </MudStack>
                                             </MudStack>
                                         }
@@ -338,6 +388,15 @@
                         }
                     </MudExpansionPanels>
                 }
+
+                <MudButton OnClick="OpenAddEditionDialog"
+                           Variant="Variant.Outlined"
+                           Color="Color.Primary"
+                           StartIcon="@Icons.Material.Filled.Add"
+                           Size="Size.Small"
+                           Class="mt-2">
+                    Add edition
+                </MudButton>
             </MudCardContent>
         </MudCard>
 
@@ -396,6 +455,7 @@
     private string workFilter = "";
     private readonly HashSet<int> expandedWorkIds = [];
     private string? newTagText;
+    private int? confirmingDeleteCopyId;
 
     // Notes debounce: 800ms after the last keystroke OR immediate on blur.
     // CTS is re-created per keystroke so the previous pending save is
@@ -554,6 +614,95 @@
             Snackbar.Add("Work saved", Severity.Success);
             await VM.InitializeAsync(BookId);
             StateHasChanged();
+        }
+    }
+
+    private async Task OpenAddEditionDialog()
+    {
+        if (VM.Book is null) return;
+        var parameters = new DialogParameters<EditionFormDialog>
+        {
+            { x => x.BookId, VM.Book.Id },
+            { x => x.IsNew, true },
+        };
+        var options = new DialogOptions { MaxWidth = MaxWidth.Small, FullWidth = true, CloseButton = true };
+        var dialog = await DialogService.ShowAsync<EditionFormDialog>("Add edition", parameters, options);
+        var result = await dialog.Result;
+        if (result is not null && !result.Canceled)
+        {
+            Snackbar.Add("Edition added", Severity.Success);
+            await VM.InitializeAsync(BookId);
+            StateHasChanged();
+        }
+    }
+
+    private async Task OpenEditEditionDialog(int editionId)
+    {
+        var parameters = new DialogParameters<EditionFormDialog>
+        {
+            { x => x.EditionId, (int?)editionId },
+            { x => x.IsNew, false },
+        };
+        var options = new DialogOptions { MaxWidth = MaxWidth.Small, FullWidth = true, CloseButton = true };
+        var dialog = await DialogService.ShowAsync<EditionFormDialog>("Edit edition", parameters, options);
+        var result = await dialog.Result;
+        if (result is not null && !result.Canceled)
+        {
+            Snackbar.Add("Edition saved", Severity.Success);
+            await VM.InitializeAsync(BookId);
+            StateHasChanged();
+        }
+    }
+
+    private async Task OpenAddCopyDialog(int editionId)
+    {
+        var parameters = new DialogParameters<CopyFormDialog>
+        {
+            { x => x.EditionId, (int?)editionId },
+            { x => x.IsNew, true },
+        };
+        var options = new DialogOptions { MaxWidth = MaxWidth.Small, FullWidth = true, CloseButton = true };
+        var dialog = await DialogService.ShowAsync<CopyFormDialog>("Add copy", parameters, options);
+        var result = await dialog.Result;
+        if (result is not null && !result.Canceled)
+        {
+            Snackbar.Add("Copy added", Severity.Success);
+            await VM.InitializeAsync(BookId);
+            StateHasChanged();
+        }
+    }
+
+    private async Task OpenEditCopyDialog(int copyId)
+    {
+        var parameters = new DialogParameters<CopyFormDialog>
+        {
+            { x => x.CopyId, (int?)copyId },
+            { x => x.IsNew, false },
+        };
+        var options = new DialogOptions { MaxWidth = MaxWidth.Small, FullWidth = true, CloseButton = true };
+        var dialog = await DialogService.ShowAsync<CopyFormDialog>("Edit copy", parameters, options);
+        var result = await dialog.Result;
+        if (result is not null && !result.Canceled)
+        {
+            Snackbar.Add("Copy saved", Severity.Success);
+            await VM.InitializeAsync(BookId);
+            StateHasChanged();
+        }
+    }
+
+    private async Task ConfirmDeleteCopyAsync(int copyId)
+    {
+        try
+        {
+            await VM.DeleteCopyAsync(copyId);
+            confirmingDeleteCopyId = null;
+            Snackbar.Add("Copy deleted", Severity.Success);
+            await VM.InitializeAsync(BookId);
+            StateHasChanged();
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Couldn't delete copy: {ex.Message}", Severity.Error);
         }
     }
 

--- a/BookTracker.Web/Components/Shared/CopyFormDialog.razor
+++ b/BookTracker.Web/Components/Shared/CopyFormDialog.razor
@@ -1,0 +1,98 @@
+@* Modal dialog for Add Copy (against an existing Edition) and Edit Copy.
+   IsNew picks between flows. Fields: condition, date acquired, notes. *@
+
+@inject CopyFormDialogViewModel VM
+
+<MudDialog>
+    <DialogContent>
+        @if (VM.NotFound)
+        {
+            <MudAlert Severity="Severity.Warning">Copy not found.</MudAlert>
+        }
+        else
+        {
+            <MudStack Spacing="3" Style="min-width: 280px;">
+                <MudSelect T="BookCondition"
+                           @bind-Value="VM.Condition"
+                           Label="Condition"
+                           Variant="Variant.Outlined"
+                           Margin="Margin.Dense">
+                    @foreach (var c in Enum.GetValues<BookCondition>())
+                    {
+                        <MudSelectItem T="BookCondition" Value="c">@ConditionLabel(c)</MudSelectItem>
+                    }
+                </MudSelect>
+
+                <MudDatePicker Label="Date acquired"
+                               Date="@VM.DateAcquired"
+                               DateChanged="@((DateTime? d) => VM.DateAcquired = d)"
+                               Variant="Variant.Outlined"
+                               Margin="Margin.Dense"
+                               Clearable="true" />
+
+                <MudTextField T="string"
+                              @bind-Value="VM.Notes"
+                              Label="Notes"
+                              Lines="3"
+                              Variant="Variant.Outlined"
+                              Margin="Margin.Dense"
+                              Placeholder="e.g. signed, dust jacket, gift from..." />
+            </MudStack>
+        }
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Cancel">Cancel</MudButton>
+        <MudButton Color="Color.Primary"
+                   Variant="Variant.Filled"
+                   Disabled="@(VM.NotFound || saving)"
+                   OnClick="SaveAsync">
+            @(saving ? "Saving..." : "Save")
+        </MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] private IMudDialogInstance MudDialog { get; set; } = default!;
+
+    // Exactly one of EditionId (Add) or CopyId (Edit) is set.
+    [Parameter] public int? EditionId { get; set; }
+    [Parameter] public int? CopyId { get; set; }
+    [Parameter] public bool IsNew { get; set; }
+
+    private bool saving;
+
+    protected override async Task OnInitializedAsync()
+    {
+        if (IsNew && EditionId is int eid)
+        {
+            VM.InitializeForAdd(eid);
+        }
+        else if (CopyId is int cid)
+        {
+            await VM.InitializeForEditAsync(cid);
+        }
+    }
+
+    private async Task SaveAsync()
+    {
+        saving = true;
+        try
+        {
+            var id = await VM.SaveAsync();
+            if (id is int) MudDialog.Close(DialogResult.Ok(id));
+        }
+        finally
+        {
+            saving = false;
+        }
+    }
+
+    private void Cancel() => MudDialog.Cancel();
+
+    private static string ConditionLabel(BookCondition c) => c switch
+    {
+        BookCondition.AsNew => "As New",
+        BookCondition.VeryGood => "Very Good",
+        _ => c.ToString(),
+    };
+}

--- a/BookTracker.Web/Components/Shared/EditionFormDialog.razor
+++ b/BookTracker.Web/Components/Shared/EditionFormDialog.razor
@@ -1,0 +1,159 @@
+@* Modal dialog for Add Edition and Edit Edition. The IsNew parameter
+   picks between the two flows — Add shows the ISBN-lookup button and a
+   first-copy condition field; Edit is field-only. *@
+
+@inject EditionFormDialogViewModel VM
+
+<MudDialog>
+    <DialogContent>
+        @if (VM.NotFound)
+        {
+            <MudAlert Severity="Severity.Warning">Edition not found.</MudAlert>
+        }
+        else
+        {
+            <MudStack Spacing="3" Style="min-width: 280px;">
+                @if (VM.IsNew)
+                {
+                    @* ISBN row with lookup button — Add flow only. *@
+                    <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Start">
+                        <MudTextField T="string"
+                                      @bind-Value="VM.Isbn"
+                                      Label="ISBN"
+                                      Variant="Variant.Outlined"
+                                      Margin="Margin.Dense"
+                                      Class="flex-grow-1" />
+                        <MudButton OnClick="LookupAsync"
+                                   Disabled="@(VM.LookingUp || string.IsNullOrWhiteSpace(VM.Isbn))"
+                                   Variant="Variant.Outlined"
+                                   StartIcon="@Icons.Material.Filled.Search"
+                                   Size="Size.Small"
+                                   Class="mt-1">
+                            @(VM.LookingUp ? "Looking..." : "Lookup")
+                        </MudButton>
+                    </MudStack>
+                    @if (!string.IsNullOrEmpty(VM.LookupMessage))
+                    {
+                        <MudText Typo="Typo.caption" Color="Color.Secondary">@VM.LookupMessage</MudText>
+                    }
+                }
+                else
+                {
+                    <MudTextField T="string"
+                                  @bind-Value="VM.Isbn"
+                                  Label="ISBN"
+                                  Variant="Variant.Outlined"
+                                  Margin="Margin.Dense"
+                                  HelperText="Leave blank for pre-1974 / self-published editions." />
+                }
+
+                <MudSelect T="BookFormat"
+                           @bind-Value="VM.Format"
+                           Label="Format"
+                           Variant="Variant.Outlined"
+                           Margin="Margin.Dense">
+                    @foreach (var f in Enum.GetValues<BookFormat>())
+                    {
+                        <MudSelectItem T="BookFormat" Value="f">@f.DisplayName()</MudSelectItem>
+                    }
+                </MudSelect>
+
+                <MudAutocomplete T="string"
+                                 @bind-Value="VM.Publisher"
+                                 SearchFunc="VM.SearchPublishersAsync"
+                                 Label="Publisher"
+                                 Variant="Variant.Outlined"
+                                 Margin="Margin.Dense"
+                                 CoerceValue="true"
+                                 CoerceText="true"
+                                 ResetValueOnEmptyText="false"
+                                 MinCharacters="0"
+                                 HelperText="Type to find existing or create new." />
+
+                <MudTextField T="string"
+                              @bind-Value="VM.FirstPublishedOrPrintedDate"
+                              Label="Date printed"
+                              Variant="Variant.Outlined"
+                              Margin="Margin.Dense"
+                              HelperText="Year, 'Month Year', or full date (e.g. 1987, Oct 1987, 1987-10-12)." />
+
+                <MudTextField T="string"
+                              @bind-Value="VM.CoverUrl"
+                              Label="Cover image URL"
+                              Variant="Variant.Outlined"
+                              Margin="Margin.Dense" />
+
+                @if (VM.IsNew)
+                {
+                    <MudSelect T="BookCondition"
+                               @bind-Value="VM.FirstCopyCondition"
+                               Label="Condition of first copy"
+                               Variant="Variant.Outlined"
+                               Margin="Margin.Dense">
+                        @foreach (var c in Enum.GetValues<BookCondition>())
+                        {
+                            <MudSelectItem T="BookCondition" Value="c">@ConditionLabel(c)</MudSelectItem>
+                        }
+                    </MudSelect>
+                }
+            </MudStack>
+        }
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Cancel">Cancel</MudButton>
+        <MudButton Color="Color.Primary"
+                   Variant="Variant.Filled"
+                   Disabled="@(VM.NotFound || saving)"
+                   OnClick="SaveAsync">
+            @(saving ? "Saving..." : "Save")
+        </MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] private IMudDialogInstance MudDialog { get; set; } = default!;
+
+    // Exactly one of (BookId + IsNew=true) or EditionId must be provided.
+    [Parameter] public int BookId { get; set; }
+    [Parameter] public int? EditionId { get; set; }
+    [Parameter] public bool IsNew { get; set; }
+
+    private bool saving;
+
+    protected override async Task OnInitializedAsync()
+    {
+        if (IsNew)
+        {
+            await VM.InitializeForAddAsync(BookId);
+        }
+        else if (EditionId is int eid)
+        {
+            await VM.InitializeForEditAsync(eid);
+        }
+    }
+
+    private async Task LookupAsync() => await VM.LookupAsync();
+
+    private async Task SaveAsync()
+    {
+        saving = true;
+        try
+        {
+            var id = await VM.SaveAsync();
+            if (id is int) MudDialog.Close(DialogResult.Ok(id));
+        }
+        finally
+        {
+            saving = false;
+        }
+    }
+
+    private void Cancel() => MudDialog.Cancel();
+
+    private static string ConditionLabel(BookCondition c) => c switch
+    {
+        BookCondition.AsNew => "As New",
+        BookCondition.VeryGood => "Very Good",
+        _ => c.ToString(),
+    };
+}

--- a/BookTracker.Web/Program.cs
+++ b/BookTracker.Web/Program.cs
@@ -81,6 +81,8 @@ builder.Services.AddTransient<BookEditViewModel>();
 builder.Services.AddTransient<BookDetailViewModel>();
 builder.Services.AddTransient<BookEditDialogViewModel>();
 builder.Services.AddTransient<WorkEditDialogViewModel>();
+builder.Services.AddTransient<EditionFormDialogViewModel>();
+builder.Services.AddTransient<CopyFormDialogViewModel>();
 builder.Services.AddTransient<BulkAddViewModel>();
 builder.Services.AddTransient<SeriesListViewModel>();
 builder.Services.AddTransient<SeriesEditViewModel>();

--- a/BookTracker.Web/ViewModels/BookDetailViewModel.cs
+++ b/BookTracker.Web/ViewModels/BookDetailViewModel.cs
@@ -171,6 +171,28 @@ public class BookDetailViewModel(IDbContextFactory<BookTrackerDbContext> dbFacto
         return detail;
     }
 
+    /// <summary>
+    /// Deletes a Copy. If it was the last Copy on its Edition, the Edition
+    /// is removed too (matches the existing Edit-page behaviour — an
+    /// Edition with no Copies doesn't represent anything useful).
+    /// </summary>
+    public async Task DeleteCopyAsync(int copyId)
+    {
+        if (Book is null) return;
+
+        await using var db = await dbFactory.CreateDbContextAsync();
+        var copy = await db.Copies.Include(c => c.Edition).ThenInclude(e => e.Copies).FirstOrDefaultAsync(c => c.Id == copyId);
+        if (copy is null) return;
+
+        var edition = copy.Edition;
+        db.Copies.Remove(copy);
+        if (edition.Copies.Count <= 1)
+        {
+            db.Editions.Remove(edition);
+        }
+        await db.SaveChangesAsync();
+    }
+
     public async Task RemoveTagAsync(int tagId)
     {
         if (Book is null) return;

--- a/BookTracker.Web/ViewModels/CopyFormDialogViewModel.cs
+++ b/BookTracker.Web/ViewModels/CopyFormDialogViewModel.cs
@@ -1,0 +1,77 @@
+using BookTracker.Data;
+using BookTracker.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookTracker.Web.ViewModels;
+
+// Dialog VM for Add Copy (against an existing Edition) and Edit Copy,
+// picked by IsNew flag.
+public class CopyFormDialogViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory)
+{
+    public bool IsNew { get; private set; }
+    public bool NotFound { get; private set; }
+    public int? EditionId { get; private set; }
+    public int? CopyId { get; private set; }
+
+    public BookCondition Condition { get; set; } = BookCondition.Good;
+    public DateTime? DateAcquired { get; set; }
+    public string? Notes { get; set; }
+
+    public void InitializeForAdd(int editionId)
+    {
+        IsNew = true;
+        EditionId = editionId;
+        CopyId = null;
+        DateAcquired = DateTime.UtcNow.Date;
+    }
+
+    public async Task InitializeForEditAsync(int copyId)
+    {
+        IsNew = false;
+        CopyId = copyId;
+
+        await using var db = await dbFactory.CreateDbContextAsync();
+        var copy = await db.Copies.FindAsync(copyId);
+        if (copy is null) { NotFound = true; return; }
+
+        EditionId = copy.EditionId;
+        Condition = copy.Condition;
+        DateAcquired = copy.DateAcquired;
+        Notes = copy.Notes;
+    }
+
+    public async Task<int?> SaveAsync()
+    {
+        if (NotFound) return null;
+
+        await using var db = await dbFactory.CreateDbContextAsync();
+
+        if (IsNew)
+        {
+            if (EditionId is not int eid) return null;
+            var copy = new Copy
+            {
+                EditionId = eid,
+                Condition = Condition,
+                DateAcquired = DateAcquired,
+                Notes = string.IsNullOrWhiteSpace(Notes) ? null : Notes.Trim(),
+            };
+            db.Copies.Add(copy);
+            await db.SaveChangesAsync();
+            return copy.Id;
+        }
+        else
+        {
+            if (CopyId is not int cid) return null;
+            var copy = await db.Copies.FindAsync(cid);
+            if (copy is null) return null;
+
+            copy.Condition = Condition;
+            copy.DateAcquired = DateAcquired;
+            copy.Notes = string.IsNullOrWhiteSpace(Notes) ? null : Notes.Trim();
+
+            await db.SaveChangesAsync();
+            return copy.Id;
+        }
+    }
+}

--- a/BookTracker.Web/ViewModels/EditionFormDialogViewModel.cs
+++ b/BookTracker.Web/ViewModels/EditionFormDialogViewModel.cs
@@ -1,0 +1,181 @@
+using BookTracker.Data;
+using BookTracker.Data.Models;
+using BookTracker.Web.Services;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookTracker.Web.ViewModels;
+
+// Dialog VM for Add Edition and Edit Edition, picked by IsNew flag.
+//
+// Add:
+//   InitializeForAddAsync(bookId) — blank form, lookup button available,
+//   FirstCopyCondition captured so save creates Edition + first Copy.
+// Edit:
+//   InitializeForEditAsync(editionId) — prefills existing fields, no
+//   lookup, no first-copy field. Save updates in place.
+//
+// Publisher is typeahead find-or-create (same shape as Author on the
+// Work dialog). ISBN is optional (nullable, filtered unique) so
+// pre-1974 editions save without one.
+public class EditionFormDialogViewModel(
+    IDbContextFactory<BookTrackerDbContext> dbFactory,
+    IBookLookupService lookup)
+{
+    public bool IsNew { get; private set; }
+    public bool NotFound { get; private set; }
+    public int BookId { get; private set; }
+    public int? EditionId { get; private set; }
+
+    public string? Isbn { get; set; }
+    public BookFormat Format { get; set; } = BookFormat.TradePaperback;
+    public string? Publisher { get; set; }
+    public string FirstPublishedOrPrintedDate { get; set; } = "";
+    public string? CoverUrl { get; set; }
+
+    // Add-only: the first Copy that ships with a new Edition. Every
+    // Edition needs at least one Copy, so the Add flow captures it here.
+    public BookCondition FirstCopyCondition { get; set; } = BookCondition.Good;
+
+    public string? LookupMessage { get; private set; }
+    public bool LookingUp { get; private set; }
+
+    public async Task InitializeForAddAsync(int bookId)
+    {
+        IsNew = true;
+        BookId = bookId;
+        EditionId = null;
+    }
+
+    public async Task InitializeForEditAsync(int editionId)
+    {
+        IsNew = false;
+        EditionId = editionId;
+
+        await using var db = await dbFactory.CreateDbContextAsync();
+        var edition = await db.Editions.Include(e => e.Publisher).FirstOrDefaultAsync(e => e.Id == editionId);
+        if (edition is null) { NotFound = true; return; }
+
+        BookId = edition.BookId;
+        Isbn = edition.Isbn;
+        Format = edition.Format;
+        Publisher = edition.Publisher?.Name;
+        FirstPublishedOrPrintedDate = PartialDateParser.Format(edition.DatePrinted, edition.DatePrintedPrecision);
+        CoverUrl = edition.CoverUrl;
+    }
+
+    public async Task<IEnumerable<string>> SearchPublishersAsync(string query, CancellationToken ct)
+    {
+        // .ToLower() inside the Where keeps behaviour consistent across
+        // providers. SQL Server defaults to case-insensitive collation so
+        // raw Contains would match either way in prod, but the EF InMemory
+        // provider used in tests is case-sensitive — explicit lowering
+        // prevents tests and prod from disagreeing.
+        var q = (query ?? "").Trim().ToLower();
+        await using var db = await dbFactory.CreateDbContextAsync();
+        var matches = db.Publishers.AsQueryable();
+        if (!string.IsNullOrEmpty(q))
+        {
+            matches = matches.Where(p => p.Name.ToLower().Contains(q));
+        }
+        return await matches
+            .OrderBy(p => p.Name)
+            .Select(p => p.Name)
+            .Take(20)
+            .ToListAsync(ct);
+    }
+
+    public async Task LookupAsync()
+    {
+        LookupMessage = null;
+        if (string.IsNullOrWhiteSpace(Isbn))
+        {
+            LookupMessage = "Enter an ISBN to look up.";
+            return;
+        }
+
+        LookingUp = true;
+        try
+        {
+            var result = await lookup.LookupByIsbnAsync(Isbn, CancellationToken.None);
+            if (result is null)
+            {
+                LookupMessage = $"No match found for ISBN {Isbn}.";
+                return;
+            }
+
+            // Auto-fill empties only — don't clobber anything the user typed.
+            if (string.IsNullOrWhiteSpace(Isbn)) Isbn = result.Isbn;
+            if (string.IsNullOrWhiteSpace(Publisher)) Publisher = result.Publisher;
+            if (string.IsNullOrWhiteSpace(CoverUrl)) CoverUrl = result.CoverUrl;
+            if (string.IsNullOrWhiteSpace(FirstPublishedOrPrintedDate) && result.DatePrinted is DateOnly d)
+            {
+                FirstPublishedOrPrintedDate = PartialDateParser.Format(d, result.DatePrintedPrecision);
+            }
+            if (result.Format is BookFormat fmt) Format = fmt;
+
+            LookupMessage = $"Prefilled from {result.Source}. Edit anything before saving.";
+        }
+        finally
+        {
+            LookingUp = false;
+        }
+    }
+
+    /// <returns>The new or updated Edition id.</returns>
+    public async Task<int?> SaveAsync()
+    {
+        if (NotFound) return null;
+
+        await using var db = await dbFactory.CreateDbContextAsync();
+
+        // Resolve Publisher via find-or-create.
+        Publisher? publisher = null;
+        var pubName = Publisher?.Trim();
+        if (!string.IsNullOrEmpty(pubName))
+        {
+            publisher = await db.Publishers.FirstOrDefaultAsync(p => p.Name == pubName);
+            if (publisher is null)
+            {
+                publisher = new Publisher { Name = pubName };
+                db.Publishers.Add(publisher);
+            }
+        }
+
+        var datePrinted = PartialDateParser.TryParse(FirstPublishedOrPrintedDate) ?? PartialDate.Empty;
+
+        if (IsNew)
+        {
+            var edition = new Edition
+            {
+                BookId = BookId,
+                Isbn = string.IsNullOrWhiteSpace(Isbn) ? null : Isbn.Trim(),
+                Format = Format,
+                DatePrinted = datePrinted.Date,
+                DatePrintedPrecision = datePrinted.Precision,
+                Publisher = publisher,
+                CoverUrl = string.IsNullOrWhiteSpace(CoverUrl) ? null : CoverUrl.Trim(),
+                Copies = [new Copy { Condition = FirstCopyCondition }],
+            };
+            db.Editions.Add(edition);
+            await db.SaveChangesAsync();
+            return edition.Id;
+        }
+        else
+        {
+            if (EditionId is not int id) return null;
+            var edition = await db.Editions.FindAsync(id);
+            if (edition is null) return null;
+
+            edition.Isbn = string.IsNullOrWhiteSpace(Isbn) ? null : Isbn.Trim();
+            edition.Format = Format;
+            edition.DatePrinted = datePrinted.Date;
+            edition.DatePrintedPrecision = datePrinted.Precision;
+            edition.PublisherId = publisher?.Id;
+            edition.Publisher = publisher;
+            edition.CoverUrl = string.IsNullOrWhiteSpace(CoverUrl) ? null : CoverUrl.Trim();
+
+            await db.SaveChangesAsync();
+            return edition.Id;
+        }
+    }
+}

--- a/BookTracker.Web/ViewModels/WorkEditDialogViewModel.cs
+++ b/BookTracker.Web/ViewModels/WorkEditDialogViewModel.cs
@@ -47,12 +47,15 @@ public class WorkEditDialogViewModel(IDbContextFactory<BookTrackerDbContext> dbF
 
     public async Task<IEnumerable<string>> SearchAuthorsAsync(string query, CancellationToken ct)
     {
-        var q = (query ?? "").Trim();
+        // Lowercased client-side before the LINQ Where so the EF InMemory
+        // provider (case-sensitive) and SQL Server (case-insensitive by
+        // default collation) agree on substring matching.
+        var q = (query ?? "").Trim().ToLower();
         await using var db = await dbFactory.CreateDbContextAsync();
         var matches = db.Authors.AsQueryable();
         if (!string.IsNullOrEmpty(q))
         {
-            matches = matches.Where(a => a.Name.Contains(q));
+            matches = matches.Where(a => a.Name.ToLower().Contains(q));
         }
 
         return await matches


### PR DESCRIPTION
Four new edit surfaces reachable from /books/{id}:
- Add edition — ISBN field with Lookup button (IBookLookupService
  auto-fill of publisher/cover/date/format into empty fields only, so
  typed values aren't clobbered), format, publisher typeahead (find-or-
  create, same shape as Author in PR 3), date printed (PartialDateParser
  free-text), cover URL, and the first copy's condition.
- Edit edition — same fields, no lookup or first-copy.
- Add copy / Edit copy — condition, DateAcquired (MudDatePicker), notes.

Delete copy uses inline confirm/cancel buttons rather than a
modal-on-modal — tap-friendly on mobile. Deleting the last copy on an
Edition cascades the Edition removal, matching the existing /edit page
behaviour (Edition with zero Copies isn't meaningful).

Two shared Dialog VMs (EditionFormDialogViewModel, CopyFormDialog-
ViewModel), each covering Add + Edit via an IsNew flag. Keeps
BookDetailViewModel lean — it gained only DeleteCopyAsync. DI
registered transient. The per-modal VM rule from PR 2's retro still
holding.

Bonus fix: SearchAuthorsAsync + SearchPublishersAsync now lower-case
both sides of the Contains() so EF InMemory (case-sensitive) and SQL
Server (default case-insensitive collation) agree. Surfaced by the
Publisher search test — would have been a real "works in prod, test
broken, or vice-versa" footgun otherwise.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
