### PR TITLE
feat(ui): mobile navbar auto-close + clickable Home tiles

### DIFF
--- a/BookTracker.Web/Components/App.razor
+++ b/BookTracker.Web/Components/App.razor
@@ -41,6 +41,7 @@
     <script src="@Assets["lib/html5-qrcode/html5-qrcode.min.js"]"></script>
     <script src="@Assets["js/barcode-scanner.js"]"></script>
     <script src="@Assets["js/photo-capture.js"]"></script>
+    <script src="@Assets["js/navbar-collapse.js"]"></script>
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>
     <script src="@Assets["service-worker-register.js"]"></script>
 </body>

--- a/BookTracker.Web/Components/Layout/MainLayout.razor
+++ b/BookTracker.Web/Components/Layout/MainLayout.razor
@@ -1,5 +1,8 @@
 @using BookTracker.Web.Theme
 @inherits LayoutComponentBase
+@implements IDisposable
+@inject NavigationManager Nav
+@inject IJSRuntime JS
 
 @* MudBlazor — root providers. Needed so any page using MudBlazor
    components (currently only pilot pages: Home + MergeBook) can dispatch
@@ -71,3 +74,22 @@
     <a href="." class="reload">Reload</a>
     <span class="dismiss">🗙</span>
 </div>
+
+@code {
+    protected override void OnInitialized()
+    {
+        // Close the mobile Bootstrap navbar collapse on every navigation.
+        // Without this the full-viewport open menu stays up after a tap
+        // and the user lands on the new page off-screen below the nav.
+        Nav.LocationChanged += OnLocationChanged;
+    }
+
+    private async void OnLocationChanged(object? sender, LocationChangedEventArgs e)
+    {
+        try { await JS.InvokeVoidAsync("NavbarCollapse.close"); }
+        catch (JSDisconnectedException) { /* circuit tearing down — nothing to do */ }
+        catch (TaskCanceledException) { /* ditto */ }
+    }
+
+    public void Dispose() => Nav.LocationChanged -= OnLocationChanged;
+}

--- a/BookTracker.Web/Components/Pages/Home.razor
+++ b/BookTracker.Web/Components/Pages/Home.razor
@@ -1,5 +1,6 @@
 @page "/"
 @inject HomeViewModel VM
+@inject NavigationManager Nav
 
 <PageTitle>Home - BookTracker</PageTitle>
 
@@ -86,7 +87,7 @@
 
     <MudGrid Spacing="3" Class="mb-4">
         <MudItem xs="12" sm="6">
-            <MudCard Elevation="2" Class="h-100">
+            <MudCard Elevation="2" Class="h-100 clickable-tile" @onclick='@(() => Nav.NavigateTo("/books"))' role="link" tabindex="0">
                 <MudCardContent>
                     <MudStack Row AlignItems="AlignItems.Center" Spacing="3">
                         <MudText Typo="Typo.h3" Class="mud-text-secondary">📚</MudText>
@@ -99,7 +100,7 @@
             </MudCard>
         </MudItem>
         <MudItem xs="12" sm="6">
-            <MudCard Elevation="2" Class="h-100">
+            <MudCard Elevation="2" Class="h-100 clickable-tile" @onclick='@(() => Nav.NavigateTo("/authors"))' role="link" tabindex="0">
                 <MudCardContent>
                     <MudStack Row AlignItems="AlignItems.Center" Spacing="3">
                         <MudText Typo="Typo.h3" Class="mud-text-secondary">✍️</MudText>

--- a/BookTracker.Web/wwwroot/css/site.css
+++ b/BookTracker.Web/wwwroot/css/site.css
@@ -119,4 +119,16 @@ body {
   .scanner-container video {
     max-height: 170px;
   }
+
+/* Home page stat tiles — rendered with MudCard + @onclick for nav. The
+   cursor + hover lift give the user a visual affordance that the tile
+   acts as a link. role="link" on the card itself carries the semantics
+   for assistive tech. */
+.clickable-tile {
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+.clickable-tile:hover {
+  transform: translateY(-2px);
+}
 }

--- a/BookTracker.Web/wwwroot/js/navbar-collapse.js
+++ b/BookTracker.Web/wwwroot/js/navbar-collapse.js
@@ -1,0 +1,14 @@
+// Closes the mobile Bootstrap navbar collapse when called. Invoked from
+// MainLayout's NavigationManager.LocationChanged subscription so the
+// hamburger menu closes itself after a nav link tap — otherwise the
+// full-viewport open menu stays up and the user has to scroll back to
+// see the page they landed on.
+window.NavbarCollapse = {
+    close: function () {
+        document.querySelectorAll('.navbar-collapse.show').forEach(el => {
+            const instance = window.bootstrap?.Collapse?.getInstance(el)
+                ?? new window.bootstrap.Collapse(el, { toggle: false });
+            instance.hide();
+        });
+    }
+};


### PR DESCRIPTION
Three small mobile-UX polish fixes:

1. The Bootstrap mobile navbar stayed expanded after tapping a nav
   link — since Blazor Server doesn't full-page-reload, the collapsed
   state persisted client-side and the full-viewport menu covered
   whatever page the user had just navigated to. Now MainLayout
   subscribes to NavigationManager.LocationChanged and calls a small
   NavbarCollapse.close JS helper on every nav, closing any open
   .navbar-collapse via Bootstrap's Collapse API.
2. The Home page "Books in collection" tile is now clickable and
   navigates to /books. Cursor + subtle lift on hover signal
   affordance; role="link" + tabindex carry the semantics for
   assistive tech.
3. Same treatment for the "Unique authors" tile → /authors.

Tweak 4 (top-10 author list click-through → Authors page drill-down)
is scoped to a follow-up PR that also rebuilds the Authors page in
MudBlazor with per-row works/books expansion.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
