### PR TITLE
feat(authors): MudBlazor rewrite + per-row works/books drill-down

### DIFF
--- a/BookTracker.Tests/ViewModels/AuthorListViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/AuthorListViewModelTests.cs
@@ -1,0 +1,159 @@
+using BookTracker.Data.Models;
+using BookTracker.Web.ViewModels;
+
+namespace BookTracker.Tests.ViewModels;
+
+public class AuthorListViewModelTests
+{
+    [Fact]
+    public async Task LoadAsync_PopulatesAuthorRows()
+    {
+        var factory = new TestDbContextFactory();
+        using (var db = factory.CreateDbContext())
+        {
+            var king = new Author { Name = "Stephen King" };
+            var bachman = new Author { Name = "Richard Bachman", CanonicalAuthor = king };
+            db.Authors.AddRange(king, bachman);
+            db.Books.Add(new Book { Title = "Carrie", Works = [new Work { Title = "Carrie", Author = king }] });
+            db.Books.Add(new Book { Title = "Thinner", Works = [new Work { Title = "Thinner", Author = bachman }] });
+            await db.SaveChangesAsync();
+        }
+
+        var vm = new AuthorListViewModel(factory);
+        await vm.LoadAsync();
+
+        Assert.Equal(2, vm.Authors.Count);
+        var kingRow = vm.Authors.Single(a => a.Name == "Stephen King");
+        Assert.Null(kingRow.CanonicalAuthorId);
+        var bachmanRow = vm.Authors.Single(a => a.Name == "Richard Bachman");
+        Assert.Equal(kingRow.Id, bachmanRow.CanonicalAuthorId);
+    }
+
+    [Fact]
+    public async Task ToggleExpandAsync_CanonicalRollsUpAliasWorks()
+    {
+        var factory = new TestDbContextFactory();
+        int kingId;
+        using (var db = factory.CreateDbContext())
+        {
+            var king = new Author { Name = "Stephen King" };
+            var bachman = new Author { Name = "Richard Bachman", CanonicalAuthor = king };
+            db.Authors.AddRange(king, bachman);
+            db.Books.Add(new Book { Title = "Carrie", Works = [new Work { Title = "Carrie", Author = king }] });
+            db.Books.Add(new Book { Title = "Thinner", Works = [new Work { Title = "Thinner", Author = bachman }] });
+            await db.SaveChangesAsync();
+            kingId = king.Id;
+        }
+
+        var vm = new AuthorListViewModel(factory);
+        await vm.LoadAsync();
+        await vm.ToggleExpandAsync(kingId);
+
+        Assert.Contains(kingId, vm.ExpandedAuthorIds);
+        var detail = vm.DetailByAuthorId[kingId];
+        Assert.Equal(2, detail.Works.Count);
+        Assert.Contains(detail.Works, w => w.Title == "Carrie");
+        Assert.Contains(detail.Works, w => w.Title == "Thinner");
+        Assert.Contains("Richard Bachman", detail.AliasNames);
+
+        // The Bachman work should be flagged with WrittenAs, the King one shouldn't.
+        Assert.Equal("Richard Bachman", detail.Works.Single(w => w.Title == "Thinner").WrittenAs);
+        Assert.Null(detail.Works.Single(w => w.Title == "Carrie").WrittenAs);
+    }
+
+    [Fact]
+    public async Task ToggleExpandAsync_AliasRowShowsOnlyOwnWorks()
+    {
+        var factory = new TestDbContextFactory();
+        int bachmanId;
+        using (var db = factory.CreateDbContext())
+        {
+            var king = new Author { Name = "Stephen King" };
+            var bachman = new Author { Name = "Richard Bachman", CanonicalAuthor = king };
+            db.Authors.AddRange(king, bachman);
+            db.Books.Add(new Book { Title = "Carrie", Works = [new Work { Title = "Carrie", Author = king }] });
+            db.Books.Add(new Book { Title = "Thinner", Works = [new Work { Title = "Thinner", Author = bachman }] });
+            await db.SaveChangesAsync();
+            bachmanId = bachman.Id;
+        }
+
+        var vm = new AuthorListViewModel(factory);
+        await vm.LoadAsync();
+        await vm.ToggleExpandAsync(bachmanId);
+
+        var detail = vm.DetailByAuthorId[bachmanId];
+        Assert.Single(detail.Works);
+        Assert.Equal("Thinner", detail.Works[0].Title);
+        Assert.Empty(detail.AliasNames); // alias rows don't roll anything up
+        Assert.Null(detail.Works[0].WrittenAs); // no "as X" label on alias-own rows
+    }
+
+    [Fact]
+    public async Task ToggleExpandAsync_SecondCallCollapsesWithoutReload()
+    {
+        var factory = new TestDbContextFactory();
+        int authorId;
+        using (var db = factory.CreateDbContext())
+        {
+            var author = new Author { Name = "A" };
+            db.Authors.Add(author);
+            db.Books.Add(new Book { Title = "B", Works = [new Work { Title = "W", Author = author }] });
+            await db.SaveChangesAsync();
+            authorId = author.Id;
+        }
+
+        var vm = new AuthorListViewModel(factory);
+        await vm.LoadAsync();
+        await vm.ToggleExpandAsync(authorId);
+        Assert.Contains(authorId, vm.ExpandedAuthorIds);
+        Assert.True(vm.DetailByAuthorId.ContainsKey(authorId));
+
+        await vm.ToggleExpandAsync(authorId);
+        Assert.DoesNotContain(authorId, vm.ExpandedAuthorIds);
+        // Detail cache survives the collapse — a later re-expand reuses it.
+        Assert.True(vm.DetailByAuthorId.ContainsKey(authorId));
+    }
+
+    [Fact]
+    public async Task GetViewMode_DefaultsToWorks_SetViewMode_Sticks()
+    {
+        var factory = new TestDbContextFactory();
+        var vm = new AuthorListViewModel(factory);
+
+        Assert.Equal(AuthorListViewModel.AuthorViewMode.Works, vm.GetViewMode(42));
+        vm.SetViewMode(42, AuthorListViewModel.AuthorViewMode.Books);
+        Assert.Equal(AuthorListViewModel.AuthorViewMode.Books, vm.GetViewMode(42));
+    }
+
+    [Fact]
+    public async Task MarkAsAliasAsync_InvalidatesDetailCache()
+    {
+        // Structural change (mark X as alias of Y) should drop any cached
+        // detail for X and Y so the next expand picks up the new roll-up.
+        var factory = new TestDbContextFactory();
+        int kingId;
+        int bachmanId;
+        using (var db = factory.CreateDbContext())
+        {
+            var king = new Author { Name = "Stephen King" };
+            var bachman = new Author { Name = "Richard Bachman" }; // NOT an alias yet
+            db.Authors.AddRange(king, bachman);
+            db.Books.Add(new Book { Title = "Carrie", Works = [new Work { Title = "Carrie", Author = king }] });
+            db.Books.Add(new Book { Title = "Thinner", Works = [new Work { Title = "Thinner", Author = bachman }] });
+            await db.SaveChangesAsync();
+            kingId = king.Id;
+            bachmanId = bachman.Id;
+        }
+
+        var vm = new AuthorListViewModel(factory);
+        await vm.LoadAsync();
+        await vm.ToggleExpandAsync(kingId);
+        Assert.Single(vm.DetailByAuthorId[kingId].Works); // Carrie only
+
+        await vm.MarkAsAliasAsync(bachmanId, kingId);
+
+        Assert.False(vm.DetailByAuthorId.ContainsKey(kingId));
+        await vm.ExpandAsync(kingId);
+        Assert.Equal(2, vm.DetailByAuthorId[kingId].Works.Count); // now includes Thinner
+    }
+}

