### PR TITLE
chore(infra): add environment-scoped FIC for booktracker-ci

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -187,7 +187,9 @@ After the first `deploy.ps1` run, set up the GitHub → Azure OIDC link:
     -GitHubOrg 'N3rdage' -GitHubRepo 'the-library'
 ```
 
-The script creates a `booktracker-ci` app registration with federated identity credentials (one for pushes to `main`, one for pull requests), assigns it Contributor on `rg-booktracker-prod`, and prints six GitHub repository variables for you to configure at `Settings → Secrets and variables → Actions → Variables`.
+The script creates a `booktracker-ci` app registration with federated identity credentials (one for pushes to `main`, one for pull requests, one for the `production` GitHub Environment used by `swap.yml`), assigns it Contributor on `rg-booktracker-prod`, and prints six GitHub repository variables for you to configure at `Settings → Secrets and variables → Actions → Variables`.
+
+> **Heads-up on environment FICs.** Any workflow that opts into a GitHub Environment (`environment: production` on a job) presents a different OIDC subject claim shape — `repo:<org>/<repo>:environment:<env-name>` instead of `…:ref:refs/heads/<branch>`. If you add a new Environment to a workflow without a matching FIC on `booktracker-ci`, dispatch fails with `AADSTS700213: No matching federated identity record found`. Re-run `setup-github-oidc.ps1` after adding new environments — the `$desiredFics` block in the script is the source of truth.
 
 The script also grants the CI SP the narrow permissions needed by the scheduled Easy Auth secret rotation:
 - **Key Vault Secrets Officer** on the single KV in the RG (write access to `AuthClientSecret`).

--- a/infra/setup-github-oidc.ps1
+++ b/infra/setup-github-oidc.ps1
@@ -55,9 +55,16 @@ if (-not $sp) {
 }
 
 # ---- Federated identity credentials -----------------------------------------
-# A FIC binds a GitHub workflow run (subject) to this app registration.
-# Adding both the branch FIC (for push-to-main deploys) and the pull-request
-# FIC (so future PR workflows can validate against Azure if needed).
+# A FIC binds a GitHub workflow run (subject) to this app registration. The
+# OIDC subject claim shape differs by trigger:
+#   - branch push:    repo:<org>/<repo>:ref:refs/heads/<branch>
+#   - pull request:   repo:<org>/<repo>:pull_request
+#   - environment:    repo:<org>/<repo>:environment:<env-name>
+# Workflows that opt into a GitHub Environment (e.g. swap.yml uses
+# `environment: production` for the wait-timer + branch-restriction guards)
+# present the third shape, so a separate FIC is needed for that subject.
+# Without the env FIC, the swap dispatch fails with AADSTS700213
+# ("No matching federated identity record found...").
 $existingFics = Get-MgApplicationFederatedIdentityCredential -ApplicationId $app.Id
 $desiredFics = @(
     @{
@@ -69,6 +76,11 @@ $desiredFics = @(
         Name = 'github-pull-request'
         Subject = "repo:${GitHubOrg}/${GitHubRepo}:pull_request"
         Description = "$GitHubOrg/$GitHubRepo pull_request"
+    },
+    @{
+        Name = 'github-environment-production'
+        Subject = "repo:${GitHubOrg}/${GitHubRepo}:environment:production"
+        Description = "$GitHubOrg/$GitHubRepo environment:production (swap.yml)"
     }
 )
 foreach ($f in $desiredFics) {


### PR DESCRIPTION
Workflows that opt into a GitHub Environment (today: swap.yml uses
`environment: production` for the wait-timer + branch-restriction guards
that landed with PR #124) present a different OIDC subject claim shape
than branch/PR triggers: `repo:<org>/<repo>:environment:<env-name>`
instead of `:ref:refs/heads/<branch>`. The booktracker-ci app registration
only had FICs for the branch + pull_request shapes, so swap dispatches
failed at OIDC login with `AADSTS700213: No matching federated identity
record found`.

setup-github-oidc.ps1: add `github-environment-production` to the
$desiredFics list. Existing idempotency loop handles re-runs (skips FICs
that already exist), so re-running on a tenant that already has the env
FIC manually added (e.g. via Portal as the immediate unblock) is a no-op.

infra/README.md: heads-up note describing the subject-claim shape
difference and pointing at the script as source of truth — saves the
next person from having to diagnose the AADSTS700213 from scratch.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
