### PR TITLE
fix(infra): always emit AI KV refs + mark secrets slot-sticky

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -65,6 +65,23 @@ All secret App Settings resolve via `@Microsoft.KeyVault(SecretUri=…)` referen
 
 App Service caches resolved KV values; rotating a secret takes effect on the next reference refresh (~24h, or immediate via portal "Refresh Key Vault references").
 
+**KV references are always emitted.** Every deploy writes the four KV-reference app settings above regardless of whether `-AnthropicApiKey` / `-TroveApiKey` is supplied on that run. The reference is stable; the *secret* is only written to Key Vault when the corresponding key param is non-empty. A deploy without the key therefore leaves the existing secret (and reference resolution) untouched. An un-provisioned secret resolves as empty to the app, which silently drops the provider from the picker.
+
+### Slot-sticky settings
+
+The following app settings are marked `slotConfigNames.appSettingNames` so they stay pinned to their slot during a swap (rather than moving with the code):
+
+- `ASPNETCORE_ENVIRONMENT`
+- `MICROSOFT_PROVIDER_AUTHENTICATION_SECRET`
+- `AI__Anthropic__ApiKey`
+- `AI__AzureOpenAI__ApiKey`
+- `AI__AzureOpenAI__Endpoint`
+- `AI__AzureOpenAI__Deployment`
+- `AI__DefaultProvider`
+- `Trove__ApiKey`
+
+Reason: swap-then-redeploy-without-the-key previously let the Anthropic key drift between slots and eventually get lost. Making keys and AI config slot-bound means swaps are purely code-shaped — secrets and environment stay where they were configured.
+
 ## Prereqs
 
 - PowerShell 7+ on Windows.

--- a/infra/modules/app-config.bicep
+++ b/infra/modules/app-config.bicep
@@ -13,12 +13,6 @@ param appInsightsConnectionString string
 @description('Key Vault name. Used to build @Microsoft.KeyVault references for secret app settings.')
 param keyVaultName string
 
-@description('True if the optional Anthropic API key was supplied (and therefore stored in KV). When false the AI__Anthropic__ApiKey setting is omitted.')
-param hasAnthropicKey bool = false
-
-@description('True if the optional Trove API key was supplied (and therefore stored in KV). When false the Trove__ApiKey setting is omitted.')
-param hasTroveKey bool = false
-
 // AI provider config (non-secret values only — secrets resolve via KV refs).
 // MicrosoftFoundry settings are intentionally omitted: this subscription is
 // Sponsored, so Claude on Foundry isn't deployable; the MicrosoftFoundry
@@ -32,6 +26,16 @@ param aiDefaultProvider string = 'Anthropic'
 // identity (which has Key Vault Secrets User role) and caches the resolved
 // value for the lifetime of the worker. Omitting the secret version tells
 // Azure to pick up the latest secret version automatically.
+//
+// References are ALWAYS emitted, regardless of whether a secret has been
+// written to KV yet. An unresolved reference surfaces as an empty string
+// to the app (which reads it as "no key configured" — the provider
+// silently drops out of the picker). The reason we always emit it: a
+// re-deploy without `-AnthropicApiKey` / `-TroveApiKey` used to *remove*
+// the app setting entirely, because it was conditional on the deploy
+// param. That left the app without any reference to pick up the secret
+// on next restart, and a subsequent slot-swap (without the setting on
+// both slots) moved the hole around unpredictably.
 #disable-next-line no-hardcoded-env-urls
 var kvBase = 'https://${keyVaultName}.vault.azure.net/secrets'
 var authClientSecretRef = '@Microsoft.KeyVault(SecretUri=${kvBase}/AuthClientSecret/)'
@@ -39,9 +43,10 @@ var openAIKeyRef = '@Microsoft.KeyVault(SecretUri=${kvBase}/AIAzureOpenAIApiKey/
 var anthropicKeyRef = '@Microsoft.KeyVault(SecretUri=${kvBase}/AIAnthropicApiKey/)'
 var troveKeyRef = '@Microsoft.KeyVault(SecretUri=${kvBase}/TroveApiKey/)'
 