--- a/BookTracker.Web/Components/Pages/Authors/Index.razor
+++ b/BookTracker.Web/Components/Pages/Authors/Index.razor
@@ -1,108 +1,277 @@
 @page "/authors"
 @inject AuthorListViewModel VM
+@inject NavigationManager Nav
 
 <PageTitle>Authors - BookTracker</PageTitle>
 
-<h1 class="mb-3">Authors</h1>
-<p class="text-muted">
-    Each author has its own row. Pen names are linked back to a canonical author so aggregations
-    (top-authors stats, author filter) roll the totals together. Stephen King's tally includes
-    his Bachman titles when you mark Bachman as an alias of King.
-</p>
+@* MudBlazor rewrite. Each author row expands to a drill-down showing
+   either the author's Works or the Books containing them (per-row
+   toggle). Canonical rows roll up any aliases — Stephen King's
+   drill-down includes Bachman titles. A deep link from Home
+   (/authors?expand=<id>) pre-opens the matching row. *@
 
-@if (!string.IsNullOrEmpty(VM.SuccessMessage))
-{
-    <div class="alert alert-success alert-dismissible fade show" role="alert">
-        @VM.SuccessMessage
-        <button type="button" class="btn-close" @onclick="() => VM.SuccessMessage = null" aria-label="Close"></button>
-    </div>
-}
+<MudContainer MaxWidth="MaxWidth.Large" Class="py-3">
 
