### PR TITLE
chore/memory rules and blog backlog

### DIFF
--- a/.claude-memory/MEMORY.md
+++ b/.claude-memory/MEMORY.md
@@ -3,6 +3,7 @@
 - [Drew — solo developer](user_drew.md) — context on the user, their stack (Windows/PowerShell/Azure/GitHub `N3rdage/the-library`, Gandi DNS), and collaboration style.
 - [Auto-commit locally](feedback_commit_locally.md) — always stage and commit before handing off; don't wait to be asked.
 - [Delete merged branches](feedback_delete_merged_branch.md) — delete local feature branch after pulling the merge into main.
+- [Branch from main](feedback_branch_from_main.md) — always start a new branch from a fresh `main` pull; never from a sibling branch (squash-merge would bundle content).
 - [Ask about mobile priority](feedback_mobile_priority.md) — when planning features, ask if mobile+web or web-only.
 - [Feature planning conventions](feedback_planning_conventions.md) — always plan first, PR breakdown for medium+, flag 5+ file changes as complex.
 - [Testing conventions](feedback_testing_conventions.md) — minimal tests for new logic to prevent regression; skip for pure markup.

--- a/.claude-memory/MEMORY.md
+++ b/.claude-memory/MEMORY.md
@@ -12,3 +12,4 @@
 - [TODO tracking](feedback_todo_tracking.md) — all TODOs in TODO.md; "sync TODOs" reconciles memory + code + TODO.md.
 - [Memory excluded from PRs](feedback_memory_commits.md) — don't stage .claude-memory/ in feature commits; flag changes for a separate commit.
 - [Keep ARCHITECTURE.md updated](feedback_architecture_doc.md) — update when structural changes are made (entities, pages, services, patterns).
+- [Blog post backlog](blog_post_backlog.md) — corpus-derived candidate posts mineable from existing retros + `patterns.md`. Definitive count as of 2026-04-28: 3 shipped, 9 strong candidates, 6 possible.

