### PR TITLE
fix: add mobile-web-app-capable meta tag alongside apple-specific one

### DIFF
--- a/BookTracker.Web/Components/App.razor
+++ b/BookTracker.Web/Components/App.razor
@@ -13,6 +13,7 @@
        deploy. *@
     <link rel="manifest" href="/manifest.webmanifest" />
     <meta name="theme-color" content="#6750A4" />
+    <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <meta name="apple-mobile-web-app-title" content="BookTracker" />


### PR DESCRIPTION
Chrome warns that `apple-mobile-web-app-capable` is deprecated. Adding
the standard `mobile-web-app-capable` keeps Safari install-to-home-screen
working while clearing the Chrome warning.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