-@if (VM.Loading)
-{
-    <div class="text-center py-5">
-        <div class="spinner-border" role="status"><span class="visually-hidden">Loading...</span></div>
-    </div>
-}
-else if (VM.Authors.Count == 0)
-{
-    <p class="text-muted">No authors yet — add a book to seed the list.</p>
-}
-else
-{
-    <div class="table-responsive">
-        <table class="table table-sm align-middle">
-            <thead class="table-light">
-                <tr>
-                    <th>Name</th>
-                    <th>Status</th>
-                    <th class="text-end" style="width: 80px;">Works</th>
-                    <th style="width: 360px;">Actions</th>
-                </tr>
-            </thead>
-            <tbody>
-                @foreach (var author in VM.Authors)
-                {
-                    <tr>
-                        <td>
-                            @if (editingId == author.Id)
-                            {
-                                <div class="input-group input-group-sm" style="max-width: 300px;">
-                                    <input type="text" class="form-control" @bind="editingName" />
-                                    <button type="button" class="btn btn-outline-success" @onclick="() => SaveRenameAsync(author.Id)">Save</button>
-                                    <button type="button" class="btn btn-outline-secondary" @onclick="() => editingId = null">Cancel</button>
-                                </div>
-                            }
-                            else
-                            {
-                                <span class="fw-semibold">@author.Name</span>
-                            }
-                        </td>
-                        <td>
-                            @if (author.CanonicalAuthorId.HasValue)
-                            {
-                                <span class="badge bg-info text-dark">alias of @author.CanonicalName</span>
-                            }
-                            else
-                            {
-                                <span class="badge bg-light text-dark border">canonical</span>
-                            }
-                        </td>
-                        <td class="text-end">@author.WorkCount</td>
-                        <td>
-                            <div class="d-flex gap-2 align-items-center">
-                                @if (editingId != author.Id)
-                                {
-                                    <button type="button" class="btn btn-sm btn-outline-secondary" @onclick="() => StartRename(author)">Rename</button>
-                                }
+    <MudText Typo="Typo.h4" Class="mb-2">Authors</MudText>
+    <MudText Typo="Typo.body2" Color="Color.Secondary" Class="mb-3">
+        Each author has its own row. Pen names are linked back to a canonical author so aggregations
+        (top-authors stats, author filter) roll the totals together. Stephen King's tally includes
+        his Bachman titles when you mark Bachman as an alias of King.
+    </MudText>
+
+    @if (!string.IsNullOrEmpty(VM.SuccessMessage))
+    {
+        <MudAlert Severity="Severity.Success"
+                  ShowCloseIcon="true"
+                  CloseIconClicked="@(() => { VM.SuccessMessage = null; StateHasChanged(); })"
+                  Class="mb-3">@VM.SuccessMessage</MudAlert>
+    }
+
+    @if (VM.Loading)
+    {
+        <MudStack AlignItems="AlignItems.Center" Class="py-5">
+            <MudProgressCircular Indeterminate="true" />
+        </MudStack>
+    }
+    else if (VM.Authors.Count == 0)
+    {
+        <MudText Color="Color.Secondary">No authors yet — add a book to seed the list.</MudText>
+    }
+    else
+    {
+        <MudPaper Elevation="1">
+            @foreach (var author in VM.Authors)
+            {
+                var expanded = VM.ExpandedAuthorIds.Contains(author.Id);
+                <div class="author-row">
+                    <MudStack Row="true"
+                              Spacing="2"
+                              AlignItems="AlignItems.Center"
+                              Wrap="Wrap.Wrap"
+                              Class="pa-3"
+                              Style="cursor: pointer;"
+                              @onclick="@(() => OnToggleExpandAsync(author.Id))">
+                        <MudIcon Icon="@(expanded ? Icons.Material.Filled.ExpandLess : Icons.Material.Filled.ExpandMore)" Size="Size.Small" />
+                        <MudText Typo="Typo.body1" Class="flex-grow-1" Style="font-weight: 500;">@author.Name</MudText>
+                        @if (author.CanonicalAuthorId.HasValue)
+                        {
+                            <MudChip T="string" Size="Size.Small" Color="Color.Info" Variant="Variant.Text">
+                                alias of @author.CanonicalName
+                            </MudChip>
+                        }
+                        else
+                        {
+                            <MudChip T="string" Size="Size.Small" Variant="Variant.Text">canonical</MudChip>
+                        }
+                        <MudText Typo="Typo.body2" Color="Color.Secondary" Style="min-width: 60px; text-align: right;">
+                            @author.WorkCount work@(author.WorkCount == 1 ? "" : "s")
+                        </MudText>
+                    </MudStack>
+
+                    @* Action row — rename + alias-management. stopPropagation keeps
+                       clicks here from re-toggling the row. *@
+                    <div @onclick:stopPropagation="true" class="px-3 pb-3">
+                        @if (editingId == author.Id)
+                        {
+                            <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center">
+                                <MudTextField T="string" @bind-Value="editingName" Variant="Variant.Outlined" Margin="Margin.Dense" Style="max-width: 320px;" />
+                                <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Primary" OnClick="@(() => SaveRenameAsync(author.Id))">Save</MudButton>
+                                <MudButton Size="Size.Small" Variant="Variant.Text" OnClick="@(() => editingId = null)">Cancel</MudButton>
+                            </MudStack>
+                        }
+                        else
+                        {
+                            <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center" Wrap="Wrap.Wrap">
+                                <MudButton Size="Size.Small" Variant="Variant.Outlined" StartIcon="@Icons.Material.Filled.Edit"
+                                           OnClick="@(() => StartRename(author))">Rename</MudButton>
                                 @if (author.CanonicalAuthorId.HasValue)
                                 {
-                                    <button type="button" class="btn btn-sm btn-outline-primary" @onclick="() => VM.PromoteToCanonicalAsync(author.Id)">Promote to canonical</button>
+                                    <MudButton Size="Size.Small" Variant="Variant.Outlined" StartIcon="@Icons.Material.Filled.Upgrade"
+                                               OnClick="@(() => VM.PromoteToCanonicalAsync(author.Id))">
+                                        Promote to canonical
+                                    </MudButton>
                                 }
                                 else
                                 {
-                                    <select class="form-select form-select-sm" style="width: 220px;" @onchange="e => MarkAsAliasAsync(author.Id, e)">
-                                        <option value="">Mark as alias of…</option>
+                                    <MudSelect T="int?"
+                                               Value="null"
+                                               ValueChanged="@(async (int? id) => { if (id is int cid) await VM.MarkAsAliasAsync(author.Id, cid); })"
+                                               Label="Mark as alias of…"
+                                               Variant="Variant.Outlined"
+                                               Margin="Margin.Dense"
+                                               Dense="true"
+                                               Style="max-width: 260px;">
                                         @foreach (var canonical in VM.CanonicalAuthors.Where(c => c.Id != author.Id))
                                         {
-                                            <option value="@canonical.Id">@canonical.Name</option>
+                                            <MudSelectItem T="int?" Value="@((int?)canonical.Id)">@canonical.Name</MudSelectItem>
                                         }
-                                    </select>
+                                    </MudSelect>
                                 }
-                            </div>
-                        </td>
-                    </tr>
-                }
-            </tbody>
-        </table>
-    </div>
-}
+                            </MudStack>
+                        }
+                    </div>
+
+                    @if (expanded)
+                    {
+                        <div @onclick:stopPropagation="true" class="px-3 pb-3">
+                            @if (!VM.DetailByAuthorId.TryGetValue(author.Id, out var detail))
+                            {
+                                <MudStack AlignItems="AlignItems.Center" Class="py-3">
+                                    <MudProgressCircular Indeterminate="true" Size="Size.Small" />
+                                </MudStack>
+                            }
+                            else
+                            {
+                                var view = VM.GetViewMode(author.Id);
+
+                                @if (detail.AliasNames.Count > 0)
+                                {
+                                    <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mb-2">
+                                        Including @detail.AliasNames.Count alias@(detail.AliasNames.Count == 1 ? "" : "es"):
+                                        @string.Join(", ", detail.AliasNames)
+                                    </MudText>
+                                }
+
+                                <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center" Class="mb-2">
+                                    <MudChip T="AuthorListViewModel.AuthorViewMode"
+                                             Size="Size.Small"
+                                             OnClick="@(() => SetView(author.Id, AuthorListViewModel.AuthorViewMode.Works))"
+                                             Color="@(view == AuthorListViewModel.AuthorViewMode.Works ? Color.Primary : Color.Default)"
+                                             Variant="@(view == AuthorListViewModel.AuthorViewMode.Works ? Variant.Filled : Variant.Outlined)">
+                                        Works (@detail.Works.Count)
+                                    </MudChip>
+                                    <MudChip T="AuthorListViewModel.AuthorViewMode"
+                                             Size="Size.Small"
+                                             OnClick="@(() => SetView(author.Id, AuthorListViewModel.AuthorViewMode.Books))"
+                                             Color="@(view == AuthorListViewModel.AuthorViewMode.Books ? Color.Primary : Color.Default)"
+                                             Variant="@(view == AuthorListViewModel.AuthorViewMode.Books ? Variant.Filled : Variant.Outlined)">
+                                        Books (@detail.Books.Count)
+                                    </MudChip>
+                                </MudStack>
+
+                                @if (view == AuthorListViewModel.AuthorViewMode.Works)
+                                {
+                                    @if (detail.Works.Count == 0)
+                                    {
+                                        <MudText Typo="Typo.body2" Color="Color.Secondary">No works recorded for this author.</MudText>
+                                    }
+                                    else
+                                    {
+                                        <MudList T="int" Dense="true" Class="pa-0">
+                                            @foreach (var w in detail.Works)
+                                            {
+                                                <MudListItem T="int" Class="px-2">
+                                                    <MudStack Spacing="0">
+                                                        <MudStack Row="true" Spacing="2" Wrap="Wrap.Wrap">
+                                                            @if (w.SeriesOrder is int so)
+                                                            {
+                                                                <MudText Typo="Typo.body2" Color="Color.Secondary">#@so</MudText>
+                                                            }
+                                                            <MudText Typo="Typo.body1" Style="font-weight: 500;">@w.Title</MudText>
+                                                            @if (!string.IsNullOrEmpty(w.WrittenAs))
+                                                            {
+                                                                <MudChip T="string" Size="Size.Small" Variant="Variant.Text" Color="Color.Info">as @w.WrittenAs</MudChip>
+                                                            }
+                                                        </MudStack>
+                                                        @if (!string.IsNullOrEmpty(w.Subtitle))
+                                                        {
+                                                            <MudText Typo="Typo.caption" Color="Color.Secondary" Style="font-style: italic;">@w.Subtitle</MudText>
+                                                        }
+                                                        <MudStack Row="true" Spacing="2" Wrap="Wrap.Wrap">
+                                                            @if (!string.IsNullOrEmpty(w.FirstPublishedDisplay))
+                                                            {
+                                                                <MudText Typo="Typo.caption" Color="Color.Secondary">First published @w.FirstPublishedDisplay</MudText>
+                                                            }
+                                                            @if (!string.IsNullOrEmpty(w.SeriesName))
+                                                            {
+                                                                <MudText Typo="Typo.caption" Color="Color.Secondary">
+                                                                    @(w.SeriesType == BookTracker.Data.Models.SeriesType.Collection ? "Collection" : "Series"): @w.SeriesName
+                                                                </MudText>
+                                                            }
+                                                        </MudStack>
+                                                        @if (w.InBooks.Count > 0)
+                                                        {
+                                                            <MudStack Row="true" Spacing="1" Wrap="Wrap.Wrap" Class="mt-1">
+                                                                <MudText Typo="Typo.caption" Color="Color.Secondary" Class="align-self-center">In:</MudText>
+                                                                @foreach (var b in w.InBooks)
+                                                                {
+                                                                    <MudLink Href="@($"/books/{b.Id}")"
+                                                                             Typo="Typo.caption">@b.Title</MudLink>
+                                                                }
+                                                            </MudStack>
+                                                        }
+                                                    </MudStack>
+                                                </MudListItem>
+                                            }
+                                        </MudList>
+                                    }
+                                }
+                                else
+                                {
+                                    @if (detail.Books.Count == 0)
+                                    {
+                                        <MudText Typo="Typo.body2" Color="Color.Secondary">No books recorded for this author.</MudText>
+                                    }
+                                    else
+                                    {
+                                        <MudList T="int" Dense="true" Class="pa-0">
+                                            @foreach (var b in detail.Books)
+                                            {
+                                                <MudListItem T="int" OnClick="@(() => Nav.NavigateTo($"/books/{b.Id}"))" Class="px-2">
+                                                    <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center" Wrap="Wrap.NoWrap">
+                                                        @if (!string.IsNullOrEmpty(b.CoverUrl))
+                                                        {
+                                                            <MudImage Src="@b.CoverUrl" Alt="@b.Title" Width="36" Height="52" Style="object-fit: cover; border-radius: 2px; flex: 0 0 auto;" />
+                                                        }
+                                                        else
+                                                        {
+                                                            <MudIcon Icon="@Icons.Material.Filled.MenuBook" Color="Color.Secondary" />
+                                                        }
+                                                        <MudStack Spacing="0" Class="flex-grow-1" Style="min-width: 0;">
+                                                            <MudText Typo="Typo.body1" Style="word-break: break-word;">@b.Title</MudText>
+                                                            <MudText Typo="Typo.caption" Color="Color.Secondary">
+                                                                @b.EditionCount edition@(b.EditionCount == 1 ? "" : "s") · @b.CopyCount cop@(b.CopyCount == 1 ? "y" : "ies")
+                                                            </MudText>
+                                                        </MudStack>
+                                                    </MudStack>
+                                                </MudListItem>
+                                            }
+                                        </MudList>
+                                    }
+                                }
+                            }
+                        </div>
+                    }
+                </div>
+                <MudDivider />
+            }
+        </MudPaper>
+    }
+
+</MudContainer>
 
 @code {
+    [SupplyParameterFromQuery(Name = "expand")] public int? ExpandId { get; set; }
+
     private int? editingId;
     private string editingName = "";
 
-    protected override async Task OnInitializedAsync() => await VM.LoadAsync();
+    protected override async Task OnInitializedAsync()
+    {
+        await VM.LoadAsync();
+        if (ExpandId is int id && VM.Authors.Any(a => a.Id == id))
+        {
+            await VM.ExpandAsync(id);
+        }
+    }
+
+    private async Task OnToggleExpandAsync(int authorId)
+    {
+        await VM.ToggleExpandAsync(authorId);
+    }
+
+    private void SetView(int authorId, AuthorListViewModel.AuthorViewMode mode) =>
+        VM.SetViewMode(authorId, mode);
 
     private void StartRename(AuthorListViewModel.AuthorRow author)
     {
@@ -114,13 +283,5 @@ else
     {
         await VM.RenameAsync(authorId, editingName);
         editingId = null;
-    }
-
-    private async Task MarkAsAliasAsync(int authorId, ChangeEventArgs e)
-    {
-        if (int.TryParse(e.Value?.ToString(), out var canonicalId))
-        {
-            await VM.MarkAsAliasAsync(authorId, canonicalId);
-        }
     }
 }

--- a/BookTracker.Web/Components/Pages/Home.razor
+++ b/BookTracker.Web/Components/Pages/Home.razor
@@ -133,13 +133,15 @@
                             @foreach (var a in VM.TopAuthors)
                             {
                                 var pct = VM.MaxAuthor == 0 ? 0 : (double)a.Count * 100.0 / VM.MaxAuthor;
-                                <div>
-                                    <MudStack Row Justify="Justify.SpaceBetween" Class="mb-1">
-                                        <MudText Typo="Typo.body2" Style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">@a.Author</MudText>
-                                        <MudText Typo="Typo.body2" Color="Color.Secondary">@a.Count</MudText>
-                                    </MudStack>
-                                    <MudProgressLinear Value="@pct" Color="Color.Primary" Size="Size.Small" />
-                                </div>
+                                <MudLink Href="@($"/authors?expand={a.CanonicalAuthorId}")" Underline="Underline.None" Color="Color.Inherit">
+                                    <div>
+                                        <MudStack Row Justify="Justify.SpaceBetween" Class="mb-1">
+                                            <MudText Typo="Typo.body2" Style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">@a.Author</MudText>
+                                            <MudText Typo="Typo.body2" Color="Color.Secondary">@a.Count</MudText>
+                                        </MudStack>
+                                        <MudProgressLinear Value="@pct" Color="Color.Primary" Size="Size.Small" />
+                                    </div>
+                                </MudLink>
                             }
                         </MudStack>
                     }

