### PR TITLE
fix: gate swap.yml on production GitHub Environment

### DIFF
--- a/.github/workflows/swap.yml
+++ b/.github/workflows/swap.yml
@@ -1,8 +1,9 @@
 name: Swap staging to production
 
-# TODO: configure a GitHub Environment named "production" (Settings -> Environments)
-# with required reviewers, then add `environment: production` to the job below so
-# the swap requires human approval before it runs.
+# The `production` GitHub Environment (Settings -> Environments) gates this
+# job: 2-minute wait timer (cancellable window for fat-finger dispatches) and
+# Deployment branches restricted to `main`. Required-reviewer approval is a
+# future step, blocked on having a collaborator (TODO.md #26).
 on:
   workflow_dispatch:
 
@@ -13,6 +14,7 @@ permissions:
 jobs:
   swap:
     runs-on: ubuntu-latest
+    environment: production
     steps:
       - name: Azure login (OIDC)
         uses: azure/login@v2


### PR DESCRIPTION
Adds `environment: production` to the swap job so dispatches go through
the GitHub Environment's 2-minute wait timer (fat-finger cancellation
window) and the `main`-only deployment-branches restriction.

Required-reviewer approval is a future step, blocked on having a
collaborator — see TODO.md #26.

Closes the workflow's pre-existing TODO comment, replacing it with a
description of the protection that's now in place.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
