### PR TITLE
feat(genres): MudBlazor genre picker on WorkEditDialog (PR B)

### DIFF
--- a/BookTracker.Tests/ViewModels/MudGenrePickerViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/MudGenrePickerViewModelTests.cs
@@ -1,0 +1,181 @@
+using BookTracker.Data.Models;
+using BookTracker.Web.ViewModels;
+
+namespace BookTracker.Tests.ViewModels;
+
+public class MudGenrePickerViewModelTests
+{
+    [Fact]
+    public async Task InitializeAsync_LoadsFlatGenresWithParentNames()
+    {
+        var factory = new TestDbContextFactory();
+        using (var db = factory.CreateDbContext())
+        {
+            var reference = new Genre { Name = "Reference" };
+            db.Genres.Add(reference);
+            db.Genres.Add(new Genre { Name = "Dictionaries", ParentGenre = reference });
+            await db.SaveChangesAsync();
+        }
+
+        var vm = new MudGenrePickerViewModel(factory);
+        await vm.InitializeAsync();
+
+        Assert.Equal(2, vm.AllGenres.Count);
+        var dict = vm.AllGenres.Single(g => g.Name == "Dictionaries");
+        Assert.Equal("Reference", dict.ParentName);
+        Assert.NotNull(dict.ParentGenreId);
+        var refGenre = vm.AllGenres.Single(g => g.Name == "Reference");
+        Assert.Null(refGenre.ParentName);
+        Assert.Null(refGenre.ParentGenreId);
+    }
+
+    [Fact]
+    public async Task Search_SubstringCaseInsensitive_ExcludesSelected()
+    {
+        var factory = new TestDbContextFactory();
+        int dictionariesId;
+        using (var db = factory.CreateDbContext())
+        {
+            var reference = new Genre { Name = "Reference" };
+            var dictionaries = new Genre { Name = "Dictionaries", ParentGenre = reference };
+            db.Genres.AddRange(reference, dictionaries,
+                new Genre { Name = "Atlases", ParentGenre = reference },
+                new Genre { Name = "Fantasy" });
+            await db.SaveChangesAsync();
+            dictionariesId = dictionaries.Id;
+        }
+
+        var vm = new MudGenrePickerViewModel(factory);
+        await vm.InitializeAsync();
+
+        var results = vm.Search("DICT", []).ToList();
+        Assert.Single(results);
+        Assert.Equal("Dictionaries", results[0].Name);
+
+        // already-selected ids are excluded
+        var filtered = vm.Search("dict", [dictionariesId]).ToList();
+        Assert.Empty(filtered);
+    }
+
+    [Fact]
+    public async Task ChipLabel_UsesParentSlashLeafForNested_LeafForTopLevel()
+    {
+        var factory = new TestDbContextFactory();
+        int dictionariesId;
+        int fantasyId;
+        using (var db = factory.CreateDbContext())
+        {
+            var reference = new Genre { Name = "Reference" };
+            var dictionaries = new Genre { Name = "Dictionaries", ParentGenre = reference };
+            var fantasy = new Genre { Name = "Fantasy" };
+            db.Genres.AddRange(reference, dictionaries, fantasy);
+            await db.SaveChangesAsync();
+            dictionariesId = dictionaries.Id;
+            fantasyId = fantasy.Id;
+        }
+
+        var vm = new MudGenrePickerViewModel(factory);
+        await vm.InitializeAsync();
+
+        Assert.Equal("Reference / Dictionaries", vm.ChipLabel(dictionariesId));
+        Assert.Equal("Fantasy", vm.ChipLabel(fantasyId));
+    }
+
+    [Fact]
+    public async Task AddGenre_AutoIncludesParentWhenChildPicked()
+    {
+        var factory = new TestDbContextFactory();
+        int referenceId;
+        int dictionariesId;
+        using (var db = factory.CreateDbContext())
+        {
+            var reference = new Genre { Name = "Reference" };
+            var dictionaries = new Genre { Name = "Dictionaries", ParentGenre = reference };
+            db.Genres.AddRange(reference, dictionaries);
+            await db.SaveChangesAsync();
+            referenceId = reference.Id;
+            dictionariesId = dictionaries.Id;
+        }
+
+        var vm = new MudGenrePickerViewModel(factory);
+        await vm.InitializeAsync();
+
+        var after = vm.AddGenre(dictionariesId, []);
+        Assert.Contains(dictionariesId, after);
+        Assert.Contains(referenceId, after);
+    }
+
+    [Fact]
+    public async Task AddGenre_IsIdempotent()
+    {
+        var factory = new TestDbContextFactory();
+        int fantasyId;
+        using (var db = factory.CreateDbContext())
+        {
+            var fantasy = new Genre { Name = "Fantasy" };
+            db.Genres.Add(fantasy);
+            await db.SaveChangesAsync();
+            fantasyId = fantasy.Id;
+        }
+
+        var vm = new MudGenrePickerViewModel(factory);
+        await vm.InitializeAsync();
+
+        var once = vm.AddGenre(fantasyId, []);
+        var twice = vm.AddGenre(fantasyId, once);
+        Assert.Single(twice);
+    }
+
+    [Fact]
+    public async Task RemoveGenre_LeavesParentAlone()
+    {
+        // Removing a child doesn't deselect its parent — matches the existing
+        // picker's behaviour (parent selection is independent of child presence).
+        var factory = new TestDbContextFactory();
+        int referenceId;
+        int dictionariesId;
+        using (var db = factory.CreateDbContext())
+        {
+            var reference = new Genre { Name = "Reference" };
+            var dictionaries = new Genre { Name = "Dictionaries", ParentGenre = reference };
+            db.Genres.AddRange(reference, dictionaries);
+            await db.SaveChangesAsync();
+            referenceId = reference.Id;
+            dictionariesId = dictionaries.Id;
+        }
+
+        var vm = new MudGenrePickerViewModel(factory);
+        await vm.InitializeAsync();
+
+        var after = vm.RemoveGenre(dictionariesId, [dictionariesId, referenceId]);
+        Assert.Contains(referenceId, after);
+        Assert.DoesNotContain(dictionariesId, after);
+    }
+
+    [Fact]
+    public async Task BuildTreeItems_GroupsChildrenUnderParents()
+    {
+        var factory = new TestDbContextFactory();
+        using (var db = factory.CreateDbContext())
+        {
+            var reference = new Genre { Name = "Reference" };
+            db.Genres.AddRange(
+                reference,
+                new Genre { Name = "Dictionaries", ParentGenre = reference },
+                new Genre { Name = "Atlases", ParentGenre = reference },
+                new Genre { Name = "Fantasy" });
+            await db.SaveChangesAsync();
+        }
+
+        var vm = new MudGenrePickerViewModel(factory);
+        await vm.InitializeAsync();
+        var tree = vm.BuildTreeItems([]);
+
+        Assert.Equal(2, tree.Count); // Reference + Fantasy
+        var referenceNode = tree.Single(t => t.Text == "Reference");
+        Assert.NotNull(referenceNode.Children);
+        Assert.Equal(2, referenceNode.Children!.Count);
+        var fantasyNode = tree.Single(t => t.Text == "Fantasy");
+        Assert.True(fantasyNode.Children is null || fantasyNode.Children.Count == 0);
+    }
+}