--- a/BookTracker.Web/ViewModels/AuthorListViewModel.cs
+++ b/BookTracker.Web/ViewModels/AuthorListViewModel.cs
@@ -1,5 +1,6 @@
 using BookTracker.Data;
 using BookTracker.Data.Models;
+using BookTracker.Web.Services;
 using Microsoft.EntityFrameworkCore;
 
 namespace BookTracker.Web.ViewModels;
@@ -10,11 +11,22 @@ namespace BookTracker.Web.ViewModels;
 // - Promote an alias back to canonical
 // - Rename
 // Author merging (combining two canonicals) is tracked in TODO.md.
+//
+// Each row can be expanded to show a drill-down with the author's Works
+// or Books (per-row toggle). For canonical authors the drill-down rolls
+// up any aliases — so Stephen King's expanded view includes Bachman
+// titles, and a note surfaces which aliases contributed. Works/books
+// load lazily on first expand; view-mode and expand state are kept on
+// the VM so flipping back and forth doesn't re-hit the DB.
 public class AuthorListViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory)
 {
     public bool Loading { get; private set; } = true;
     public List<AuthorRow> Authors { get; private set; } = [];
     public string? SuccessMessage { get; set; }
+
+    public HashSet<int> ExpandedAuthorIds { get; private set; } = [];
+    public Dictionary<int, AuthorDetail> DetailByAuthorId { get; private set; } = [];
+    public Dictionary<int, AuthorViewMode> ViewModeByAuthorId { get; private set; } = [];
 
     public async Task LoadAsync()
     {
@@ -43,6 +55,96 @@ public class AuthorListViewModel(IDbContextFactory<BookTrackerDbContext> dbFacto
 
     public IEnumerable<AuthorRow> CanonicalAuthors => Authors.Where(a => a.CanonicalAuthorId is null);
 
+    public async Task ToggleExpandAsync(int authorId)
+    {
+        if (ExpandedAuthorIds.Remove(authorId)) return;
+        ExpandedAuthorIds.Add(authorId);
+        if (!DetailByAuthorId.ContainsKey(authorId))
+        {
+            DetailByAuthorId[authorId] = await LoadDetailAsync(authorId);
+        }
+    }
+
+    /// <summary>Pre-expand (idempotent) — used when /authors?expand=<id> is followed.</summary>
+    public async Task ExpandAsync(int authorId)
+    {
+        ExpandedAuthorIds.Add(authorId);
+        if (!DetailByAuthorId.ContainsKey(authorId))
+        {
+            DetailByAuthorId[authorId] = await LoadDetailAsync(authorId);
+        }
+    }
+
+    public AuthorViewMode GetViewMode(int authorId) =>
+        ViewModeByAuthorId.TryGetValue(authorId, out var m) ? m : AuthorViewMode.Works;
+
+    public void SetViewMode(int authorId, AuthorViewMode mode) =>
+        ViewModeByAuthorId[authorId] = mode;
+
+    private async Task<AuthorDetail> LoadDetailAsync(int authorId)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync();
+
+        var author = await db.Authors
+            .Include(a => a.Aliases)
+            .FirstOrDefaultAsync(a => a.Id == authorId);
+        if (author is null) return AuthorDetail.Empty;
+
+        bool isCanonical = author.CanonicalAuthorId is null;
+
+        // Collect every author id that rolls up into this view — the
+        // author itself plus (for canonicals) every alias that points at it.
+        var ids = new List<int> { authorId };
+        if (isCanonical)
+        {
+            ids.AddRange(author.Aliases.Select(a => a.Id));
+        }
+
+        var works = await db.Works
+            .Include(w => w.Author)
+            .Include(w => w.Books)
+            .Include(w => w.Series)
+            .Where(w => ids.Contains(w.AuthorId))
+            .OrderBy(w => w.Title)
+            .ToListAsync();
+
+        var workRows = works.Select(w => new WorkRow(
+            w.Id,
+            w.Title,
+            w.Subtitle,
+            // Flag which alias a work was written as, but only on canonical
+            // rows (on an alias row the author is always itself). For single-
+            // identity canonicals this is always null.
+            isCanonical && w.AuthorId != authorId ? w.Author.Name : null,
+            PartialDateParser.Format(w.FirstPublishedDate, w.FirstPublishedDatePrecision),
+            w.Series?.Name,
+            w.Series?.Type,
+            w.SeriesOrder,
+            w.Books.Select(b => new BookRef(b.Id, b.Title)).ToList()
+        )).ToList();
+
+        var bookIds = works.SelectMany(w => w.Books).Select(b => b.Id).Distinct().ToList();
+        var books = await db.Books
+            .Where(b => bookIds.Contains(b.Id))
+            .Include(b => b.Editions).ThenInclude(e => e.Copies)
+            .OrderBy(b => b.Title)
+            .ToListAsync();
+
+        var bookRows = books.Select(b => new BookSummaryRow(
+            b.Id,
+            b.Title,
+            b.DefaultCoverArtUrl,
+            b.Editions.Count,
+            b.Editions.Sum(e => e.Copies.Count)
+        )).ToList();
+
+        var aliasNames = isCanonical
+            ? author.Aliases.Select(a => a.Name).OrderBy(n => n).ToList()
+            : new List<string>();
+
+        return new AuthorDetail(workRows, bookRows, aliasNames);
+    }
+
     public async Task MarkAsAliasAsync(int aliasId, int canonicalId)
     {
         if (aliasId == canonicalId) return; // can't alias to self
@@ -68,6 +170,7 @@ public class AuthorListViewModel(IDbContextFactory<BookTrackerDbContext> dbFacto
 
         await db.SaveChangesAsync();
         SuccessMessage = $"\"{alias.Name}\" is now an alias of \"{canonical.Name}\".";
+        InvalidateDetailsFor(aliasId, canonicalId, rootCanonicalId);
         await LoadAsync();
     }
 
@@ -77,9 +180,11 @@ public class AuthorListViewModel(IDbContextFactory<BookTrackerDbContext> dbFacto
         var alias = await db.Authors.FirstOrDefaultAsync(a => a.Id == aliasId);
         if (alias is null || alias.CanonicalAuthorId is null) return;
 
+        var priorCanonicalId = alias.CanonicalAuthorId.Value;
         alias.CanonicalAuthorId = null;
         await db.SaveChangesAsync();
         SuccessMessage = $"\"{alias.Name}\" is now its own canonical author.";
+        InvalidateDetailsFor(aliasId, priorCanonicalId);
         await LoadAsync();
     }
 
@@ -103,8 +208,47 @@ public class AuthorListViewModel(IDbContextFactory<BookTrackerDbContext> dbFacto
         author.Name = trimmed;
         await db.SaveChangesAsync();
         SuccessMessage = $"Renamed to \"{trimmed}\".";
+        InvalidateDetailsFor(authorId);
         await LoadAsync();
     }
 
+    // Any structural change (alias / promote / rename) potentially invalidates
+    // the cached drill-down detail for the affected authors — drop them so
+    // the next expand reloads fresh from the DB.
+    private void InvalidateDetailsFor(params int[] authorIds)
+    {
+        foreach (var id in authorIds) DetailByAuthorId.Remove(id);
+    }
+
     public record AuthorRow(int Id, string Name, int? CanonicalAuthorId, string? CanonicalName, int WorkCount);
+
+    public record AuthorDetail(
+        IReadOnlyList<WorkRow> Works,
+        IReadOnlyList<BookSummaryRow> Books,
+        IReadOnlyList<string> AliasNames)
+    {
+        public static AuthorDetail Empty => new([], [], []);
+    }
+
+    public record WorkRow(
+        int Id,
+        string Title,
+        string? Subtitle,
+        string? WrittenAs,
+        string FirstPublishedDisplay,
+        string? SeriesName,
+        SeriesType? SeriesType,
+        int? SeriesOrder,
+        IReadOnlyList<BookRef> InBooks);
+
+    public record BookSummaryRow(
+        int Id,
+        string Title,
+        string? CoverUrl,
+        int EditionCount,
+        int CopyCount);
+
+    public record BookRef(int Id, string Title);
+
+    public enum AuthorViewMode { Works, Books }
 }

--- a/BookTracker.Web/ViewModels/HomeViewModel.cs
+++ b/BookTracker.Web/ViewModels/HomeViewModel.cs
@@ -42,7 +42,7 @@ public class HomeViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory)
             .ToDictionaryAsync(x => x.Id, x => x.Name);
 
         TopAuthors = authorTotals
-            .Select(t => new AuthorCount(nameLookup.GetValueOrDefault(t.CanonicalId) ?? "(unknown)", t.Count))
+            .Select(t => new AuthorCount(t.CanonicalId, nameLookup.GetValueOrDefault(t.CanonicalId) ?? "(unknown)", t.Count))
             .OrderByDescending(a => a.Count)
             .ThenBy(a => a.Author)
             .ToList();
@@ -60,6 +60,6 @@ public class HomeViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory)
         MaxGenre = TopGenres.Count > 0 ? TopGenres.Max(g => g.Count) : 0;
     }
 