-// Build app settings as a single object so prod and staging stay in sync.
-// Conditional members let us omit Anthropic when no key was provided.
-var baseAppSettings = {
+// Same shape for prod + staging; slotConfigNames below marks the secret-ish
+// entries as slot-sticky so swaps don't move them if the two slots' values
+// ever diverge.
+var appSettingsValues = {
   ASPNETCORE_ENVIRONMENT: 'Production'
   APPLICATIONINSIGHTS_CONNECTION_STRING: appInsightsConnectionString
   MICROSOFT_PROVIDER_AUTHENTICATION_SECRET: authClientSecretRef
@@ -49,9 +54,25 @@ var baseAppSettings = {
   AI__AzureOpenAI__Endpoint: aiAzureOpenAIEndpoint
   AI__AzureOpenAI__ApiKey: openAIKeyRef
   AI__AzureOpenAI__Deployment: aiAzureOpenAIDeployment
+  AI__Anthropic__ApiKey: anthropicKeyRef
+  Trove__ApiKey: troveKeyRef
 }
-var withAnthropic = hasAnthropicKey ? union(baseAppSettings, { AI__Anthropic__ApiKey: anthropicKeyRef }) : baseAppSettings
-var appSettingsValues = hasTroveKey ? union(withAnthropic, { Trove__ApiKey: troveKeyRef }) : withAnthropic
+
+// Settings that must stay pinned to their slot during a swap. Keys and
+// environment-flavoured values should never hop between prod and staging,
+// even if today they happen to be identical. Azure's slot swap moves any
+// setting NOT in this list with the code; listing them here is the only
+// way to make them slot-bound.
+var slotStickyAppSettingNames = [
+  'ASPNETCORE_ENVIRONMENT'
+  'MICROSOFT_PROVIDER_AUTHENTICATION_SECRET'
+  'AI__Anthropic__ApiKey'
+  'AI__AzureOpenAI__ApiKey'
+  'AI__AzureOpenAI__Endpoint'
+  'AI__AzureOpenAI__Deployment'
+  'AI__DefaultProvider'
+  'Trove__ApiKey'
+]
 
 // Paths served publicly (without Easy Auth). Limited to the PWA assets
 // Chrome/Safari fetch without credentials during the install-validation
@@ -84,6 +105,16 @@ resource appSettings 'Microsoft.Web/sites/config@2023-12-01' = {
   parent: app
   name: 'appsettings'
   properties: appSettingsValues
+}
+
+// Slot-sticky setting names. Attached to the production site (not the slot)
+// per Azure's model — a single list governs swap behaviour for all slots.
+resource slotConfigNames 'Microsoft.Web/sites/config@2023-12-01' = {
+  parent: app
+  name: 'slotConfigNames'
+  properties: {
+    appSettingNames: slotStickyAppSettingNames
+  }
 }
 
 resource connStrings 'Microsoft.Web/sites/config@2023-12-01' = {

--- a/infra/modules/resources.bicep
+++ b/infra/modules/resources.bicep
@@ -203,8 +203,6 @@ module appConfig './app-config.bicep' = {
     sqlDatabaseName: sqlDatabaseName
     appInsightsConnectionString: obs.outputs.appInsightsConnectionString
     keyVaultName: keyVaultName
-    hasAnthropicKey: !empty(anthropicApiKey)
-    hasTroveKey: !empty(troveApiKey)
     aiAzureOpenAIEndpoint: ai.outputs.openAIEndpoint
     aiAzureOpenAIDeployment: ai.outputs.openAIDeploymentName
   }


### PR DESCRIPTION
Two compounding issues made the Anthropic key vanish on repeat
slot swaps:

1. app-config.bicep gated the AI__Anthropic__ApiKey / Trove__ApiKey
   app settings on `hasAnthropicKey` / `hasTroveKey`, which was
   `!empty(anthropicApiKey)` — so any deploy run WITHOUT the key
   param rewrote the app settings WITHOUT the KV reference. The
   existing KV secret stayed, but the app setting referencing it
   was stripped, so the app lost the provider on next restart.
2. No settings were marked slot-sticky (no slotConfigNames
   resource), so secrets and AI endpoints swapped freely between
   slots. Combined with (1), even slots that had the setting
   could end up hosting the code that expected it to be absent.

Fix:
- Drop the hasAnthropicKey / hasTroveKey params from
  app-config.bicep; always emit every KV reference. An unresolved
  reference (secret never written) surfaces as empty to the app —
  which the provider factory reads as "not configured" and silently
  drops. The KV secrets themselves remain conditional in
  keyvault.bicep (only written when the key param is non-empty),
  so re-deploys without the key don't overwrite an existing secret.
- Add a slotConfigNames resource marking the secret-ish settings
  as slot-sticky (ASPNETCORE_ENVIRONMENT, the auth client secret,
  both AI provider keys, AI endpoints, default provider, Trove
  key). Swaps now move the code between slots without dragging
  secrets or per-slot config with them.
- resources.bicep stops passing the dropped flags.
- infra/README.md documents both behaviours.

Bicep compiles clean. Can't verify end-to-end from here — next
deploy + swap is the real test.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