--- a/BookTracker.Tests/ViewModels/WorkEditDialogViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/WorkEditDialogViewModelTests.cs
@@ -169,6 +169,71 @@ public class WorkEditDialogViewModelTests
     }
 
     [Fact]
+    public async Task InitializeAsync_LoadsExistingGenreIds()
+    {
+        var factory = new TestDbContextFactory();
+        int workId;
+        int fantasyId;
+        using (var db = factory.CreateDbContext())
+        {
+            var fantasy = new Genre { Name = "Fantasy" };
+            var work = new Work
+            {
+                Title = "w",
+                Author = new Author { Name = "a" },
+                Genres = [fantasy],
+            };
+            db.Books.Add(new Book { Title = "B", Works = [work] });
+            await db.SaveChangesAsync();
+            workId = work.Id;
+            fantasyId = fantasy.Id;
+        }
+
+        var vm = new WorkEditDialogViewModel(factory);
+        await vm.InitializeAsync(workId);
+
+        Assert.Single(vm.SelectedGenreIds);
+        Assert.Contains(fantasyId, vm.SelectedGenreIds);
+    }
+
+    [Fact]
+    public async Task SaveAsync_ReconcilesGenreSelection()
+    {
+        var factory = new TestDbContextFactory();
+        int workId;
+        int fantasyId;
+        int horrorId;
+        using (var db = factory.CreateDbContext())
+        {
+            var fantasy = new Genre { Name = "Fantasy" };
+            var horror = new Genre { Name = "Horror" };
+            db.Genres.AddRange(fantasy, horror);
+            var work = new Work
+            {
+                Title = "w",
+                Author = new Author { Name = "a" },
+                Genres = [fantasy], // starts with Fantasy
+            };
+            db.Books.Add(new Book { Title = "B", Works = [work] });
+            await db.SaveChangesAsync();
+            workId = work.Id;
+            fantasyId = fantasy.Id;
+            horrorId = horror.Id;
+        }
+
+        var vm = new WorkEditDialogViewModel(factory);
+        await vm.InitializeAsync(workId);
+        // Swap selection: drop Fantasy, add Horror.
+        vm.SelectedGenreIds = [horrorId];
+        await vm.SaveAsync();
+
+        using var db2 = factory.CreateDbContext();
+        var saved = db2.Works.Include(w => w.Genres).Single(w => w.Id == workId);
+        Assert.Single(saved.Genres);
+        Assert.Equal(horrorId, saved.Genres[0].Id);
+    }
+
+    [Fact]
     public async Task SearchAuthorsAsync_MatchesSubstring()
     {
         var factory = new TestDbContextFactory();

--- a/BookTracker.Web/Components/Shared/MudGenrePicker.razor
+++ b/BookTracker.Web/Components/Shared/MudGenrePicker.razor
@@ -1,0 +1,132 @@
+@* MudBlazor genre picker. Three surfaces over a single SelectedGenreIds
+   source of truth:
+     1. Chips band — closeable chips per selected genre.
+     2. MudAutocomplete input — type to search (substring, case-insensitive).
+     3. Collapsible MudTreeView — browse-all tree with parent/child checkboxes.
+   All three read from / write to the same parameter list. Picking a sub-
+   genre auto-includes its parent, matching the existing Bootstrap picker. *@
+
+@inject MudGenrePickerViewModel VM
+
+<MudStack Spacing="2">
+
+    @* Selected chips. *@
+    @if (SelectedGenreIds.Count > 0)
+    {
+        <MudStack Row="true" Spacing="1" Wrap="Wrap.Wrap">
+            @foreach (var id in SelectedGenreIds)
+            {
+                var label = VM.ChipLabel(id);
+                <MudChip T="string"
+                         Size="Size.Small"
+                         Variant="Variant.Outlined"
+                         OnClose="@(() => OnRemoveAsync(id))">@label</MudChip>
+            }
+        </MudStack>
+    }
+
+    @* Typeahead input. *@
+    <MudAutocomplete T="MudGenrePickerViewModel.GenreRow"
+                     Value="null"
+                     ValueChanged="OnAutocompletePick"
+                     SearchFunc="SearchAsync"
+                     ToStringFunc="@(g => g is null ? string.Empty : VM.DropdownLabel(g))"
+                     Placeholder="Add a genre..."
+                     Variant="Variant.Outlined"
+                     Margin="Margin.Dense"
+                     Clearable="true"
+                     ResetValueOnEmptyText="true"
+                     MinCharacters="0"
+                     CoerceValue="false"
+                     Adornment="Adornment.Start"
+                     AdornmentIcon="@Icons.Material.Filled.Add" />
+
+    @* Browse-all tree, collapsed by default. *@
+    <div>
+        <MudButton OnClick="@(() => browseOpen = !browseOpen)"
+                   Variant="Variant.Text"
+                   Size="Size.Small"
+                   StartIcon="@(browseOpen ? Icons.Material.Filled.ExpandLess : Icons.Material.Filled.ExpandMore)">
+            @(browseOpen ? "Hide browse" : "Browse all genres")
+        </MudButton>
+        @if (browseOpen)
+        {
+            <MudPaper Elevation="0" Class="mt-1 pa-2" Style="max-height: 320px; overflow-y: auto; border: 1px solid var(--mud-palette-divider);">
+                <MudTreeView T="int"
+                             Items="@treeItems"
+                             SelectionMode="SelectionMode.MultiSelection"
+                             SelectedValues="@selectedSet"
+                             SelectedValuesChanged="OnTreeSelectionChanged"
+                             AutoExpand="true"
+                             Hover="true"
+                             Dense="true" />
+            </MudPaper>
+        }
+    </div>
+</MudStack>
+
+@code {
+    [Parameter, EditorRequired] public List<int> SelectedGenreIds { get; set; } = [];
+    [Parameter] public EventCallback<List<int>> SelectedGenreIdsChanged { get; set; }
+
+    private bool browseOpen;
+    private List<TreeItemData<int>> treeItems = [];
+    private IReadOnlyCollection<int> selectedSet = [];
+
+    protected override async Task OnInitializedAsync()
+    {
+        await VM.InitializeAsync();
+        RebuildTree();
+    }
+
+    protected override void OnParametersSet()
+    {
+        // Keep the tree binding in sync when the parent updates SelectedGenreIds.
+        selectedSet = SelectedGenreIds.ToList();
+        RebuildTree();
+    }
+
+    private void RebuildTree()
+    {
+        treeItems = VM.BuildTreeItems(SelectedGenreIds);
+    }
+
+    private Task<IEnumerable<MudGenrePickerViewModel.GenreRow>> SearchAsync(string query, CancellationToken ct)
+        => Task.FromResult(VM.Search(query, SelectedGenreIds));
+
+    private async Task OnAutocompletePick(MudGenrePickerViewModel.GenreRow? picked)
+    {
+        if (picked is null) return;
+        var next = VM.AddGenre(picked.Id, SelectedGenreIds);
+        await CommitAsync(next);
+    }
+
+    private async Task OnRemoveAsync(int id)
+    {
+        var next = VM.RemoveGenre(id, SelectedGenreIds);
+        await CommitAsync(next);
+    }
+
+    private async Task OnTreeSelectionChanged(IReadOnlyCollection<int> values)
+    {
+        // Tree fires on every tick/untick. Reconcile against current selection,
+        // then run additions through AddGenre so parent auto-selection applies.
+        var current = SelectedGenreIds.ToHashSet();
+        var incoming = values.ToHashSet();
+
+        var next = current.Intersect(incoming).ToList(); // keep still-selected
+        foreach (var newId in incoming.Except(current))
+        {
+            next = VM.AddGenre(newId, next);
+        }
+        await CommitAsync(next);
+    }
+
+    private async Task CommitAsync(List<int> next)
+    {
+        SelectedGenreIds = next;
+        selectedSet = next.ToList();
+        RebuildTree();
+        await SelectedGenreIdsChanged.InvokeAsync(next);
+    }
+}

--- a/BookTracker.Web/Components/Shared/WorkEditDialog.razor
+++ b/BookTracker.Web/Components/Shared/WorkEditDialog.razor
@@ -1,8 +1,6 @@
-@* Modal dialog for editing a single Work's fields (title, subtitle,
-   author with typeahead, first-published date, series + order) from
-   the View page. Genres are deliberately not in this dialog — the
-   hierarchical MudBlazor genre picker is its own future PR, so this
-   dialog links users to /edit for that one field. *@
+@* Modal dialog for editing a single Work's fields from the View page.
+   Covers title, subtitle, author (typeahead), first-published date,
+   series + order, and genres (via MudGenrePicker — PR B). *@
 
 @inject WorkEditDialogViewModel VM
 
