### PR TITLE
fix(shopping): load Work.Author in ISBN + book-select lookups

### DIFF
--- a/BookTracker.Tests/ViewModels/ShoppingViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/ShoppingViewModelTests.cs
@@ -1,0 +1,88 @@
+using BookTracker.Data.Models;
+using BookTracker.Web.ViewModels;
+
+namespace BookTracker.Tests.ViewModels;
+
+public class ShoppingViewModelTests
+{
+    [Fact]
+    public async Task SearchByIsbnAsync_ExistingBook_PopulatesAuthorWithoutCrashing()
+    {
+        // Regression for the NullReferenceException that surfaced on the
+        // Shopping page when an ISBN matched an existing edition. The query
+        // was missing .Include(w => w.Author), so PrimaryAuthor dereferenced
+        // a null navigation property. This test seeds a book + edition and
+        // ensures the result comes back with the author populated.
+        var factory = new TestDbContextFactory();
+        const string isbn = "9780552131063";
+
+        using (var db = factory.CreateDbContext())
+        {
+            var author = new Author { Name = "Terry Pratchett" };
+            var book = new Book
+            {
+                Title = "Mort",
+                Works = [new Work { Title = "Mort", Author = author }],
+                Editions =
+                [
+                    new Edition
+                    {
+                        Isbn = isbn,
+                        Format = BookFormat.MassMarketPaperback,
+                        Copies = [new Copy { Condition = BookCondition.Good }],
+                    }
+                ],
+            };
+            db.Books.Add(book);
+            await db.SaveChangesAsync();
+        }
+
+        var vm = new ShoppingViewModel(factory);
+        await vm.SearchByIsbnAsync(isbn);
+
+        Assert.NotNull(vm.Result);
+        Assert.True(vm.Result!.Found);
+        Assert.Equal("Terry Pratchett", vm.Result.Author);
+        Assert.Equal("Mort", vm.Result.Title);
+        Assert.Equal(1, vm.Result.CopyCount);
+    }
+
+    [Fact]
+    public async Task SearchByIsbnAsync_NoMatch_ReturnsNotFound()
+    {
+        var factory = new TestDbContextFactory();
+        var vm = new ShoppingViewModel(factory);
+        await vm.SearchByIsbnAsync("0000000000000");
+
+        Assert.NotNull(vm.Result);
+        Assert.False(vm.Result!.Found);
+    }
+
+    [Fact]
+    public async Task SelectBookAsync_PopulatesAuthorWithoutCrashing()
+    {
+        // Same regression surface as SearchByIsbnAsync — SelectBookAsync
+        // also loaded Works without Authors.
+        var factory = new TestDbContextFactory();
+        int bookId;
+
+        using (var db = factory.CreateDbContext())
+        {
+            var book = new Book
+            {
+                Title = "Good Omens",
+                Works = [new Work { Title = "Good Omens", Author = new Author { Name = "Terry Pratchett & Neil Gaiman" } }],
+                Editions = [new Edition { Isbn = "x", Copies = [new Copy { Condition = BookCondition.Good }] }],
+            };
+            db.Books.Add(book);
+            await db.SaveChangesAsync();
+            bookId = book.Id;
+        }
+
+        var vm = new ShoppingViewModel(factory);
+        await vm.SelectBookAsync(bookId);
+
+        Assert.NotNull(vm.Result);
+        Assert.Equal("Terry Pratchett & Neil Gaiman", vm.Result!.Author);
+    }
+}

--- a/BookTracker.Web/ViewModels/ShoppingViewModel.cs
+++ b/BookTracker.Web/ViewModels/ShoppingViewModel.cs
@@ -85,6 +85,8 @@ public class ShoppingViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
             var editions = await db.Editions
                 .Include(e => e.Book)
                     .ThenInclude(b => b.Works).ThenInclude(w => w.Series)
+                .Include(e => e.Book)
+                    .ThenInclude(b => b.Works).ThenInclude(w => w.Author)
                 .Include(e => e.Copies)
                 .Where(e => e.Isbn == isbn)
                 .ToListAsync();
@@ -194,6 +196,7 @@ public class ShoppingViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
             .Include(b => b.Editions)
                 .ThenInclude(e => e.Copies)
             .Include(b => b.Works).ThenInclude(w => w.Series)
+            .Include(b => b.Works).ThenInclude(w => w.Author)
             .FirstOrDefaultAsync(b => b.Id == bookId);
 
         if (book is null) return;
@@ -211,9 +214,19 @@ public class ShoppingViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
 
     // For display in shopping search results — most books have a single Work
     // and therefore a single author, but compendiums may span several. Comma-
-    // join to keep things readable.
+    // join to keep things readable. Null-tolerant on Author because every
+    // caller is expected to Include(w => w.Author) but forgetting has
+    // shipped a user-visible NullReferenceException in the past — here we
+    // degrade to "(unknown)" rather than crashing the lookup.
     private static string PrimaryAuthor(Book book)
-        => string.Join(", ", book.Works.Select(w => w.Author.Name).Distinct());
+    {
+        var names = book.Works
+            .Select(w => string.IsNullOrWhiteSpace(w.Author?.Name) ? null : w.Author!.Name)
+            .Where(n => n is not null)
+            .Distinct()
+            .ToList();
+        return names.Count > 0 ? string.Join(", ", names) : "(unknown)";
+    }
 
     private static async Task<SeriesInfo?> GetSeriesInfoAsync(BookTrackerDbContext db, Book book)
     {


### PR DESCRIPTION
SearchByIsbnAsync and SelectBookAsync loaded Book.Works but never
Include'd Author on each Work, so PrimaryAuthor's w.Author.Name
dereferenced a null navigation and the lookup crashed with a
NullReferenceException on any ISBN that matched an existing book.
(SearchByTextAsync was correct — it had the Include — which is why
typing a title worked while typing or scanning an ISBN broke the
Shopping page.)

Fix:
- Add .Include(b => b.Works).ThenInclude(w => w.Author) to both
  previously-broken queries.
- Harden PrimaryAuthor itself against null authors — return
  "(unknown)" if every Work.Author was null, filter nulls when
  joining. Callers are still expected to Include the navigation;
  this is defence against "we already shipped this bug once, stop
  letting it be catastrophic next time."

Regression tests cover both call sites and the not-found path.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
