### PR TITLE
fix(lookup): series enrichment requires Open Library details view

### DIFF
--- a/BookTracker.Tests/Services/BookLookupServiceTests.cs
+++ b/BookTracker.Tests/Services/BookLookupServiceTests.cs
@@ -168,16 +168,29 @@ public class BookLookupServiceTests
     }
 
     [Fact]
-    public async Task LookupByIsbnAsync_PopulatesSeries_FromOpenLibrary()
+    public async Task LookupByIsbnAsync_PopulatesSeries_FromOpenLibraryDetailsView()
     {
+        // Open Library's `jscmd=data` view (the curated abbreviated shape) does
+        // NOT include the series field. Series lives only in `jscmd=details`.
+        // The service makes two OL calls — data for the friendly fields, then
+        // details for series — and combines the result. This test proves both
+        // calls happen and the details payload is what populates Series.
         var handler = new FakeHandler
         {
-            ["openlibrary.org/api/books"] = OkJson($$"""
+            ["jscmd=data"] = OkJson($$"""
                 {
                   "ISBN:{{Isbn}}": {
                     "title": "Sourcery",
-                    "authors": [ { "name": "Terry Pratchett" } ],
-                    "series": [ "Discworld -- 5" ]
+                    "authors": [ { "name": "Terry Pratchett" } ]
+                  }
+                }
+                """),
+            ["jscmd=details"] = OkJson($$"""
+                {
+                  "ISBN:{{Isbn}}": {
+                    "details": {
+                      "series": [ "Discworld -- 5" ]
+                    }
                   }
                 }
                 """)
@@ -187,9 +200,39 @@ public class BookLookupServiceTests
         var result = await svc.LookupByIsbnAsync(Isbn, CancellationToken.None);
 
         Assert.NotNull(result);
-        Assert.Equal("Discworld", result!.Series);
+        Assert.Equal("Sourcery", result!.Title);
+        Assert.Equal("Discworld", result.Series);
         Assert.Equal(5, result.SeriesNumber);
         Assert.Equal("5", result.SeriesNumberRaw);
+        Assert.Contains(handler.Requests, r => r.Contains("jscmd=details"));
+    }
+
+    [Fact]
+    public async Task LookupByIsbnAsync_LeavesSeriesNull_WhenDetailsCallFails()
+    {
+        // Graceful degrade: if the details call fails (404, parse error, etc.),
+        // the data view still produces a valid result with Series=null. The
+        // suggestion banner falls back to local title/author matching.
+        var handler = new FakeHandler
+        {
+            ["jscmd=data"] = OkJson($$"""
+                {
+                  "ISBN:{{Isbn}}": {
+                    "title": "Sourcery",
+                    "authors": [ { "name": "Terry Pratchett" } ]
+                  }
+                }
+                """)
+            // No mock for jscmd=details — handler returns 404, service swallows.
+        };
+
+        var svc = CreateService(handler, troveKey: "present");
+        var result = await svc.LookupByIsbnAsync(Isbn, CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.Equal("Sourcery", result!.Title);
+        Assert.Null(result.Series);
+        Assert.Null(result.SeriesNumber);
     }
 
     [Theory]

--- a/BookTracker.Web/Components/Pages/Books/BulkAdd.razor
+++ b/BookTracker.Web/Components/Pages/Books/BulkAdd.razor
@@ -217,9 +217,15 @@
                                     }
                                     else
                                     {
-                                        <div class="fw-semibold text-truncate">@(row.Title ?? "\u2014")</div>
+                                        @* Wrap multi-line on mobile rather than truncating with ellipsis \u2014
+                                           Open Library titles sometimes include format/contributor noise
+                                           ("by X (Author) ON Compact Disc") and ellipsis hides useful
+                                           context. text-break handles long unbroken substrings (URLs,
+                                           glued-up titles like "TheArt of Discworld") that would
+                                           otherwise overflow the flex container. *@
+                                        <div class="fw-semibold text-break">@(row.Title ?? "\u2014")</div>
                                     }
-                                    <div class="text-muted small">@(row.Author ?? "\u2014")</div>
+                                    <div class="text-muted small text-break">@(row.Author ?? "\u2014")</div>
                                     <div class="font-monospace text-muted" style="font-size: 0.7rem;">@row.Isbn</div>
                                 </div>
                                 <button type="button" class="btn btn-outline-danger btn-sm flex-shrink-0 ms-2" @onclick="() => VM.RemoveRow(row)" title="Remove">
@@ -486,7 +492,10 @@
     {
         if (row.SeriesSuggestion is not null && row.Action == BulkAddViewModel.RowAction.Pending)
         {
-            <div class="text-warning small mt-1">
+            @* text-break ensures the suggestion message wraps cleanly even when
+               it contains long unbroken segments (series names, em-dash phrases).
+               Without it, mobile cards show the message clipped at the right edge. *@
+            <div class="text-warning small mt-1 text-break">
                 <strong>Series:</strong> @row.SeriesSuggestion.Message
                 @if (row.SeriesSuggestion.SeriesId.HasValue)
                 {

--- a/BookTracker.Web/Services/BookLookupService.cs
+++ b/BookTracker.Web/Services/BookLookupService.cs
@@ -95,7 +95,11 @@ public partial class BookLookupService(
                 .ToList();
 
             var (olDate, olPrecision) = ParseLooseDate(book.PublishDate);
-            var (seriesName, seriesNumber, seriesNumberRaw) = ParseOpenLibrarySeries(book.Series);
+            // Series lives in the `jscmd=details` view, not the `jscmd=data`
+            // curated view we hit above — so this is a separate call. Failure
+            // here is non-fatal: the result still returns with Series=null and
+            // the suggestion banner falls back to local title/author matching.
+            var (seriesName, seriesNumber, seriesNumberRaw) = await TryFetchOpenLibrarySeriesAsync(isbn, ct);
             return new BookLookupResult(
                 Isbn: isbn,
                 Title: book.Title,
@@ -116,6 +120,25 @@ public partial class BookLookupService(
         {
             logger.LogWarning(ex, "Open Library lookup failed for ISBN {Isbn}", isbn);
             return null;
+        }
+    }
+
+    private async Task<(string?, int?, string?)> TryFetchOpenLibrarySeriesAsync(string isbn, CancellationToken ct)
+    {
+        try
+        {
+            var url = $"https://openlibrary.org/api/books?bibkeys=ISBN:{isbn}&format=json&jscmd=details";
+            var doc = await http.GetFromJsonAsync<Dictionary<string, OpenLibraryDetailsWrapper>>(url, ct);
+            if (doc is null || !doc.TryGetValue($"ISBN:{isbn}", out var wrapper) || wrapper.Details is null)
+            {
+                return (null, null, null);
+            }
+            return ParseOpenLibrarySeries(wrapper.Details.Series);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Open Library details lookup failed for ISBN {Isbn}", isbn);
+            return (null, null, null);
         }
     }
 
@@ -325,9 +348,19 @@ public partial class BookLookupService(
         [JsonPropertyName("cover")] public OpenLibraryCover? Cover { get; set; }
         [JsonPropertyName("physical_format")] public string? PhysicalFormat { get; set; }
         [JsonPropertyName("physical_dimensions")] public string? PhysicalDimensions { get; set; }
-        // `series` arrives as a list of free-text strings — entries like
-        // "Discworld", "Discworld -- 5", or "Foundation series ; bk. 1".
-        // Parsed via ParseOpenLibrarySeries.
+    }
+
+    // The `jscmd=details` view wraps the Edition's raw record under `details`.
+    // Used only for the `series` field — everything else parses from the
+    // friendlier `jscmd=data` shape (OpenLibraryBook above).
+    private sealed class OpenLibraryDetailsWrapper
+    {
+        [JsonPropertyName("details")] public OpenLibraryDetails? Details { get; set; }
+    }
+    private sealed class OpenLibraryDetails
+    {
+        // Free-text strings — entries like "Discworld", "Discworld -- 5",
+        // or "Foundation series ; bk. 1". Parsed via ParseOpenLibrarySeries.
         [JsonPropertyName("series")] public List<string>? Series { get; set; }
     }
     private sealed class OpenLibraryAuthor { [JsonPropertyName("name")] public string? Name { get; set; } }


### PR DESCRIPTION
Real bug from PR-A capture testing: the Open Library `jscmd=data` view
we hit doesn't include the `series` field — it's curated/abbreviated.
Series lives only in `jscmd=details`. PR-A's parser was correct in
shape but the field never arrived in the response we received, so the
suggestion banner always fell back to local title/author matching.

Fix:
- TryOpenLibraryAsync runs as before for the friendly fields, then
  TryFetchOpenLibrarySeriesAsync makes a second call to the details
  endpoint and extracts `details.series`. Failure in the details call
  is non-fatal — Series stays null, suggestion banner falls back to
  local matching, original lookup result is unaffected.
- New OpenLibraryDetailsWrapper / OpenLibraryDetails DTOs (only the
  series field; everything else stays in the data view).
- Removed the misleading `Series` property from OpenLibraryBook (the
  data view doesn't have it).

Also fix overflow on Bulk Add mobile cards (issue 2 from the same
testing session):
- Title: switch from `text-truncate` (single-line ellipsis hides
  useful context, especially when Open Library titles are long /
  contain noise like "by X (Author) ON Compact Disc") to multi-line
  `text-break` wrap.
- Series suggestion: add `text-break` so long messages wrap cleanly
  inside the flex column instead of clipping at the right edge.

Tests:
- LookupByIsbnAsync_PopulatesSeries_FromOpenLibraryDetailsView mocks
  both endpoints separately and proves details is what populates Series.
- LookupByIsbnAsync_LeavesSeriesNull_WhenDetailsCallFails covers the
  graceful-degrade path (details 404 → result still valid, Series=null).
- All 308 tests pass.

Honest caveat — not browser-tested. Worth a sanity scan of (a) a real
Discworld novel ISBN like 9780552134613 (Sourcery, expected to surface
"Discworld #5" via the API now), (b) a long-title ISBN to confirm the
mobile card no longer clips, and (c) a non-series book to confirm the
banner falls back to the local "this author has X works" suggestion.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