@@ -67,9 +65,12 @@
                                      Margin="Margin.Dense"
                                      Min="1" />
                 }
-                <MudText Typo="Typo.caption" Color="Color.Secondary">
-                    Genres are edited on the <MudLink Href="@($"/books/{BookId}/edit")">full edit page</MudLink>.
-                </MudText>
+
+                <div>
+                    <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mb-1">Genres</MudText>
+                    <MudGenrePicker SelectedGenreIds="VM.SelectedGenreIds"
+                                    SelectedGenreIdsChanged="ids => VM.SelectedGenreIds = ids" />
+                </div>
             </MudStack>
         }
     </DialogContent>

--- a/BookTracker.Web/Program.cs
+++ b/BookTracker.Web/Program.cs
@@ -75,6 +75,7 @@ builder.Services.AddTransient<BookFormViewModel>();
 builder.Services.AddTransient<EditionFormViewModel>();
 builder.Services.AddTransient<CopyFormViewModel>();
 builder.Services.AddTransient<GenrePickerViewModel>();
+builder.Services.AddTransient<MudGenrePickerViewModel>();
 builder.Services.AddTransient<BookListViewModel>();
 builder.Services.AddTransient<BookAddViewModel>();
 builder.Services.AddTransient<BookEditViewModel>();

--- a/BookTracker.Web/ViewModels/MudGenrePickerViewModel.cs
+++ b/BookTracker.Web/ViewModels/MudGenrePickerViewModel.cs
@@ -1,0 +1,102 @@
+using BookTracker.Data;
+using Microsoft.EntityFrameworkCore;
+using MudBlazor;
+
+namespace BookTracker.Web.ViewModels;
+
+// Backing VM for the MudBlazor genre picker used in WorkEditDialog.
+// The component has three surfaces (chips, typeahead, collapsible tree)
+// that all manipulate the same SelectedGenreIds set — this VM owns the
+// full genre catalog and the search/projection helpers; selection
+// state is owned by the component (passed in as a parameter, kept
+// in sync via a callback).
+public class MudGenrePickerViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory)
+{
+    public List<GenreRow> AllGenres { get; private set; } = [];
+    private Dictionary<int, GenreRow> _byId = [];
+
+    public async Task InitializeAsync()
+    {
+        await using var db = await dbFactory.CreateDbContextAsync();
+        var rows = await db.Genres
+            .OrderBy(g => g.Name)
+            .Select(g => new { g.Id, g.Name, g.ParentGenreId })
+            .ToListAsync();
+
+        var byId = rows.ToDictionary(r => r.Id, r => r);
+
+        AllGenres = rows.Select(r => new GenreRow(
+            r.Id,
+            r.Name,
+            r.ParentGenreId,
+            r.ParentGenreId is int pid && byId.TryGetValue(pid, out var parent) ? parent.Name : null))
+            .ToList();
+
+        _byId = AllGenres.ToDictionary(g => g.Id);
+    }
+
+    /// <summary>Typeahead — substring match over the flat list, case-insensitive, excludes already-selected.</summary>
+    public IEnumerable<GenreRow> Search(string? query, IReadOnlyCollection<int> alreadySelected)
+    {
+        var q = (query ?? "").Trim();
+        var skip = alreadySelected.ToHashSet();
+        IEnumerable<GenreRow> matches = AllGenres.Where(g => !skip.Contains(g.Id));
+        if (!string.IsNullOrEmpty(q))
+        {
+            matches = matches.Where(g => g.Name.Contains(q, StringComparison.OrdinalIgnoreCase));
+        }
+        return matches.Take(20);
+    }
+
+    /// <summary>The chip label for a genre — "Parent / Leaf" when nested, just "Leaf" for top-level.</summary>
+    public string ChipLabel(int genreId) =>
+        _byId.TryGetValue(genreId, out var g) && g.ParentName is string parent
+            ? $"{parent} / {g.Name}"
+            : _byId.TryGetValue(genreId, out var flat) ? flat.Name : "(unknown)";
+
+    /// <summary>The dropdown label used by the autocomplete — "Parent > Child" when nested, just leaf otherwise.</summary>
+    public string DropdownLabel(GenreRow g) =>
+        g.ParentName is string parent ? $"{parent} > {g.Name}" : g.Name;
+
+    /// <summary>MudTreeView items — top-level parents with children attached.</summary>
+    public List<TreeItemData<int>> BuildTreeItems(IReadOnlyCollection<int> selectedIds)
+    {
+        var selected = selectedIds.ToHashSet();
+        var topLevel = AllGenres.Where(g => g.ParentGenreId is null).OrderBy(g => g.Name).ToList();
+        return topLevel.Select(top => new TreeItemData<int>
+        {
+            Value = top.Id,
+            Text = top.Name,
+            Expandable = AllGenres.Any(g => g.ParentGenreId == top.Id),
+            Children = AllGenres.Where(g => g.ParentGenreId == top.Id)
+                .OrderBy(g => g.Name)
+                .Select(child => new TreeItemData<int>
+                {
+                    Value = child.Id,
+                    Text = child.Name,
+                    Expandable = false,
+                })
+                .ToList<TreeItemData<int>>(),
+        }).ToList();
+    }
+
+    /// <summary>Adds a genre to the selection set. Auto-selects the parent when a child is picked — matches the
+    /// existing Bootstrap picker's behaviour so a "Dictionaries" selection implies "Reference" too.</summary>
+    public List<int> AddGenre(int genreId, IReadOnlyCollection<int> current)
+    {
+        var result = current.ToList();
+        if (!result.Contains(genreId)) result.Add(genreId);
+        if (_byId.TryGetValue(genreId, out var g) && g.ParentGenreId is int parentId && !result.Contains(parentId))
+        {
+            result.Add(parentId);
+        }
+        return result;
+    }
+
+    public List<int> RemoveGenre(int genreId, IReadOnlyCollection<int> current)
+    {
+        return current.Where(id => id != genreId).ToList();
+    }
+
+    public record GenreRow(int Id, string Name, int? ParentGenreId, string? ParentName);
+}

