### PR TITLE
fix: EF Core 10.x LINQ regression on /publishers page load

### DIFF
--- a/BookTracker.Web/ViewModels/PublisherListViewModel.cs
+++ b/BookTracker.Web/ViewModels/PublisherListViewModel.cs
@@ -30,9 +30,16 @@ public class PublisherListViewModel(IDbContextFactory<BookTrackerDbContext> dbFa
         Loading = true;
         await using var db = await dbFactory.CreateDbContextAsync();
 
+        // OrderBy before Select so EF orders on the source entity column, not on
+        // a property of a constructed PublisherRow. EF Core 10.x can't translate
+        // OrderBy-on-record-projection when the record's constructor includes a
+        // navigation aggregate (here `p.Editions.Count`) — it tries to invoke
+        // the constructor inside the ORDER BY and fails. Anonymous types still
+        // translate fine because EF maps property names back to source columns;
+        // record positional constructors break that mapping.
         Publishers = await db.Publishers
-            .Select(p => new PublisherRow(p.Id, p.Name, p.Editions.Count))
             .OrderBy(p => p.Name)
+            .Select(p => new PublisherRow(p.Id, p.Name, p.Editions.Count))
             .ToListAsync();
 
         Loading = false;


### PR DESCRIPTION
EF Core 10.x (post-bump #126) can no longer translate `Select(p => new PublisherRow(...))` followed by `OrderBy(p => p.Name)` when the record constructor includes a navigation aggregate (`p.Editions.Count`). It tries to invoke the constructor inside the ORDER BY clause and throws InvalidOperationException at query compile time. The /publishers page crashed the Blazor circuit on first navigation as a result.

Fix is a one-line reorder: OrderBy on the entity (Publisher.Name → straightforward column), THEN Select into the record. Same SQL shape, same result, but EF doesn't have to lift a property out of a constructed record.

Anonymous-type projections still translate correctly because EF resolves property names back to source columns by name; record positional constructors break that mapping. AuthorListViewModel and SeriesListViewModel inspected and not affected (anonymous type and OrderBy-first respectively).

Test-infra gap: PublisherListViewModelTests.LoadAsync_PopulatesPublisherRows_WithEditionCounts passed against the broken code because BookTracker.Tests uses EF InMemory, which translates LINQ in-process without enforcing SQL translation rules. Worth tracking as a follow-up TODO, not in scope for this fix.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