-    public record AuthorCount(string Author, int Count);
+    public record AuthorCount(int CanonicalAuthorId, string Author, int Count);
     public record GenreCount(string Genre, int Count);
 }


### PR DESCRIPTION
Each author row is now expandable and shows either that author's Works
or the Books containing them (per-row toggle, loads on first expand,
cached for subsequent flips). Canonical rows roll up aliases — Stephen
King's expanded view includes Bachman titles, with the Bachman-authored
rows flagged "as Richard Bachman" and a heading note listing the
aliases contributing to the rollup. Alias rows show only their own
direct works/books.

Detail loads lazily (one query per first expand) so the page stays fast
with many authors; view-mode and expand state live on the VM so toggling
doesn't re-hit the DB.

Deep linking: /authors?expand=<id> pre-opens the matching row. Wired
into Home's top-10 author list — clicking a bar jumps straight to that
author's drill-down. HomeViewModel.AuthorCount gained a CanonicalAuthorId
field to support this.

Rename / alias-management actions moved under each row with MudBlazor
equivalents (MudButton / MudSelect). Page-level layout is a MudPaper
with dividers instead of the Bootstrap table — fits the "convert as we
touch" rollout since this PR materially changed the page.

VM now invalidates cached detail for any authors affected by a
structural change (mark-as-alias, promote-to-canonical, rename), so the
next expand re-queries and reflects the updated rollup.

Tests cover: detail rollup for canonical vs alias, expand/collapse state
and cache retention, view-mode default/set, cache invalidation after
alias operations.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