--- a/.claude-memory/blog_post_backlog.md
+++ b/.claude-memory/blog_post_backlog.md
@@ -1,0 +1,105 @@
+---
+name: Blog post backlog — corpus catch-up + going-forward queue
+description: One-time mine of all retros + patterns.md as of 2026-04-28. Each entry is a candidate post Drew can pick from. Already-shipped posts at the top with their source mapping; catch-up candidates ranked by strength of angle; "skip/fold-in" listed for completeness so the count is definitive. Going-forward, new retros add their candidate post here at write time.
+type: project
+---
+
+## Status as of 2026-04-28
+
+- **3 posts shipped** (covered).
+- **9 strong catch-up candidates** (clear angle, durable lesson, transferable beyond this stack).
+- **6 possible catch-up candidates** (could be a post or could fold into another — TBD when picked up).
+- **15+ retros with no obvious blog hook on their own** (specific, dated, or already covered — listed at the bottom for the definitive count).
+
+## Already shipped
+
+| # | Date | Title | Drew on |
+|---|---|---|---|
+| 1 | 2026-04-23 | [Why the most-edited part of our codebase isn't code](../../blog/2026-04-23-most-edited-isnt-code.md) | `patterns.md §3` (memory as durable context); the four memory-type framing |
+| 2 | 2026-04-24 | [Why our risky UI rollouts ship as two-line PRs](../../blog/2026-04-24-01-scaffold-first-rollout.md) | Book View page arc retros (`retro_book_view_page_pr1`–`pr4` + `_swap`); the "scaffold opt-in → feature PRs → swap when feature-complete" template |
+| 3 | 2026-04-27 | [Empty staging catches schema, not data](../../blog/2026-04-27-01-empty-staging-catches-schema-not-data.md) | `retro_staging_db_separation.md`; the EF-transactional-vs-broken framing |
+
+## Strong catch-up candidates
+
+Concrete angle, durable lesson, transferable beyond BookTracker's stack. Order is rough — pick whichever speaks to current energy.
+
+- **"When 'go ahead' is the wrong answer" / "The plan: prefix"** — `patterns.md §1`, `feedback_plan_prefix.md`. The convention that turned "wait, discuss first" from a recurring correction into a one-character prefix. Audience: anyone using AI coding assistants who's hit the "wrote 200 lines of code I didn't want" problem.
+
+- **"I didn't click that button"** — `patterns.md §4` (browser-test honesty) + the bonus pattern "caveat as first-class output." The honest framing: AI compiles, type-checks, unit-tests; AI does *not* click buttons. Standardising "honest caveat — not browser-tested" as a footer is the load-bearing convention. Audience: AI-collaboration; teams worried about over-reliance.
+
+- **"Compiler errors are a refactor todo list"** — `patterns.md §8`, anchored by `retro_work_refactor.md` (30+ files, top-down compile-error sweep) and `retro_pen_names.md`. Why tight types pay back during refactors regardless of who's writing the code. Audience: backend / typed-language devs; resonates beyond AI.
+
+- **"Five PRs, same template, four distinct decisions" — the duplicate-management arc retrospective** — sources: `retro_duplicates_listing` / `_author_merge` / `_work_merge` / `_edition_merge_and_enrichment` / `_book_merge`. The merge-shape template (auto-fill-empties, transactional, refusal vs aggregator) held across five entity types; the per-entity differences were the interesting part. Audience: data-modelling devs; meta-pattern for repeated-feature-shape work.
+
+- **"Having a permission ≠ granting that permission to someone"** — `retro_easy_auth_secret_rotation.md`. The privilege-level distinction generalises: Graph `AppRoleAssignment.ReadWrite.All`, Kubernetes RBAC verbs on Roles vs RoleBindings, SQL `GRANT … WITH GRANT OPTION`, Linux chmod vs chattr. One-paragraph generalisation post; broad audience.
+
+- **"No findings is a valid audit outcome"** — `retro_security_audit.md`. The framing argues *how* each section was verified is the durable artefact, not the verdict. Living-doc + monthly-issue-cadence pattern as the alternative to a point-in-time PDF. Audience: security-curious devs; broader than "audit your code" content.
+
+- **"Try-and-learn beats spec-first for destructive operations"** — `retro_reusable_instructions.md`. Two reusable paste-into-another-Claude prompts (git history rewrite, going-public walkthrough) that emerged from working through the operation rather than specifying it upfront. Reusable-prompts-as-deliverables is the meta-shape. Audience: AI-collaboration; high relevance for the blog's core readers.
+
+- **"Auto-fill-empties beat strict-replace"** — `retro_edition_merge_and_enrichment.md`. The first version was strict-replace; failed the first time it was used. Pivoted to auto-fill-empties + retrofit existing records. The lesson is bigger than dedup: "designed-with-no-data" defaults often pick the wrong semantics. Audience: data-modelling, dedup-curious.
+
+- **"Lookup data is messier than your tests"** — `patterns.md §10`, anchored by `retro_genre_matcher.md` (the bidirectional `Contains()` bug), `retro_format_detection.md`, `retro_imprecise_dates.md`, `retro_trove_fallback.md`. Real-surface examples from Open Library + Google Books + Trove. Budget for "lookup data quality" as ongoing, not one-time. Audience: anyone integrating external metadata APIs.
+
+## Possible catch-up candidates
+
+Could be a post; could fold into one of the strong candidates as a section. TBD when picked up.
+
+- **"Drift across adjacent code is a bug-shaped gap"** — `retro_bug_nest.md`. Three bugs, each with a pre-existing pattern in the codebase that would have prevented it. The lesson: when introducing a pattern, check whether the not-yet-converted code has the bug-shape the pattern fixes. Could fold into a "Convert as we touch" post or stand alone.
+
+- **"List with expandable detail needs three VM collections, not a framework"** — `retro_authors_drilldown.md`. Lazy-load-on-expand, alias rollup, deep-link from a dashboard. The Three-VM-Collections shape is reusable. Niche but specific.
+
+- **"Convert as we touch — pragmatic UI-library migration"** — `retro_mudblazor_pilot_and_theme.md`. Bootstrap and MudBlazor coexist per-page indefinitely by design. No deadline, no big-bang rewrite. Probably folds with the bug-nest "drift" insight.
+
+- **"Find-or-create at every save site"** — `patterns.md §7`. One resolver helper called from five sites; silent auto-create over typeahead-suggest as the friction-vs-rigour trade-off. Would pair well in an "interaction defaults" post.
+
+- **"Additive-then-cutover schema migrations"** — `patterns.md §5`, `retro_work_refactor.md`, `retro_book_to_edition_copy.md`. PR1 (additive, dual-write) then PR2 (cutover, drop). Niche to data-model refactors but a strong case study.
+
+- **"Planning docs uncover preferences silent defaults miss"** — `retro_going_public.md`. Drew picked Option A on `.claude-memory/` over my recommended B because of project framing I didn't have. The lesson is about explicit-options-with-recommendations as a planning shape. Could fold into the plan: prefix post or stand alone.
+
+## Other retros — no obvious blog hook on their own
+
+For the definitive count. Many are valuable as repo memory or as one-paragraph references inside the posts above; few are post-shaped on their own.
+
+| Retro | Why not a standalone post |
+|---|---|
+| `retro_initial_scaffolding` | Reconstructed from git, dated, mostly setup-narrative |
+| `retro_book_data_model_v1` | Superseded by later Edition+Copy and Work refactors |
+| `retro_book_to_edition_copy` | Folds into additive-then-cutover post |
+| `retro_format_detection` | Folds into "lookup data is messier than your tests" |
+| `retro_genre_matcher` | Folds into "lookup data" post |
+| `retro_genre_taxonomy` | Domain-modelling; narrow |
+| `retro_no_isbn_lookup` | Filtered-unique-index detail; narrow |
+| `retro_imprecise_dates` | DateOnly + precision pair; folds into "lookup data" |
+| `retro_trove_fallback` | Silent-skip-when-keyless; folds into "lookup data" |
+| `retro_chores` | License + small fixes; low signal |
+| `retro_pwa` | Niche infra (manifest + icons + SW) |
+| `retro_pwa_auth_exclusions` | Specific Easy Auth gotcha; could be a paragraph elsewhere |
+| `retro_bulk_capture` | Barcode + photo OCR specifics |
+| `retro_series_and_shopping` | 8 PRs in a day; weak narrative arc |
+| `retro_library_groupings` | UX accordion + lazy-load; narrow |
+| `retro_add_copy_flow` | Duplicate detection at lookup; specific |
+| `retro_pen_names` | Domain-modelling for aliases; folds into compile-error post |
+| `retro_book_view_page_pr1`–`pr4` + `_swap` | Already covered by post #2 |
+| `retro_mvvm_refactor` | .NET-specific; could ground a "test-infra as gateway" post |
+| `retro_ai_integration` | Multi-provider arch; dense, would need narrowing |
+| `retro_architecture_doc` | Doc discipline; one-paragraph reference at most |
+| `retro_dependabot_hygiene` | Dependency hygiene; niche |
+| `retro_prologue_claude_desktop` | Pre-code transcript; specific to project genesis |
+| `retro_infra_security_arc` | VNet/KV/PE/AI deep dive; would need niche audience |
+| `retro_refresh_local_db` | BACPAC script + SqlPackage gotchas; could ground a "scripts as durable artefacts" post |
+| `retro_author_merge` | InMemory provider footguns; could ground a test-infra post |
+
+## Going-forward pattern
+
+After this catch-up corpus is mined, new retros add their own backlog entry at write time:
+
+- When a retro is written, add a one-bullet candidate post at the top of "Strong" or "Possible" with the source retro link.
+- When a post ships, move its entry from candidates to "Already shipped."
+- When the catch-up "Strong" list empties, the going-forward pattern is the only source of new candidates — no more sweeps needed.
+
+## Suggested starter prompt for picking the next post
+
+In a fresh session, this is enough to choose the next one to draft:
+
+> Let's pick the next blog post from the backlog. Suggest 3 from the strong-candidate list with one-line angles and which retro is the anchor.

--- a/.claude-memory/feedback_branch_from_main.md
+++ b/.claude-memory/feedback_branch_from_main.md
@@ -1,0 +1,23 @@
+---
+name: Always branch from main
+description: Before starting any new work, return to main and pull. Never start a new branch from a still-pending sibling branch — sibling-stacking causes squash-merge weirdness and unintentional content bundling.
+type: feedback
+---
+
+When starting any new branch, the sequence is always:
+
+```powershell
+git checkout main
+git pull
+git checkout -b <prefix>/<name>
+```
+
+Even if the previous branch hasn't been pushed yet, even if the new work feels related to the previous, even if the previous branch's content "would be useful as a starting point" — return to main first.
+
+**Why:** With squash-merge as the project's default (and that decision held after a deliberate review on 2026-04-28), branching from a sibling means the new branch's diff against main includes BOTH the sibling's content AND the new work. When the new branch is merged, GitHub's squash flattens both sets of changes into one commit. Past incident (PR #130, 2026-04-27): a chore/todo branch was followed by a blog/retro branch built on top of it; the squash bundled the chore PR's content into the blog PR. End state was correct but the PR title misled, and local cleanup needed `git branch -D` because git couldn't see the squashed-merged content as merged.
+
+**How to apply:**
+
+- After every "merged" confirmation from Drew, before any other action, run `git checkout main && git pull` (the delete-merged-branch rule already mandates this — this rule just adds: *always start the next branch from there*, never from the just-deleted sibling's parent or any other branch).
+- If new work has logical sub-parts that ship together, prefer **multiple commits in one PR** (squash preserves all commit subjects in the squash-commit body) rather than stacking branches. The 2026-04-27 incident would have been avoided by this shape — TODO + retro + blog as three commits on one branch.
+- If work genuinely needs a stack (PR-B depends on unmerged PR-A's content), say so explicitly to Drew so we plan the merge sequence together — don't create the stack silently.

--- a/.claude-memory/feedback_memory_commits.md
+++ b/.claude-memory/feedback_memory_commits.md
@@ -1,26 +1,40 @@
 ---
-name: Memory changes excluded from PRs
-description: Don't stage .claude-memory/ in feature commits. Memory lands as its own periodic chore PR, triggered by arc-close, external reference, or monthly housekeeping.
+name: Memory changes excluded from PRs (with closing-PR exception)
+description: Don't stage .claude-memory/ in feature commits — with one exception. The closing PR of a feature arc carries its retro + TODO Shipped move; everything else lands as its own periodic chore PR (external-reference trigger or monthly sweep).
 type: feedback
 originSessionId: f4ac39e5-d24f-4335-a75d-edce7263c131
 ---
-When committing feature work, do not stage files in `.claude-memory/`. Memory changes should not be mixed into feature PRs.
+When committing feature work, do not stage files in `.claude-memory/`. Memory changes should not be mixed into feature PRs — **with one exception**: the closing PR of a feature arc carries its own retro + the TODO.md move-to-Shipped (see "Exception" section below). Everything else still lands as a separate `chore(memory): …` PR.
 
-If memory files have been added or modified during the session, mention it when handing off the branch: "Memory files were also updated — want to do a separate commit for those?"
+If memory files have been added or modified during the session and they're *not* covered by the closing-PR exception, mention it when handing off the branch: "Memory files were also updated — want to do a separate commit for those?"
 
-**Why:** Memory files are workflow metadata, not feature code. Mixing them into feature PRs adds noise to diffs and code review.
+**Why:** General workflow memory (feedback files, pattern docs, user-profile tweaks) is metadata about *how we work*, not metadata about *what shipped* — it doesn't belong in feature diffs. The closing-PR exception is specifically for memory that documents *the thing being shipped* (its retro) plus the TODO.md row that moves it to Shipped. Bundling those keeps the work and its record atomic.
 
-**How to apply:** When running `git add`, explicitly list feature files rather than using `git add .` or `git add -A`. After the feature commit, check `git status` for `.claude-memory/` changes and flag them to Drew.
+**How to apply:** When running `git add`, explicitly list feature files. For closing PRs, that includes the retro + `retros/index.md` + `TODO.md`; for non-closing PRs, that excludes everything in `.claude-memory/`. After the commit, check `git status` for unstaged `.claude-memory/` changes and flag them to Drew.
 
 ## When memory *does* land
 
-"Don't stage with features" is the rule; the implicit corollary was "never, then," which in practice meant a 46-file gap accumulated over a month before a blog post referenced memory content and forced the issue. The updated rule:
+"Don't stage with features" is the rule; the implicit corollary was "never, then," which in practice meant a 46-file gap accumulated over a month before a blog post referenced memory content and forced the issue. The updated rules:
 
-Memory lands as its own small `chore/*` PR when **any** of the following fires:
+### Exception — closing PR of a feature arc carries its own retro + TODO update
 
-1. **A feature arc closes and its retro is written.** A "feature arc" is a multi-PR thread (book-detail arc, duplicate-management arc, going-public arc). Land the arc's retro + any feedback / pattern files accumulated during it, together, shortly after the arc's final PR merges. Subject line: `chore(memory): retro + patterns from <arc> arc`.
-2. **An external artefact references memory content.** Blog posts, README edits, or any doc that links to `.claude-memory/` files needs those files to actually be public. When such an artefact is prepared, a memory-landing PR goes in *before* the artefact's PR merges — otherwise the artefact ships broken links.
-3. **Monthly housekeeping.** If neither (1) nor (2) has fired in ~30 days, do a sweep regardless. Catches drift: new feedback files written in passing, small pattern-doc updates, one-off references that never reached the external-artefact threshold. Subject line: `chore(memory): monthly sweep`.
+The PR that ships the **last piece of an arc** also lands:
+
+- The arc's retro under `.claude-memory/retros/`.
+- The `retros/index.md` link to the new retro.
+- The `TODO.md` move-to-Shipped row, including any follow-up TODOs surfaced during the arc and any cross-reference renumbering.
+
+These ride along with the closing PR (one branch, multiple commits if helpful — the squash preserves every commit subject in the squash-commit body). Bundling keeps the work and its full record atomic: when the feature ships, its retro and TODO state ship with it, and there's no "I shipped the feature, then forgot to write the retro / move the TODO row" gap. Locked in 2026-04-28 after the staging-DB-sep arc shipped this way (PR #130 retro + blog + TODO + new follow-ups, all together).
+
+What still doesn't ride along: feedback files, pattern-doc updates, user-profile tweaks, project notes — any general workflow memory accumulated during the arc but not specifically *about* what shipped. Those go in the periodic memory chore PR per the triggers below.
+
+### Other memory still lands as its own `chore(memory): …` PR
+
+Memory not covered by the closing-PR exception lands as its own small `chore/*` PR when **any** of these fires:
+
+1. **An external artefact references memory content.** Blog posts, README edits, or any doc that links to `.claude-memory/` files needs those files to actually be public. When such an artefact is prepared, a memory-landing PR goes in *before* the artefact's PR merges — otherwise the artefact ships broken links.
+2. **Monthly housekeeping.** If neither (1) nor a closing-PR exception has fired in ~30 days, do a sweep regardless. Catches drift: new feedback files written in passing, small pattern-doc updates, one-off references that never reached the external-artefact threshold. Subject line: `chore(memory): monthly sweep`.
+3. **A blog post is being written.** Blog posts are their own PRs (separate from the closing-arc PR they may reference) — same rules as any other external-artefact case.
 
 ## What to include in a memory chore PR
 

--- a/.claude-memory/project_blog.md
+++ b/.claude-memory/project_blog.md
@@ -19,7 +19,7 @@ When Drew opens a session with "let's work on the blog" or similar:
 2. **Propose 3 candidate post outlines** — different angles on different parts of the corpus. Brief: title, 2–3 sentence summary, which retros / patterns it draws from, who it's for.
 3. **Wait for Drew to pick** (or hybridise). Don't draft until selection is explicit.
 4. **Drafting**: aim for the post Drew picked, ~1000–2000 words depending on scope. Use the retro `Quotable` lines as candidate pull-quotes. Cite specific PRs by number (`PR #42`) when grounding a claim — readers can follow the link.
-5. **Land in `blog/` at repo root** as a single `.md` file per post. Filename `YYYY-MM-DD-slug.md`. (Create the `blog/` directory on first post.)
+5. **Land in `blog/` at repo root** as a single `.md` file per post. Filename `YYYY-MM-DD-NN-slug.md` where `NN` is a zero-padded sequence number for that date (`01`, `02`, …) — ensures multiple posts on the same day sort chronologically by filename. Start a new date at `01` even if only one post is planned. (Create the `blog/` directory on first post.)
 6. **Treat the post as a feature**: own branch, own PR, the same small-PR / hand-off-for-push rhythm. Drew pushes and merges as usual.
 7. **After publish**: capture any insight from the writing process itself in a small retro file under `retros/` so the meta-arc gets tracked too.
 
@@ -37,9 +37,15 @@ Audience: other developers using or interested in using Claude / Claude Code on 
 - **Claude-perspective observations are fair game.** Things like "what gets loaded on session startup and in what order" or "what user-profile memory feels like from inside" are available to a Claude-narrator and not to a Drew-narrator. Use them where they add content, not just for flavour.
 - **What Claude won't claim:** solo authorship of Drew's framing calls (experiment framing, Option-A decisions, etc.) or a personal history beyond the project ("the past 30 years of software engineering has taught me..." — no).
 
-## Post backlog (candidate topics beyond the corpus)
+## Post backlog
 
-Concrete ideas that have surfaced mid-project and are worth drafting once the main corpus ideas are mined. Less structured than the `retros/` + `patterns.md` sources; add one-liners as they come up.
+The corpus-derived candidate list (one-time mine of all retros + `patterns.md` as of 2026-04-28) lives in [`blog_post_backlog.md`](blog_post_backlog.md). Each entry has a one-line angle and the source retro it anchors on. When picking the next post, start there — it's the definitive count of what's mineable from existing retros.
+
+Going forward, new retros add their own candidate entry to the backlog at write time, and shipped posts move from "candidates" to "shipped" in the same file.
+
+### Post-corpus ideas (not from a specific shipped arc)
+
+These didn't come from a retro — they surfaced mid-project as standalone observations. Add one-liners as they come up.
 
 - **Branch protection as a solo dev isn't overhead, it's a second pair of eyes.** Drew's observation after the repo flipped public: the new "CI must pass + reviewer-optional" rhythm slows merges slightly but eliminates the "I thought I'd merged that" failure mode (see `retros/retro_book_view_page_pr1.md` for the specific incident). The post would argue that the bureaucracy framing misses the point — the forcing function is the value, not the ceremony.
 
@@ -47,6 +53,6 @@ Concrete ideas that have surfaced mid-project and are worth drafting once the ma
 
 In a fresh Claude Code session, this is enough to get going:
 
-> Let's work on the BookTracker blog. Read the retros index and patterns doc, then propose 3 candidate post outlines I can pick from.
+> Let's work on the BookTracker blog. Read the backlog and propose 3 candidate post outlines I can pick from.
 
 The memory directory is loaded automatically; this prompt just signals intent + asks for proposals before drafting.


### PR DESCRIPTION
- **chore(memory): add branch-from-main rule + closing-PR-carries-retro exception**
- **chore(memory): add blog-post backlog (corpus catch-up + going-forward)**