--- a/BookTracker.Web/ViewModels/WorkEditDialogViewModel.cs
+++ b/BookTracker.Web/ViewModels/WorkEditDialogViewModel.cs
@@ -7,9 +7,8 @@ namespace BookTracker.Web.ViewModels;
 
 // Dialog-scoped VM for "Edit work" on the View page. Edits a single
 // Work's title, subtitle, author (find-or-create with typeahead), first
-// published date (PartialDateParser), and series membership + order.
-// Genres stay on the full /edit page in this PR — the hierarchical
-// MudBlazor rebuild is tracked separately.
+// published date (PartialDateParser), series membership + order, and
+// genres (via MudGenrePicker — PR B).
 public class WorkEditDialogViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory)
 {
     public bool NotFound { get; private set; }
@@ -21,6 +20,7 @@ public class WorkEditDialogViewModel(IDbContextFactory<BookTrackerDbContext> dbF
     public string FirstPublishedDate { get; set; } = "";
     public int? SelectedSeriesId { get; set; }
     public int? SeriesOrder { get; set; }
+    public List<int> SelectedGenreIds { get; set; } = [];
 
     public List<SeriesOption> AvailableSeries { get; private set; } = [];
 
@@ -29,7 +29,10 @@ public class WorkEditDialogViewModel(IDbContextFactory<BookTrackerDbContext> dbF
         WorkId = workId;
 
         await using var db = await dbFactory.CreateDbContextAsync();
-        var work = await db.Works.Include(w => w.Author).FirstOrDefaultAsync(w => w.Id == workId);
+        var work = await db.Works
+            .Include(w => w.Author)
+            .Include(w => w.Genres)
+            .FirstOrDefaultAsync(w => w.Id == workId);
         if (work is null) { NotFound = true; return; }
 
         Title = work.Title;
@@ -38,6 +41,7 @@ public class WorkEditDialogViewModel(IDbContextFactory<BookTrackerDbContext> dbF
         FirstPublishedDate = PartialDateParser.Format(work.FirstPublishedDate, work.FirstPublishedDatePrecision);
         SelectedSeriesId = work.SeriesId;
         SeriesOrder = work.SeriesOrder;
+        SelectedGenreIds = work.Genres.Select(g => g.Id).ToList();
 
         AvailableSeries = await db.Series
             .OrderBy(s => s.Name)
@@ -70,7 +74,10 @@ public class WorkEditDialogViewModel(IDbContextFactory<BookTrackerDbContext> dbF
         if (NotFound || string.IsNullOrWhiteSpace(Title) || string.IsNullOrWhiteSpace(AuthorName)) return;
 
         await using var db = await dbFactory.CreateDbContextAsync();
-        var work = await db.Works.Include(w => w.Author).FirstOrDefaultAsync(w => w.Id == WorkId);
+        var work = await db.Works
+            .Include(w => w.Author)
+            .Include(w => w.Genres)
+            .FirstOrDefaultAsync(w => w.Id == WorkId);
         if (work is null) return;
 
         work.Title = Title.Trim();
@@ -83,6 +90,12 @@ public class WorkEditDialogViewModel(IDbContextFactory<BookTrackerDbContext> dbF
 
         work.SeriesId = SelectedSeriesId;
         work.SeriesOrder = SelectedSeriesId.HasValue ? SeriesOrder : null;
+
+        // Reconcile Genres to match the selection. Load requested genres
+        // by id and replace the work's collection.
+        var desired = await db.Genres.Where(g => SelectedGenreIds.Contains(g.Id)).ToListAsync();
+        work.Genres.Clear();
+        foreach (var g in desired) work.Genres.Add(g);
 
         await db.SaveChangesAsync();
     }


### PR DESCRIPTION
New MudGenrePicker component combines three surfaces over a single
SelectedGenreIds source of truth:
- Chips band — closeable chips per selected genre. Label is
  "Parent / Leaf" for sub-genres, bare leaf for top-level.
- MudAutocomplete typeahead — substring match (case-insensitive),
  dropdown shows "Parent > Child" for disambiguation. Excludes
  already-selected.
- Collapsible MudTreeView (closed by default) — browse-all with
  multi-selection. Opens on demand for exploration.

Picking a sub-genre auto-includes its parent (same as the existing
Bootstrap picker — a "Dictionaries" selection implies "Reference").

Wired into WorkEditDialog, replacing the "genres are edited on /edit"
caveat from PR 3. Existing Bootstrap GenrePicker left in place on
/books/add and /books/{id}/edit — "convert as we touch" stays the
rollout strategy; those pages aren't being touched by this PR.

WorkEditDialogViewModel loads existing genre IDs on init and
reconciles Work.Genres to match on save (load-by-id → replace).

MudTreeView note: in MudBlazor 9, SelectionMode="MultiSelection"
handles multi-select without an explicit CheckBoxes attribute (the
analyzer flags CheckBoxes as invalid on the root). Haven't browser-
confirmed the resulting visual; row clicks should toggle selection
either way via the SelectedValues binding.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
