### PR TITLE
feat(books): swap Library list click target to View page

### DIFF
--- a/BookTracker.Web/Components/Pages/Books/Edit.razor
+++ b/BookTracker.Web/Components/Pages/Books/Edit.razor
@@ -22,7 +22,7 @@ else
 {
     <div class="d-flex justify-content-between align-items-center mb-3 flex-wrap gap-2">
         <h1 class="mb-0">Edit book</h1>
-        <a href="@($"/books/{BookId}")" class="btn btn-outline-secondary btn-sm">View (preview)</a>
+        <a href="@($"/books/{BookId}")" class="btn btn-outline-secondary btn-sm">Back to view</a>
     </div>
 
     @if (!string.IsNullOrEmpty(VM.SuccessMessage))

--- a/BookTracker.Web/Components/Pages/Books/List.razor
+++ b/BookTracker.Web/Components/Pages/Books/List.razor
@@ -217,7 +217,7 @@ else
         await VM.ChangeGroupingAsync(GroupBySelected);
     }
 
-    private void NavigateToEdit(int bookId) => Nav.NavigateTo($"/books/{bookId}/edit");
+    private void NavigateToBook(int bookId) => Nav.NavigateTo($"/books/{bookId}");
 
     private RenderFragment RenderBooks(IReadOnlyList<BookListViewModel.BookListItem> books) =>
     @<text>
@@ -238,7 +238,7 @@ else
                 <tbody>
                     @foreach (var book in books)
                     {
-                        <tr role="button" @onclick="() => NavigateToEdit(book.Id)" style="cursor: pointer;">
+                        <tr role="button" @onclick="() => NavigateToBook(book.Id)" style="cursor: pointer;">
                             <td>
                                 @if (!string.IsNullOrWhiteSpace(book.CoverUrl))
                                 {
@@ -291,7 +291,7 @@ else
         <div class="d-md-none">
             @foreach (var book in books)
             {
-                <div class="book-card-mobile d-flex gap-3 align-items-start" @onclick="() => NavigateToEdit(book.Id)">
+                <div class="book-card-mobile d-flex gap-3 align-items-start" @onclick="() => NavigateToBook(book.Id)">
                     @if (!string.IsNullOrWhiteSpace(book.CoverUrl))
                     {
                         <img src="@book.CoverUrl" alt="" class="rounded flex-shrink-0" style="width: 48px; height: 68px; object-fit: cover;" />


### PR DESCRIPTION
Clicking a book in /books now lands on /books/{id} (the View page)
instead of /books/{id}/edit. The View page has been feature-complete
for normal single-Work books since PR 4 (rating, status, notes, tags,
edit Book/Work details, edit editions + copies), so it's the right
default landing for browsing. Users who need genres or compendium
building reach /edit via the "Full edit page" link in the View header.

The temporary "View (preview)" link on the Edit page (added in PR 1 so
the View could be clicked without the rest of the app depending on it)
is now a permanent "Back to view" link — symmetric with "Full edit
page" going the other direction.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
