### PR TITLE
feat(authors): scroll pre-expanded row into view on deep-link

### DIFF
--- a/BookTracker.Web/Components/App.razor
+++ b/BookTracker.Web/Components/App.razor
@@ -42,6 +42,7 @@
     <script src="@Assets["js/barcode-scanner.js"]"></script>
     <script src="@Assets["js/photo-capture.js"]"></script>
     <script src="@Assets["js/navbar-collapse.js"]"></script>
+    <script src="@Assets["js/scroll-to.js"]"></script>
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>
     <script src="@Assets["service-worker-register.js"]"></script>
 </body>

--- a/BookTracker.Web/Components/Pages/Authors/Index.razor
+++ b/BookTracker.Web/Components/Pages/Authors/Index.razor
@@ -1,6 +1,7 @@
 @page "/authors"
 @inject AuthorListViewModel VM
 @inject NavigationManager Nav
+@inject IJSRuntime JS
 
 <PageTitle>Authors - BookTracker</PageTitle>
 
@@ -43,7 +44,7 @@
             @foreach (var author in VM.Authors)
             {
                 var expanded = VM.ExpandedAuthorIds.Contains(author.Id);
-                <div class="author-row">
+                <div class="author-row" id="@($"author-row-{author.Id}")">
                     <MudStack Row="true"
                               Spacing="2"
                               AlignItems="AlignItems.Center"
@@ -255,6 +256,7 @@
 
     private int? editingId;
     private string editingName = "";
+    private bool scrolledToExpanded;
 
     protected override async Task OnInitializedAsync()
     {
@@ -262,6 +264,20 @@
         if (ExpandId is int id && VM.Authors.Any(a => a.Id == id))
         {
             await VM.ExpandAsync(id);
+        }
+    }
+
+    // Scroll the pre-expanded row into view once the initial render has placed
+    // it in the DOM. Only fires once per navigation (scrolledToExpanded guard)
+    // so manual expand/collapse later doesn't yank the viewport.
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender && !scrolledToExpanded && ExpandId is int id && VM.Authors.Any(a => a.Id == id))
+        {
+            scrolledToExpanded = true;
+            try { await JS.InvokeVoidAsync("ScrollTo.element", $"author-row-{id}"); }
+            catch (JSDisconnectedException) { /* circuit tearing down */ }
+            catch (TaskCanceledException) { /* ditto */ }
         }
     }
 

--- a/BookTracker.Web/wwwroot/js/scroll-to.js
+++ b/BookTracker.Web/wwwroot/js/scroll-to.js
@@ -1,0 +1,10 @@
+// Small JS helper for scrolling a specific element into view. Currently
+// used by the Authors page to jump to an author pre-expanded via
+// /authors?expand=<id>, but kept generic so future pages that support
+// deep-link-to-row (Series, Library groupings, etc.) can reuse it.
+window.ScrollTo = {
+    element: function (id) {
+        const el = document.getElementById(id);
+        if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+};


### PR DESCRIPTION
Landing on /authors?expand=<id> already pre-opened the matching row
but left the viewport at the top of the list, so users had to scroll
to find the row that had just expanded. Now the page scrolls that
specific row into view after the first render.

- Each author row gets id="author-row-{id}" for DOM targeting.
- New wwwroot/js/scroll-to.js with a generic ScrollTo.element helper
  (kept generic so future deep-link-to-row pages can reuse).
- OnAfterRenderAsync in Authors/Index.razor invokes ScrollTo.element
  once on first render when ExpandId is set — guarded by a
  scrolledToExpanded flag so manual expand/collapse later doesn't
  yank the viewport.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
