### PR TITLE
feat: /publishers page — rename, delete-unused, merge

### DIFF
--- a/BookTracker.Tests/ViewModels/PublisherListViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/PublisherListViewModelTests.cs
@@ -1,0 +1,191 @@
+using BookTracker.Data.Models;
+using BookTracker.Web.ViewModels;
+
+namespace BookTracker.Tests.ViewModels;
+
+public class PublisherListViewModelTests
+{
+    [Fact]
+    public async Task LoadAsync_PopulatesPublisherRows_WithEditionCounts()
+    {
+        var factory = new TestDbContextFactory();
+        using (var db = factory.CreateDbContext())
+        {
+            var tor = new Publisher { Name = "Tor" };
+            var unused = new Publisher { Name = "Unused Press" };
+            db.Publishers.AddRange(tor, unused);
+            db.Books.Add(new Book
+            {
+                Title = "Foo",
+                Editions =
+                [
+                    new Edition { Publisher = tor, Format = BookFormat.Hardcover },
+                    new Edition { Publisher = tor, Format = BookFormat.TradePaperback }
+                ]
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var vm = new PublisherListViewModel(factory);
+        await vm.LoadAsync();
+
+        Assert.Equal(2, vm.Publishers.Count);
+        var torRow = vm.Publishers.Single(p => p.Name == "Tor");
+        Assert.Equal(2, torRow.EditionCount);
+        Assert.Equal(0, vm.Publishers.Single(p => p.Name == "Unused Press").EditionCount);
+    }
+
+    [Fact]
+    public async Task RenameAsync_UpdatesName_AndInvalidatesDetailCache()
+    {
+        var factory = new TestDbContextFactory();
+        int publisherId;
+        using (var db = factory.CreateDbContext())
+        {
+            var p = new Publisher { Name = "Tor" };
+            db.Publishers.Add(p);
+            await db.SaveChangesAsync();
+            publisherId = p.Id;
+        }
+
+        var vm = new PublisherListViewModel(factory);
+        await vm.LoadAsync();
+        await vm.ToggleExpandAsync(publisherId);
+        Assert.True(vm.DetailByPublisherId.ContainsKey(publisherId));
+
+        await vm.RenameAsync(publisherId, "  Tor Books  ");
+
+        Assert.Equal("Tor Books", vm.Publishers.Single().Name); // trimmed
+        Assert.False(vm.DetailByPublisherId.ContainsKey(publisherId));
+    }
+
+    [Fact]
+    public async Task RenameAsync_RefusesCollisionWithAnotherPublisher()
+    {
+        var factory = new TestDbContextFactory();
+        int torBooksId;
+        using (var db = factory.CreateDbContext())
+        {
+            db.Publishers.Add(new Publisher { Name = "Tor" });
+            var torBooks = new Publisher { Name = "Tor Books" };
+            db.Publishers.Add(torBooks);
+            await db.SaveChangesAsync();
+            torBooksId = torBooks.Id;
+        }
+
+        var vm = new PublisherListViewModel(factory);
+        await vm.LoadAsync();
+        await vm.RenameAsync(torBooksId, "Tor");
+
+        Assert.Contains("already exists", vm.SuccessMessage);
+        Assert.Equal("Tor Books", vm.Publishers.Single(p => p.Id == torBooksId).Name);
+    }
+
+    [Fact]
+    public async Task DeleteUnusedAsync_DeletesPublisherWithZeroEditions()
+    {
+        var factory = new TestDbContextFactory();
+        int unusedId;
+        using (var db = factory.CreateDbContext())
+        {
+            var unused = new Publisher { Name = "Unused Press" };
+            db.Publishers.Add(unused);
+            await db.SaveChangesAsync();
+            unusedId = unused.Id;
+        }
+
+        var vm = new PublisherListViewModel(factory);
+        await vm.LoadAsync();
+        await vm.DeleteUnusedAsync(unusedId);
+
+        Assert.Empty(vm.Publishers);
+    }
+
+    [Fact]
+    public async Task DeleteUnusedAsync_RefusesWhenEditionsStillReference()
+    {
+        var factory = new TestDbContextFactory();
+        int publisherId;
+        using (var db = factory.CreateDbContext())
+        {
+            var p = new Publisher { Name = "Tor" };
+            db.Publishers.Add(p);
+            db.Books.Add(new Book
+            {
+                Title = "Foo",
+                Editions = [new Edition { Publisher = p, Format = BookFormat.Hardcover }]
+            });
+            await db.SaveChangesAsync();
+            publisherId = p.Id;
+        }
+
+        var vm = new PublisherListViewModel(factory);
+        await vm.LoadAsync();
+        await vm.DeleteUnusedAsync(publisherId);
+
+        Assert.Contains("Can't delete", vm.SuccessMessage);
+        Assert.Single(vm.Publishers); // still there
+    }
+
+    [Fact]
+    public async Task MergeAsync_ReassignsEditionsAndDeletesSource()
+    {
+        var factory = new TestDbContextFactory();
+        int sourceId;
+        int targetId;
+        using (var db = factory.CreateDbContext())
+        {
+            var source = new Publisher { Name = "Tor Books" };
+            var target = new Publisher { Name = "Tor" };
+            db.Publishers.AddRange(source, target);
+            db.Books.Add(new Book
+            {
+                Title = "Foo",
+                Editions =
+                [
+                    new Edition { Publisher = source, Format = BookFormat.Hardcover },
+                    new Edition { Publisher = source, Format = BookFormat.TradePaperback }
+                ]
+            });
+            await db.SaveChangesAsync();
+            sourceId = source.Id;
+            targetId = target.Id;
+        }
+
+        var vm = new PublisherListViewModel(factory);
+        await vm.LoadAsync();
+        await vm.MergeAsync(sourceId, targetId);
+
+        using var db2 = factory.CreateDbContext();
+        Assert.Null(db2.Publishers.FirstOrDefault(p => p.Id == sourceId));
+        Assert.Equal(2, db2.Editions.Count(e => e.PublisherId == targetId));
+        Assert.Contains("reassigned", vm.SuccessMessage);
+    }
+
+    [Fact]
+    public async Task MergeAsync_NoOpWhenSourceEqualsTarget()
+    {
+        var factory = new TestDbContextFactory();
+        int publisherId;
+        using (var db = factory.CreateDbContext())
+        {
+            var p = new Publisher { Name = "Tor" };
+            db.Publishers.Add(p);
+            db.Books.Add(new Book
+            {
+                Title = "Foo",
+                Editions = [new Edition { Publisher = p, Format = BookFormat.Hardcover }]
+            });
+            await db.SaveChangesAsync();
+            publisherId = p.Id;
+        }
+
+        var vm = new PublisherListViewModel(factory);
+        await vm.LoadAsync();
+        await vm.MergeAsync(publisherId, publisherId);
+
+        using var db2 = factory.CreateDbContext();
+        Assert.NotNull(db2.Publishers.FirstOrDefault(p => p.Id == publisherId));
+        Assert.Equal(1, db2.Editions.Count(e => e.PublisherId == publisherId));
+    }
+}

--- a/BookTracker.Web/Components/Layout/MainLayout.razor
+++ b/BookTracker.Web/Components/Layout/MainLayout.razor
@@ -41,6 +41,9 @@
                         <NavLink class="nav-link text-dark" href="authors">Authors</NavLink>
                     </li>
                     <li class="nav-item">
+                        <NavLink class="nav-link text-dark" href="publishers">Publishers</NavLink>
+                    </li>
+                    <li class="nav-item">
                         <NavLink class="nav-link text-dark" href="shopping">Shopping</NavLink>
                     </li>
                     <li class="nav-item">

--- a/BookTracker.Web/Components/Pages/Publishers/Index.razor
+++ b/BookTracker.Web/Components/Pages/Publishers/Index.razor
@@ -1,0 +1,216 @@
+@page "/publishers"
+@using BookTracker.Data.Models
+@inject PublisherListViewModel VM
+@inject NavigationManager Nav
+
+<PageTitle>Publishers - BookTracker</PageTitle>
+
+@* Mirrors the /authors page. Each publisher row expands to a drill-down
+   of the editions that reference it; inline actions cover rename,
+   delete-unused, and merge-into-another-publisher. Publishers have no
+   alias model — a merge is outright (target absorbs all editions, source
+   deleted). *@
+
+<MudContainer MaxWidth="MaxWidth.Large" Class="py-3">
+
+    <MudText Typo="Typo.h4" Class="mb-2">Publishers</MudText>
+    <MudText Typo="Typo.body2" Color="Color.Secondary" Class="mb-3">
+        Every publisher that currently attaches to an edition. Rename in place to fix typos, delete when
+        nothing references a publisher, or merge "Tor" into "Tor Books" (or vice-versa) to collapse
+        duplicates — the target absorbs all editions and the source is deleted.
+    </MudText>
+
+    @if (!string.IsNullOrEmpty(VM.SuccessMessage))
+    {
+        <MudAlert Severity="Severity.Success"
+                  ShowCloseIcon="true"
+                  CloseIconClicked="@(() => { VM.SuccessMessage = null; StateHasChanged(); })"
+                  Class="mb-3">@VM.SuccessMessage</MudAlert>
+    }
+
+    @if (VM.Loading)
+    {
+        <MudStack AlignItems="AlignItems.Center" Class="py-5">
+            <MudProgressCircular Indeterminate="true" />
+        </MudStack>
+    }
+    else if (VM.Publishers.Count == 0)
+    {
+        <MudText Color="Color.Secondary">No publishers yet — add a book with a publisher to seed the list.</MudText>
+    }
+    else
+    {
+        <MudPaper Elevation="1">
+            @foreach (var publisher in VM.Publishers)
+            {
+                var expanded = VM.ExpandedPublisherIds.Contains(publisher.Id);
+                <div class="publisher-row">
+                    <MudStack Row="true"
+                              Spacing="2"
+                              AlignItems="AlignItems.Center"
+                              Wrap="Wrap.Wrap"
+                              Class="pa-3"
+                              Style="cursor: pointer;"
+                              @onclick="@(() => OnToggleExpandAsync(publisher.Id))">
+                        <MudIcon Icon="@(expanded ? Icons.Material.Filled.ExpandLess : Icons.Material.Filled.ExpandMore)" Size="Size.Small" />
+                        <MudText Typo="Typo.body1" Class="flex-grow-1" Style="font-weight: 500;">@publisher.Name</MudText>
+                        <MudText Typo="Typo.body2" Color="Color.Secondary" Style="min-width: 80px; text-align: right;">
+                            @publisher.EditionCount edition@(publisher.EditionCount == 1 ? "" : "s")
+                        </MudText>
+                    </MudStack>
+
+                    @* Action bar — rename / merge / delete-unused. stopPropagation
+                       keeps clicks here from re-toggling the row. *@
+                    <div @onclick:stopPropagation="true" class="px-3 pb-3">
+                        @if (renamingId == publisher.Id)
+                        {
+                            <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center" Wrap="Wrap.Wrap">
+                                <MudTextField T="string" @bind-Value="renamingName" Variant="Variant.Outlined" Margin="Margin.Dense" Style="max-width: 320px;" />
+                                <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Primary" OnClick="@(() => SaveRenameAsync(publisher.Id))">Save</MudButton>
+                                <MudButton Size="Size.Small" Variant="Variant.Text" OnClick="@(() => renamingId = null)">Cancel</MudButton>
+                            </MudStack>
+                        }
+                        else if (pendingMergeSourceId == publisher.Id && pendingMergeTargetId is int targetId)
+                        {
+                            var targetName = VM.Publishers.FirstOrDefault(p => p.Id == targetId)?.Name ?? "(unknown)";
+                            <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center" Wrap="Wrap.Wrap">
+                                <MudText Typo="Typo.body2">
+                                    Merge <strong>@publisher.Name</strong> into <strong>@targetName</strong> —
+                                    reassigns @publisher.EditionCount edition@(publisher.EditionCount == 1 ? "" : "s") and deletes <strong>@publisher.Name</strong>. This can't be undone.
+                                </MudText>
+                                <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Error" OnClick="@(() => ConfirmMergeAsync(publisher.Id, targetId))">Confirm merge</MudButton>
+                                <MudButton Size="Size.Small" Variant="Variant.Text" OnClick="ClearPendingMerge">Cancel</MudButton>
+                            </MudStack>
+                        }
+                        else
+                        {
+                            <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center" Wrap="Wrap.Wrap">
+                                <MudButton Size="Size.Small" Variant="Variant.Outlined" StartIcon="@Icons.Material.Filled.Edit"
+                                           OnClick="@(() => StartRename(publisher))">Rename</MudButton>
+
+                                <MudSelect T="int?"
+                                           Value="null"
+                                           ValueChanged="@((int? id) => { if (id is int tid) StartMerge(publisher.Id, tid); })"
+                                           Label="Merge into…"
+                                           Variant="Variant.Outlined"
+                                           Margin="Margin.Dense"
+                                           Dense="true"
+                                           Style="max-width: 260px;">
+                                    @foreach (var other in VM.Publishers.Where(p => p.Id != publisher.Id))
+                                    {
+                                        <MudSelectItem T="int?" Value="@((int?)other.Id)">@other.Name</MudSelectItem>
+                                    }
+                                </MudSelect>
+
+                                @if (publisher.EditionCount == 0)
+                                {
+                                    <MudButton Size="Size.Small" Variant="Variant.Outlined" Color="Color.Error" StartIcon="@Icons.Material.Filled.Delete"
+                                               OnClick="@(() => VM.DeleteUnusedAsync(publisher.Id))">Delete</MudButton>
+                                }
+                            </MudStack>
+                        }
+                    </div>
+
+                    @if (expanded)
+                    {
+                        <div @onclick:stopPropagation="true" class="px-3 pb-3">
+                            @if (!VM.DetailByPublisherId.TryGetValue(publisher.Id, out var detail))
+                            {
+                                <MudStack AlignItems="AlignItems.Center" Class="py-3">
+                                    <MudProgressCircular Indeterminate="true" Size="Size.Small" />
+                                </MudStack>
+                            }
+                            else if (detail.Editions.Count == 0)
+                            {
+                                <MudText Typo="Typo.body2" Color="Color.Secondary">No editions reference this publisher.</MudText>
+                            }
+                            else
+                            {
+                                <MudList T="int" Dense="true" Class="pa-0">
+                                    @foreach (var e in detail.Editions)
+                                    {
+                                        <MudListItem T="int" OnClick="@(() => Nav.NavigateTo($"/books/{e.BookId}"))" Class="px-2">
+                                            <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center" Wrap="Wrap.NoWrap">
+                                                @if (!string.IsNullOrEmpty(e.CoverUrl))
+                                                {
+                                                    <MudImage Src="@e.CoverUrl" Alt="@e.BookTitle" Width="36" Height="52" Style="object-fit: cover; border-radius: 2px; flex: 0 0 auto;" />
+                                                }
+                                                else
+                                                {
+                                                    <MudIcon Icon="@Icons.Material.Filled.MenuBook" Color="Color.Secondary" />
+                                                }
+                                                <MudStack Spacing="0" Class="flex-grow-1" Style="min-width: 0;">
+                                                    <MudText Typo="Typo.body1" Style="word-break: break-word;">@e.BookTitle</MudText>
+                                                    <MudStack Row="true" Spacing="2" Wrap="Wrap.Wrap">
+                                                        <MudText Typo="Typo.caption" Color="Color.Secondary">@e.Format</MudText>
+                                                        @if (e.DatePrinted is DateOnly d)
+                                                        {
+                                                            <MudText Typo="Typo.caption" Color="Color.Secondary">@d.Year</MudText>
+                                                        }
+                                                        @if (!string.IsNullOrEmpty(e.Isbn))
+                                                        {
+                                                            <MudText Typo="Typo.caption" Color="Color.Secondary">ISBN @e.Isbn</MudText>
+                                                        }
+                                                        <MudText Typo="Typo.caption" Color="Color.Secondary">
+                                                            @e.CopyCount cop@(e.CopyCount == 1 ? "y" : "ies")
+                                                        </MudText>
+                                                    </MudStack>
+                                                </MudStack>
+                                            </MudStack>
+                                        </MudListItem>
+                                    }
+                                </MudList>
+                            }
+                        </div>
+                    }
+                </div>
+                <MudDivider />
+            }
+        </MudPaper>
+    }
+
+</MudContainer>
+
+@code {
+    private int? renamingId;
+    private string renamingName = "";
+
+    private int? pendingMergeSourceId;
+    private int? pendingMergeTargetId;
+
+    protected override async Task OnInitializedAsync() => await VM.LoadAsync();
+
+    private async Task OnToggleExpandAsync(int publisherId) => await VM.ToggleExpandAsync(publisherId);
+
+    private void StartRename(PublisherListViewModel.PublisherRow publisher)
+    {
+        renamingId = publisher.Id;
+        renamingName = publisher.Name;
+        ClearPendingMerge();
+    }
+
+    private async Task SaveRenameAsync(int publisherId)
+    {
+        await VM.RenameAsync(publisherId, renamingName);
+        renamingId = null;
+    }
+
+    private void StartMerge(int sourceId, int targetId)
+    {
+        pendingMergeSourceId = sourceId;
+        pendingMergeTargetId = targetId;
+        renamingId = null;
+    }
+
+    private void ClearPendingMerge()
+    {
+        pendingMergeSourceId = null;
+        pendingMergeTargetId = null;
+    }
+
+    private async Task ConfirmMergeAsync(int sourceId, int targetId)
+    {
+        await VM.MergeAsync(sourceId, targetId);
+        ClearPendingMerge();
+    }
+}

--- a/BookTracker.Web/Program.cs
+++ b/BookTracker.Web/Program.cs
@@ -88,6 +88,7 @@ builder.Services.AddTransient<BulkAddViewModel>();
 builder.Services.AddTransient<SeriesListViewModel>();
 builder.Services.AddTransient<SeriesEditViewModel>();
 builder.Services.AddTransient<AuthorListViewModel>();
+builder.Services.AddTransient<PublisherListViewModel>();
 builder.Services.AddTransient<ShoppingViewModel>();
 builder.Services.AddTransient<DuplicatesViewModel>();
 builder.Services.AddTransient<AuthorMergeViewModel>();

--- a/BookTracker.Web/ViewModels/PublisherListViewModel.cs
+++ b/BookTracker.Web/ViewModels/PublisherListViewModel.cs
@@ -1,0 +1,179 @@
+using BookTracker.Data;
+using BookTracker.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookTracker.Web.ViewModels;
+
+// Backs the /publishers page. Lists all Publisher entities with their
+// edition counts and supports rename / delete-unused / merge.
+//
+// Publishers are simpler than Authors — no canonical/alias model — so
+// name variants like "Tor" vs "Tor Books" are reconciled via outright
+// merge (target absorbs all editions, source deleted). Imprint-style
+// aliasing (Pan → Macmillan) is a future extension.
+//
+// Each row can be expanded to show a drill-down of the editions this
+// publisher covers. Editions load lazily on first expand and the cache is
+// invalidated whenever a structural change (rename / merge / delete)
+// could affect what's displayed.
+public class PublisherListViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory)
+{
+    public bool Loading { get; private set; } = true;
+    public List<PublisherRow> Publishers { get; private set; } = [];
+    public string? SuccessMessage { get; set; }
+
+    public HashSet<int> ExpandedPublisherIds { get; private set; } = [];
+    public Dictionary<int, PublisherDetail> DetailByPublisherId { get; private set; } = [];
+
+    public async Task LoadAsync()
+    {
+        Loading = true;
+        await using var db = await dbFactory.CreateDbContextAsync();
+
+        Publishers = await db.Publishers
+            .Select(p => new PublisherRow(p.Id, p.Name, p.Editions.Count))
+            .OrderBy(p => p.Name)
+            .ToListAsync();
+
+        Loading = false;
+    }
+
+    public async Task ToggleExpandAsync(int publisherId)
+    {
+        if (ExpandedPublisherIds.Remove(publisherId)) return;
+        ExpandedPublisherIds.Add(publisherId);
+        if (!DetailByPublisherId.ContainsKey(publisherId))
+        {
+            DetailByPublisherId[publisherId] = await LoadDetailAsync(publisherId);
+        }
+    }
+
+    private async Task<PublisherDetail> LoadDetailAsync(int publisherId)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync();
+
+        var editions = await db.Editions
+            .Where(e => e.PublisherId == publisherId)
+            .Include(e => e.Book)
+            .Include(e => e.Copies)
+            .OrderBy(e => e.Book.Title)
+            .ThenBy(e => e.DatePrinted)
+            .Select(e => new EditionRow(
+                e.Id,
+                e.BookId,
+                e.Book.Title,
+                e.Isbn,
+                e.Format,
+                e.DatePrinted,
+                e.CoverUrl,
+                e.Copies.Count))
+            .ToListAsync();
+
+        return new PublisherDetail(editions);
+    }
+
+    public async Task RenameAsync(int publisherId, string newName)
+    {
+        var trimmed = newName.Trim();
+        if (string.IsNullOrEmpty(trimmed)) return;
+
+        await using var db = await dbFactory.CreateDbContextAsync();
+        var publisher = await db.Publishers.FirstOrDefaultAsync(p => p.Id == publisherId);
+        if (publisher is null) return;
+
+        // Publisher.Name has a unique index — guard against colliding with
+        // another row explicitly so the user gets a helpful message instead
+        // of a DB exception.
+        var clash = await db.Publishers.AnyAsync(p => p.Id != publisherId && p.Name == trimmed);
+        if (clash)
+        {
+            SuccessMessage = $"A publisher named \"{trimmed}\" already exists. Use the merge action to combine them.";
+            return;
+        }
+
+        publisher.Name = trimmed;
+        await db.SaveChangesAsync();
+        SuccessMessage = $"Renamed to \"{trimmed}\".";
+        InvalidateDetailsFor(publisherId);
+        await LoadAsync();
+    }
+
+    public async Task DeleteUnusedAsync(int publisherId)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync();
+        var publisher = await db.Publishers
+            .Include(p => p.Editions)
+            .FirstOrDefaultAsync(p => p.Id == publisherId);
+        if (publisher is null) return;
+
+        // Edition.PublisherId has OnDelete.Restrict, so this would blow up
+        // at the DB if attempted with editions attached. Guard at VM level
+        // and surface a helpful message.
+        if (publisher.Editions.Count > 0)
+        {
+            SuccessMessage = $"Can't delete \"{publisher.Name}\" — {publisher.Editions.Count} edition{(publisher.Editions.Count == 1 ? "" : "s")} still reference it. Merge it into another publisher instead.";
+            return;
+        }
+
+        var name = publisher.Name;
+        db.Publishers.Remove(publisher);
+        await db.SaveChangesAsync();
+        SuccessMessage = $"Deleted unused publisher \"{name}\".";
+        InvalidateDetailsFor(publisherId);
+        await LoadAsync();
+    }
+
+    public async Task MergeAsync(int sourceId, int targetId)
+    {
+        if (sourceId == targetId) return;
+
+        await using var db = await dbFactory.CreateDbContextAsync();
+        var source = await db.Publishers
+            .Include(p => p.Editions)
+            .FirstOrDefaultAsync(p => p.Id == sourceId);
+        var target = await db.Publishers.FirstOrDefaultAsync(p => p.Id == targetId);
+        if (source is null || target is null) return;
+
+        var editionCount = source.Editions.Count;
+
+        // Reassign then delete in a single transaction so we never leave a
+        // half-merged state if SaveChanges fails partway. Matches the
+        // pattern in AuthorMergeService.
+        await using var tx = await db.Database.BeginTransactionAsync();
+
+        foreach (var edition in source.Editions)
+        {
+            edition.PublisherId = targetId;
+        }
+        db.Publishers.Remove(source);
+
+        await db.SaveChangesAsync();
+        await tx.CommitAsync();
+
+        SuccessMessage = $"Merged \"{source.Name}\" into \"{target.Name}\" — {editionCount} edition{(editionCount == 1 ? "" : "s")} reassigned.";
+        InvalidateDetailsFor(sourceId, targetId);
+        await LoadAsync();
+    }
+
+    private void InvalidateDetailsFor(params int[] publisherIds)
+    {
+        foreach (var id in publisherIds) DetailByPublisherId.Remove(id);
+    }
+
+    public record PublisherRow(int Id, string Name, int EditionCount);
+
+    public record PublisherDetail(IReadOnlyList<EditionRow> Editions)
+    {
+        public static PublisherDetail Empty => new([]);
+    }
+
+    public record EditionRow(
+        int Id,
+        int BookId,
+        string BookTitle,
+        string? Isbn,
+        BookFormat Format,
+        DateOnly? DatePrinted,
+        string? CoverUrl,
+        int CopyCount);
+}


### PR DESCRIPTION
Mirrors /authors structurally: MudBlazor, per-row expand to drill-down of
editions, inline rename + merge + delete actions. Publishers have no
alias model (unlike Authors), so "Tor"/"Tor Books"-style duplicates are
reconciled via outright merge — target absorbs all editions, source
deleted. Two-step confirm for merge since it's destructive and
irreversible; delete is guarded to zero-edition rows (Edition.PublisherId
is Restrict on delete, so DB rejects otherwise).

PublisherListViewModel holds all ops inline, matching AuthorListViewModel
rather than spinning up a separate service — the operations are simple
enough. Merge uses an explicit transaction for atomicity, matching
AuthorMergeService's pattern.

No schema change. Responsive for both mobile and desktop via the same
MudStack/Wrap pattern as Authors.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
