### PR TITLE
feat/multi author works pr1

### DIFF
--- a/BookTracker.Data/BookTrackerDbContext.cs
+++ b/BookTracker.Data/BookTrackerDbContext.cs
@@ -16,6 +16,7 @@ public class BookTrackerDbContext(DbContextOptions<BookTrackerDbContext> options
     public DbSet<MaintenanceLog> MaintenanceLogs => Set<MaintenanceLog>();
     public DbSet<Work> Works => Set<Work>();
     public DbSet<Author> Authors => Set<Author>();
+    public DbSet<WorkAuthor> WorkAuthors => Set<WorkAuthor>();
     public DbSet<IgnoredDuplicate> IgnoredDuplicates => Set<IgnoredDuplicate>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
@@ -102,11 +103,33 @@ public class BookTrackerDbContext(DbContextOptions<BookTrackerDbContext> options
             .OnDelete(DeleteBehavior.SetNull);
 
         // Each Work belongs to exactly one Author entity (which itself may
-        // be a pen-name alias of another canonical Author).
+        // be a pen-name alias of another canonical Author). Legacy single-
+        // author FK kept during PR1 of the multi-author cutover; PR2 will
+        // drop this and switch reads to the WorkAuthors join below.
         modelBuilder.Entity<Work>()
             .HasOne(w => w.Author)
             .WithMany(a => a.Works)
             .HasForeignKey(w => w.AuthorId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        // WorkAuthor join entity for the Work ↔ Author M:N relationship.
+        // Composite PK on (WorkId, AuthorId) — the same Author can't appear
+        // twice on a single Work. Cascade on Work delete (the join row only
+        // exists as long as the Work does); Restrict on Author delete (don't
+        // allow deleting an Author that's still credited on a Work).
+        modelBuilder.Entity<WorkAuthor>()
+            .HasKey(wa => new { wa.WorkId, wa.AuthorId });
+
+        modelBuilder.Entity<WorkAuthor>()
+            .HasOne(wa => wa.Work)
+            .WithMany(w => w.WorkAuthors)
+            .HasForeignKey(wa => wa.WorkId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        modelBuilder.Entity<WorkAuthor>()
+            .HasOne(wa => wa.Author)
+            .WithMany(a => a.WorkAuthors)
+            .HasForeignKey(wa => wa.AuthorId)
             .OnDelete(DeleteBehavior.Restrict);
 
         modelBuilder.Entity<Author>()

--- a/BookTracker.Data/Migrations/20260504011049_AddWorkAuthor.Designer.cs
+++ b/BookTracker.Data/Migrations/20260504011049_AddWorkAuthor.Designer.cs
@@ -4,6 +4,7 @@ using BookTracker.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BookTracker.Data.Migrations
 {
     [DbContext(typeof(BookTrackerDbContext))]
-    partial class BookTrackerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260504011049_AddWorkAuthor")]
+    partial class AddWorkAuthor
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BookTracker.Data/Migrations/20260504011049_AddWorkAuthor.cs
+++ b/BookTracker.Data/Migrations/20260504011049_AddWorkAuthor.cs
@@ -1,0 +1,64 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BookTracker.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddWorkAuthor : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "WorkAuthors",
+                columns: table => new
+                {
+                    WorkId = table.Column<int>(type: "int", nullable: false),
+                    AuthorId = table.Column<int>(type: "int", nullable: false),
+                    Order = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_WorkAuthors", x => new { x.WorkId, x.AuthorId });
+                    table.ForeignKey(
+                        name: "FK_WorkAuthors_Authors_AuthorId",
+                        column: x => x.AuthorId,
+                        principalTable: "Authors",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_WorkAuthors_Works_WorkId",
+                        column: x => x.WorkId,
+                        principalTable: "Works",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_WorkAuthors_AuthorId",
+                table: "WorkAuthors",
+                column: "AuthorId");
+
+            // Backfill: every existing Work seeds one WorkAuthor row from its
+            // legacy AuthorId, with Order = 0 (lead/sole author). Idempotent
+            // via NOT EXISTS so re-running the migration on an already-
+            // migrated DB is a no-op (matches patterns.md §6).
+            migrationBuilder.Sql(@"
+INSERT INTO [WorkAuthors] ([WorkId], [AuthorId], [Order])
+SELECT [Id], [AuthorId], 0
+FROM [Works]
+WHERE NOT EXISTS (
+    SELECT 1 FROM [WorkAuthors] wa
+    WHERE wa.[WorkId] = [Works].[Id] AND wa.[AuthorId] = [Works].[AuthorId]
+);");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "WorkAuthors");
+        }
+    }
+}

--- a/BookTracker.Data/Models/Author.cs
+++ b/BookTracker.Data/Models/Author.cs
@@ -27,4 +27,7 @@ public class Author
     public List<Author> Aliases { get; set; } = [];
 
     public List<Work> Works { get; set; } = [];
+
+    /// <summary>Multi-author join entries — every Work this Author is credited on, including co-authored ones.</summary>
+    public List<WorkAuthor> WorkAuthors { get; set; } = [];
 }

--- a/BookTracker.Data/Models/Work.cs
+++ b/BookTracker.Data/Models/Work.cs
@@ -21,8 +21,15 @@ public class Work
     [MaxLength(300)]
     public string? Subtitle { get; set; }
 
+    // Legacy single-author FK — kept during PR1 of the multi-author cutover
+    // for dual-write. Reads still go through this; the new WorkAuthors
+    // collection populates in parallel until PR2 cuts reads over and drops
+    // this column.
     public int AuthorId { get; set; }
     public Author Author { get; set; } = null!;
+
+    /// <summary>Multi-author join. Populated alongside AuthorId during the cutover; primary read source after PR2.</summary>
+    public List<WorkAuthor> WorkAuthors { get; set; } = [];
 
     /// <summary>The year/date the Work was first published — distinct from any specific Edition's print date.</summary>
     public DateOnly? FirstPublishedDate { get; set; }

--- a/BookTracker.Data/Models/WorkAuthor.cs
+++ b/BookTracker.Data/Models/WorkAuthor.cs
@@ -1,0 +1,32 @@
+namespace BookTracker.Data.Models;
+
+// Join entity for Work ↔ Author (M:N). A Work can credit multiple Authors
+// (Preston + Child writing *Relic* together; the Destroyer series credits
+// Murphy + Sapir for ~90% of the run).
+//
+// `Order` = display position. 0 = lead/primary, ascending for additional
+// authors — keeps "Preston & Child" stable rather than alphabetising.
+//
+// Author canonical-alias rollup chains transparently: each WorkAuthor.Author
+// → Author.CanonicalAuthorId resolves the same way as before. A Work
+// co-credited to Stephen King + Richard Bachman rolls up under King's
+// canonical for aggregations that dedupe by canonical.
+//
+// Composite PK (WorkId, AuthorId) encodes the invariant that the same
+// Author can't appear twice on a single Work.
+//
+// PR1 of the multi-author cutover (additive): Work keeps both AuthorId
+// (legacy single-author FK) and WorkAuthors (this join) — saves dual-write,
+// reads still come from AuthorId. PR2 drops AuthorId and switches reads
+// to WorkAuthors.
+public class WorkAuthor
+{
+    public int WorkId { get; set; }
+    public Work Work { get; set; } = null!;
+
+    public int AuthorId { get; set; }
+    public Author Author { get; set; } = null!;
+
+    /// <summary>Display position. 0 = lead/primary author, ascending for additional authors.</summary>
+    public int Order { get; set; }
+}

--- a/BookTracker.Tests/Services/AuthorResolverTests.cs
+++ b/BookTracker.Tests/Services/AuthorResolverTests.cs
@@ -1,0 +1,97 @@
+using BookTracker.Data.Models;
+using BookTracker.Web.Services;
+
+namespace BookTracker.Tests.Services;
+
+public class AuthorResolverTests
+{
+    private readonly TestDbContextFactory _factory = new();
+
+    [Fact]
+    public void ParseNames_SplitsOnCommaAndAmpersand()
+    {
+        Assert.Equal(["Douglas Preston", "Lincoln Child"], AuthorResolver.ParseNames("Douglas Preston, Lincoln Child"));
+        Assert.Equal(["Douglas Preston", "Lincoln Child"], AuthorResolver.ParseNames("Douglas Preston & Lincoln Child"));
+        Assert.Equal(["Murphy", "Sapir"], AuthorResolver.ParseNames("Murphy, Sapir"));
+    }
+
+    [Fact]
+    public void ParseNames_TrimsWhitespaceAndDropsBlanks()
+    {
+        Assert.Equal(["Preston", "Child"], AuthorResolver.ParseNames("  Preston ,, &  Child   "));
+    }
+
+    [Fact]
+    public void ParseNames_EmptyInputs_ReturnEmptyList()
+    {
+        Assert.Empty(AuthorResolver.ParseNames(null));
+        Assert.Empty(AuthorResolver.ParseNames(""));
+        Assert.Empty(AuthorResolver.ParseNames("  "));
+    }
+
+    [Fact]
+    public async Task FindOrCreateAllAsync_ReusesExistingAuthorsAndCreatesNew()
+    {
+        using (var db = _factory.CreateDbContext())
+        {
+            db.Authors.Add(new Author { Name = "Douglas Preston" });
+            await db.SaveChangesAsync();
+        }
+
+        await using var db2 = _factory.CreateDbContext();
+        var authors = await AuthorResolver.FindOrCreateAllAsync(
+            ["Douglas Preston", "Lincoln Child"], db2);
+        await db2.SaveChangesAsync();
+
+        // Order preserved; Preston was reused (so two authors total in DB);
+        // Child is freshly created.
+        Assert.Equal(2, authors.Count);
+        Assert.Equal("Douglas Preston", authors[0].Name);
+        Assert.Equal("Lincoln Child", authors[1].Name);
+
+        using var verify = _factory.CreateDbContext();
+        Assert.Equal(2, verify.Authors.Count());
+    }
+
+    [Fact]
+    public async Task FindOrCreateAllAsync_DedupesCaseInsensitivelyAndDropsBlanks()
+    {
+        await using var db = _factory.CreateDbContext();
+        var authors = await AuthorResolver.FindOrCreateAllAsync(
+            ["Tolkien", "  ", "tolkien", "Tolkien"], db);
+
+        // First "Tolkien" is created; subsequent variants are dedup'd; the
+        // blank entry is dropped.
+        Assert.Single(authors);
+        Assert.Equal("Tolkien", authors[0].Name);
+    }
+
+    [Fact]
+    public async Task AssignAuthors_DualWritesLeadAndJoinWithOrder()
+    {
+        // Direct unit test of the helper — independent of the surrounding
+        // VM save paths so a regression in AssignAuthors surfaces here.
+        await using var db = _factory.CreateDbContext();
+        var preston = new Author { Name = "Preston" };
+        var child = new Author { Name = "Child" };
+        db.Authors.AddRange(preston, child);
+
+        var work = new Work { Title = "Relic" };
+
+        AuthorResolver.AssignAuthors(work, [preston, child]);
+
+        Assert.Equal(preston, work.Author);
+        Assert.Equal(2, work.WorkAuthors.Count);
+        Assert.Equal(preston, work.WorkAuthors[0].Author);
+        Assert.Equal(0, work.WorkAuthors[0].Order);
+        Assert.Equal(child, work.WorkAuthors[1].Author);
+        Assert.Equal(1, work.WorkAuthors[1].Order);
+    }
+
+    [Fact]
+    public void AssignAuthors_EmptyList_Throws()
+    {
+        var work = new Work { Title = "x" };
+        Assert.Throws<ArgumentException>(() => AuthorResolver.AssignAuthors(work, []));
+    }
+}

--- a/BookTracker.Tests/ViewModels/BookAddViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/BookAddViewModelTests.cs
@@ -89,7 +89,7 @@ public class BookAddViewModelTests
         // WorkInput (for the auto-created primary Work).
         Assert.Equal("And Then There Were None", vm.BookInput.Title);
         Assert.Equal("And Then There Were None", vm.WorkInput.Title);
-        Assert.Equal("Agatha Christie", vm.WorkInput.Author);
+        Assert.Equal(new[] { "Agatha Christie" }, vm.WorkInput.Authors);
         Assert.Equal("https://example.invalid/cover.jpg", vm.BookInput.DefaultCoverArtUrl);
         // Year-only candidate → year-precision text in the input.
         Assert.Equal("1939", vm.WorkInput.FirstPublishedDate);
@@ -101,7 +101,7 @@ public class BookAddViewModelTests
         var vm = CreateVm();
         vm.BookInput.Title = "User typed this";
         vm.WorkInput.Title = "User typed this";
-        vm.WorkInput.Author = "User author";
+        vm.WorkInput.Authors = ["User author"];
         vm.WorkInput.FirstPublishedDate = "15 Jun 1939";
 
         var candidate = new BookSearchCandidate(
@@ -116,7 +116,7 @@ public class BookAddViewModelTests
         await vm.ApplyCandidateAsync(candidate, CreateGenrePicker());
 
         Assert.Equal("User typed this", vm.BookInput.Title);
-        Assert.Equal("User author", vm.WorkInput.Author);
+        Assert.Equal(new[] { "User author" }, vm.WorkInput.Authors);
         Assert.Equal("15 Jun 1939", vm.WorkInput.FirstPublishedDate);
     }
 
@@ -126,7 +126,7 @@ public class BookAddViewModelTests
         var vm = CreateVm();
         vm.BookInput.Title = "And Then There Were None";
         vm.WorkInput.Title = "And Then There Were None";
-        vm.WorkInput.Author = "Agatha Christie";
+        vm.WorkInput.Authors = ["Agatha Christie"];
         vm.EditionInput.Isbn = "";
 
         var ok = await vm.SaveAsync(new List<int>());
@@ -146,13 +146,13 @@ public class BookAddViewModelTests
         var vm1 = CreateVm();
         vm1.BookInput.Title = "Book A";
         vm1.WorkInput.Title = "Book A";
-        vm1.WorkInput.Author = "Author A";
+        vm1.WorkInput.Authors = ["Author A"];
         Assert.NotNull(await vm1.SaveAsync(new List<int>()));
 
         var vm2 = CreateVm();
         vm2.BookInput.Title = "Book B";
         vm2.WorkInput.Title = "Book B";
-        vm2.WorkInput.Author = "Author B";
+        vm2.WorkInput.Authors = ["Author B"];
         Assert.NotNull(await vm2.SaveAsync(new List<int>()));
 
         using var db = _factory.CreateDbContext();
@@ -185,7 +185,7 @@ public class BookAddViewModelTests
         // Form fields stay empty — the prefill path is skipped because the
         // user is being told "you already own this book" instead.
         Assert.Null(vm.BookInput.Title);
-        Assert.Null(vm.WorkInput.Author);
+        Assert.Empty(vm.WorkInput.Authors);
         // Open Library shouldn't have been hit.
         await _lookup.DidNotReceiveWithAnyArgs().LookupByIsbnAsync(default!, default);
     }
@@ -224,7 +224,7 @@ public class BookAddViewModelTests
         var vm = CreateVm();
         vm.BookInput.Title = "The Hobbit";
         vm.WorkInput.Title = "The Hobbit";
-        vm.WorkInput.Author = "J.R.R. Tolkien";
+        vm.WorkInput.Authors = ["J.R.R. Tolkien"];
         vm.WorkInput.FirstPublishedDate = "21 Sep 1937";
         vm.EditionInput.Isbn = "9780345391803";
 
@@ -238,6 +238,38 @@ public class BookAddViewModelTests
         Assert.Equal("J.R.R. Tolkien", work.Author.Name);
         Assert.Equal(new DateOnly(1937, 9, 21), work.FirstPublishedDate);
         Assert.Equal(DatePrecision.Day, work.FirstPublishedDatePrecision);
+    }
+
+    [Fact]
+    public async Task SaveAsync_MultipleAuthors_DualWritesLeadAndJoin()
+    {
+        // Multi-author cutover PR1: save path sets Work.Author = lead chip
+        // (legacy AuthorId for backwards compat) AND populates Work.WorkAuthors
+        // with all chips, Order ascending. Co-author becomes a real Author row
+        // via find-or-create.
+        var vm = CreateVm();
+        vm.BookInput.Title = "Relic";
+        vm.WorkInput.Title = "Relic";
+        vm.WorkInput.Authors = ["Douglas Preston", "Lincoln Child"];
+        vm.EditionInput.Isbn = "9780812543261";
+
+        var ok = await vm.SaveAsync(new List<int>());
+
+        Assert.NotNull(ok);
+        using var db = _factory.CreateDbContext();
+        var work = db.Works
+            .Include(w => w.Author)
+            .Include(w => w.WorkAuthors).ThenInclude(wa => wa.Author)
+            .Single();
+        Assert.Equal("Douglas Preston", work.Author.Name);
+        Assert.Equal(2, work.WorkAuthors.Count);
+        var ordered = work.WorkAuthors.OrderBy(wa => wa.Order).ToList();
+        Assert.Equal("Douglas Preston", ordered[0].Author.Name);
+        Assert.Equal(0, ordered[0].Order);
+        Assert.Equal("Lincoln Child", ordered[1].Author.Name);
+        Assert.Equal(1, ordered[1].Order);
+        // Both authors exist as canonical Author rows.
+        Assert.Equal(2, db.Authors.Count(a => a.Name == "Douglas Preston" || a.Name == "Lincoln Child"));
     }
 
     [Fact]

--- a/BookTracker.Tests/ViewModels/WorkEditDialogViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/WorkEditDialogViewModelTests.cs
@@ -46,7 +46,7 @@ public class WorkEditDialogViewModelTests
         Assert.False(vm.NotFound);
         Assert.Equal("Mort", vm.Title);
         Assert.Equal("A Discworld Novel", vm.Subtitle);
-        Assert.Equal("Terry Pratchett", vm.AuthorName);
+        Assert.Equal(new[] { "Terry Pratchett" }, vm.AuthorNames);
         Assert.Equal("12 Nov 1987", vm.FirstPublishedDate);
         Assert.NotNull(vm.SelectedSeriesId);
         Assert.Equal(4, vm.SeriesOrder);
@@ -74,7 +74,7 @@ public class WorkEditDialogViewModelTests
         await vm.InitializeAsync(workId);
         vm.Title = "  Mort  ";
         vm.Subtitle = "A Discworld Novel";
-        vm.AuthorName = "Old Author";
+        vm.AuthorNames = ["Old Author"];
         vm.FirstPublishedDate = "1987";
         await vm.SaveAsync();
 
@@ -106,7 +106,7 @@ public class WorkEditDialogViewModelTests
 
         var vm = new WorkEditDialogViewModel(factory);
         await vm.InitializeAsync(workId);
-        vm.AuthorName = "Terry Pratchett";
+        vm.AuthorNames = ["Terry Pratchett"];
         await vm.SaveAsync();
 
         using var db2 = factory.CreateDbContext();
@@ -130,7 +130,7 @@ public class WorkEditDialogViewModelTests
 
         var vm = new WorkEditDialogViewModel(factory);
         await vm.InitializeAsync(workId);
-        vm.AuthorName = "Brand New Author";
+        vm.AuthorNames = ["Brand New Author"];
         await vm.SaveAsync();
 
         using var db2 = factory.CreateDbContext();

--- a/BookTracker.Web/Components/Pages/Books/BulkAdd.razor
+++ b/BookTracker.Web/Components/Pages/Books/BulkAdd.razor
@@ -176,7 +176,14 @@
                                     }
                                     @RenderSeriesSuggestion(row)
                                 </td>
-                                <td>@(row.Author ?? "\u2014")</td>
+                                <td>
+                                    @* Editable so multi-author and lookup-miss rows can be
+                                       fixed inline. Comma or "&" separates multiple authors \u2014
+                                       parsed at save time via AuthorResolver.ParseNames. *@
+                                    <input type="text" class="form-control form-control-sm"
+                                           @bind="row.Author"
+                                           placeholder="Author(s) \u2014 use commas for co-authors" />
+                                </td>
                                 <td>
                                     @RenderSource(row)
                                 </td>
@@ -225,7 +232,9 @@
                                            otherwise overflow the flex container. *@
                                         <div class="fw-semibold text-break">@(row.Title ?? "\u2014")</div>
                                     }
-                                    <div class="text-muted small text-break">@(row.Author ?? "\u2014")</div>
+                                    <input type="text" class="form-control form-control-sm mb-1"
+                                           @bind="row.Author"
+                                           placeholder="Author(s) \u2014 commas for co-authors" />
                                     <div class="font-monospace text-muted" style="font-size: 0.7rem;">@row.Isbn</div>
                                 </div>
                                 <button type="button" class="btn btn-outline-danger btn-sm flex-shrink-0 ms-2" @onclick="() => VM.RemoveRow(row)" title="Remove">

--- a/BookTracker.Web/Components/Shared/MudAuthorPicker.razor
+++ b/BookTracker.Web/Components/Shared/MudAuthorPicker.razor
@@ -33,7 +33,8 @@
             }
         </div>
     }
-    <MudAutocomplete T="string"
+    <MudAutocomplete @ref="autocompleteRef"
+                     T="string"
                      Value="@newAuthor"
                      ValueChanged="OnValueChangedAsync"
                      SearchFunc="SearchAsync"
@@ -55,6 +56,7 @@
     [Parameter] public string HelperText { get; set; } = "Type to find existing or create new. Pick an item or press Enter to add.";
 
     private string? newAuthor;
+    private MudAutocomplete<string>? autocompleteRef;
 
     private async Task<IEnumerable<string>> SearchAsync(string query, CancellationToken ct)
     {
@@ -92,6 +94,15 @@
             await AuthorsChanged.InvokeAsync(Authors);
         }
         newAuthor = null;
+
+        // MudAutocomplete keeps its internal display text after a pick — setting
+        // newAuthor=null on the parameter doesn'\''t force the input to clear.
+        // ClearAsync() resets both the displayed text and the internal value
+        // so the user can type the next author without manually clearing first.
+        if (autocompleteRef is not null)
+        {
+            await autocompleteRef.ClearAsync();
+        }
     }
 
     private async Task RemoveAsync(string name)

--- a/BookTracker.Web/Components/Shared/MudAuthorPicker.razor
+++ b/BookTracker.Web/Components/Shared/MudAuthorPicker.razor
@@ -1,0 +1,102 @@
+@* Multi-author input with autocomplete + chips. Used on Add Book, the
+   /edit page's Primary Work form, and the Work edit dialog (BookDetail
+   modal). Mirrors the MudAutocomplete + chips shape from MudGenrePicker
+   but flatter — no taxonomy, just a list of names with find-or-create-on-
+   type semantics.
+
+   Two-way binding via `Authors` + `AuthorsChanged`:
+       <MudAuthorPicker Authors="vm.Authors"
+                        AuthorsChanged="list => vm.Authors = list" />
+
+   PR1 of the multi-author cutover (#14): the picker collects names; the
+   save path resolves each via AuthorResolver.FindOrCreateAllAsync and
+   dual-writes (Work.Author = lead for legacy compat, Work.WorkAuthors =
+   all entries with Order). PR2 will switch reads to the join. *@
+
+@using BookTracker.Data
+@using Microsoft.EntityFrameworkCore
+@inject IDbContextFactory<BookTrackerDbContext> DbFactory
+
+<MudPaper Outlined="true" Class="pa-2">
+    @if (Authors.Count > 0)
+    {
+        <div class="d-flex flex-wrap gap-1 mb-2">
+            @foreach (var name in Authors)
+            {
+                var captured = name;
+                <MudChip T="string"
+                         Text="@captured"
+                         Variant="Variant.Filled"
+                         Color="Color.Primary"
+                         Size="Size.Small"
+                         OnClose="@(() => RemoveAsync(captured))" />
+            }
+        </div>
+    }
+    <MudAutocomplete T="string"
+                     Value="@newAuthor"
+                     ValueChanged="OnValueChangedAsync"
+                     SearchFunc="SearchAsync"
+                     Label="@Label"
+                     Variant="Variant.Outlined"
+                     Margin="Margin.Dense"
+                     CoerceValue="true"
+                     CoerceText="true"
+                     ResetValueOnEmptyText="false"
+                     MinCharacters="0"
+                     ShowProgressIndicator="true"
+                     HelperText="@HelperText" />
+</MudPaper>
+
+@code {
+    [Parameter, EditorRequired] public List<string> Authors { get; set; } = [];
+    [Parameter] public EventCallback<List<string>> AuthorsChanged { get; set; }
+    [Parameter] public string Label { get; set; } = "Author";
+    [Parameter] public string HelperText { get; set; } = "Type to find existing or create new. Pick an item or press Enter to add.";
+
+    private string? newAuthor;
+
+    private async Task<IEnumerable<string>> SearchAsync(string query, CancellationToken ct)
+    {
+        // Lowercased client-side before the LINQ Where so EF InMemory (case-
+        // sensitive) and SQL Server (case-insensitive default collation) agree
+        // on substring matching. Mirrors WorkEditDialogViewModel.SearchAuthorsAsync.
+        var q = (query ?? "").Trim().ToLower();
+        await using var db = await DbFactory.CreateDbContextAsync();
+        var matches = db.Authors.AsQueryable();
+        if (!string.IsNullOrEmpty(q))
+        {
+            matches = matches.Where(a => a.Name.ToLower().Contains(q));
+        }
+
+        var existing = Authors.ToHashSet(StringComparer.OrdinalIgnoreCase);
+        return await matches
+            .OrderBy(a => a.Name)
+            .Select(a => a.Name)
+            .Where(n => !existing.Contains(n))
+            .Take(20)
+            .ToListAsync(ct);
+    }
+
+    private async Task OnValueChangedAsync(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return;
+        var trimmed = value.Trim().TrimEnd(',', ';', '&').Trim();
+        if (string.IsNullOrEmpty(trimmed)) return;
+
+        // Case-insensitive de-dup on the existing list — typing an author
+        // already in the chip set should be a no-op rather than a duplicate.
+        if (!Authors.Any(a => a.Equals(trimmed, StringComparison.OrdinalIgnoreCase)))
+        {
+            Authors.Add(trimmed);
+            await AuthorsChanged.InvokeAsync(Authors);
+        }
+        newAuthor = null;
+    }
+
+    private async Task RemoveAsync(string name)
+    {
+        Authors.RemoveAll(a => a.Equals(name, StringComparison.OrdinalIgnoreCase));
+        await AuthorsChanged.InvokeAsync(Authors);
+    }
+}

--- a/BookTracker.Web/Components/Shared/WorkEditDialog.razor
+++ b/BookTracker.Web/Components/Shared/WorkEditDialog.razor
@@ -25,19 +25,14 @@
                               Label="Subtitle"
                               Variant="Variant.Outlined"
                               Margin="Margin.Dense" />
-                <MudAutocomplete T="string"
-                                 @bind-Value="VM.AuthorName"
-                                 SearchFunc="VM.SearchAuthorsAsync"
-                                 Label="Author"
-                                 Required="true"
-                                 RequiredError="Author is required."
-                                 Variant="Variant.Outlined"
-                                 Margin="Margin.Dense"
-                                 CoerceValue="true"
-                                 CoerceText="true"
-                                 ResetValueOnEmptyText="false"
-                                 MinCharacters="0"
-                                 HelperText="Type to find existing or create new." />
+                <div>
+                    <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mb-1">Author(s)</MudText>
+                    @* Multi-author chip list. Lead chip = legacy AuthorId during
+                       the PR1/PR2 cutover. *@
+                    <MudAuthorPicker Authors="VM.AuthorNames"
+                                     AuthorsChanged="list => VM.AuthorNames = list"
+                                     Label="Add author" />
+                </div>
                 <MudTextField T="string"
                               @bind-Value="VM.FirstPublishedDate"
                               Label="First published"
@@ -78,7 +73,7 @@
         <MudButton OnClick="Cancel">Cancel</MudButton>
         <MudButton Color="Color.Primary"
                    Variant="Variant.Filled"
-                   Disabled="@(VM.NotFound || string.IsNullOrWhiteSpace(VM.Title) || string.IsNullOrWhiteSpace(VM.AuthorName) || saving)"
+                   Disabled="@(VM.NotFound || string.IsNullOrWhiteSpace(VM.Title) || VM.AuthorNames.Count == 0 || saving)"
                    OnClick="SaveAsync">
             @(saving ? "Saving..." : "Save")
         </MudButton>

--- a/BookTracker.Web/Components/Shared/WorkForm.razor
+++ b/BookTracker.Web/Components/Shared/WorkForm.razor
@@ -8,9 +8,14 @@
                 <ValidationMessage For="() => Input.Title" class="text-danger small" />
             </div>
             <div class="col-md-4">
-                <label class="form-label">Author</label>
-                <InputText @bind-Value="Input.Author" class="form-control" />
-                <ValidationMessage For="() => Input.Author" class="text-danger small" />
+                <label class="form-label">Author(s)</label>
+                @* Multi-author chip picker — list of names; first chip is the
+                   lead author (Work.AuthorId for legacy compat in PR1).
+                   Validation lives in the save path because DataAnnotations
+                   doesn'\''t map "non-empty list of non-empty strings" cleanly. *@
+                <MudAuthorPicker Authors="Input.Authors"
+                                 AuthorsChanged="list => Input.Authors = list"
+                                 Label="Add author" />
             </div>
             <div class="col-md-8">
                 <label class="form-label">Subtitle</label>

--- a/BookTracker.Web/Services/AuthorResolver.cs
+++ b/BookTracker.Web/Services/AuthorResolver.cs
@@ -10,6 +10,12 @@ namespace BookTracker.Web.Services;
 // fresh name silently creates a canonical Author. Dedup happens later
 // via the /authors page (mark one as alias of another) or via the
 // follow-up merge UI (TODO.md).
+//
+// Multi-author cutover (PR1 of #14): the batch helpers below take a list
+// of names and produce ordered Author entities + WorkAuthor join rows.
+// Save sites still set Work.Author to the lead (legacy compat) AND
+// populate Work.WorkAuthors with all authors; PR2 will drop Work.AuthorId
+// and switch reads to the join.
 public static class AuthorResolver
 {
     public static async Task<Author> FindOrCreateAsync(string name, BookTrackerDbContext db, CancellationToken ct = default)
@@ -26,5 +32,66 @@ public static class AuthorResolver
         var fresh = new Author { Name = trimmed };
         db.Authors.Add(fresh);
         return fresh;
+    }
+
+    /// <summary>
+    /// Sequentially find-or-create each name; preserves input order, drops
+    /// blanks, de-duplicates by trimmed name (case-insensitive). Returned
+    /// list maps positionally to the authors as they should be displayed.
+    /// </summary>
+    public static async Task<List<Author>> FindOrCreateAllAsync(IEnumerable<string> names, BookTrackerDbContext db, CancellationToken ct = default)
+    {
+        var result = new List<Author>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var raw in names)
+        {
+            var trimmed = raw?.Trim();
+            if (string.IsNullOrEmpty(trimmed)) continue;
+            if (!seen.Add(trimmed)) continue;
+            result.Add(await FindOrCreateAsync(trimmed, db, ct));
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Parse a free-form author string into a list of names. Splits on commas
+    /// and ampersands so "Preston, Lincoln Child" and "Preston &amp; Child"
+    /// both become two names. Used by surfaces (Bulk Add) where the user
+    /// types into a single cell rather than a chip picker.
+    /// </summary>
+    public static List<string> ParseNames(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw)) return [];
+        return raw
+            .Split(['&', ','], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Where(s => !string.IsNullOrWhiteSpace(s))
+            .ToList();
+    }
+
+    /// <summary>
+    /// PR1 dual-write helper. Sets Work.Author to the lead (first) author for
+    /// legacy-FK compat AND replaces Work.WorkAuthors with one join row per
+    /// author, Order ascending from 0. Caller is responsible for ensuring
+    /// authors come from FindOrCreateAllAsync (so brand-new ones are
+    /// already attached to the DbContext) and for SaveChangesAsync.
+    /// </summary>
+    public static void AssignAuthors(Work work, IReadOnlyList<Author> authors)
+    {
+        if (authors.Count == 0)
+        {
+            throw new ArgumentException("At least one author required.", nameof(authors));
+        }
+
+        work.Author = authors[0];
+
+        work.WorkAuthors.Clear();
+        for (var i = 0; i < authors.Count; i++)
+        {
+            work.WorkAuthors.Add(new WorkAuthor
+            {
+                Author = authors[i],
+                Order = i,
+            });
+        }
     }
 }

--- a/BookTracker.Web/ViewModels/BookAddViewModel.cs
+++ b/BookTracker.Web/ViewModels/BookAddViewModel.cs
@@ -131,7 +131,13 @@ public class BookAddViewModel(
             if (string.IsNullOrWhiteSpace(BookInput.DefaultCoverArtUrl)) BookInput.DefaultCoverArtUrl = result.CoverUrl;
             if (string.IsNullOrWhiteSpace(WorkInput.Title)) WorkInput.Title = result.Title ?? "";
             if (string.IsNullOrWhiteSpace(WorkInput.Subtitle)) WorkInput.Subtitle = result.Subtitle;
-            if (string.IsNullOrWhiteSpace(WorkInput.Author)) WorkInput.Author = result.Author ?? "";
+            // Lookup gives a single author string — seed the chip list with it
+            // when empty. User can add additional co-authors via the picker
+            // before saving.
+            if (WorkInput.Authors.Count == 0 && !string.IsNullOrWhiteSpace(result.Author))
+            {
+                WorkInput.Authors = [result.Author];
+            }
             if (string.IsNullOrWhiteSpace(EditionInput.Isbn)) EditionInput.Isbn = result.Isbn;
             if (string.IsNullOrWhiteSpace(EditionInput.Publisher)) EditionInput.Publisher = result.Publisher;
             if (string.IsNullOrWhiteSpace(EditionInput.DatePrinted) && result.DatePrinted is DateOnly d)
@@ -246,7 +252,10 @@ public class BookAddViewModel(
         if (string.IsNullOrWhiteSpace(BookInput.Title)) BookInput.Title = candidate.Title ?? "";
         if (string.IsNullOrWhiteSpace(BookInput.DefaultCoverArtUrl)) BookInput.DefaultCoverArtUrl = candidate.CoverUrl;
         if (string.IsNullOrWhiteSpace(WorkInput.Title)) WorkInput.Title = candidate.Title ?? "";
-        if (string.IsNullOrWhiteSpace(WorkInput.Author)) WorkInput.Author = candidate.Author ?? "";
+        if (WorkInput.Authors.Count == 0 && !string.IsNullOrWhiteSpace(candidate.Author))
+        {
+            WorkInput.Authors = [candidate.Author];
+        }
         // first_publish_year is the WORK's first year — perfect fit for
         // Work.FirstPublishedDate; not the edition's print date. We only
         // know the year so format it as such.
@@ -289,17 +298,24 @@ public class BookAddViewModel(
                 }
             }
 
-            var author = await AuthorResolver.FindOrCreateAsync(WorkInput.Author!, db);
+            var authors = await AuthorResolver.FindOrCreateAllAsync(WorkInput.Authors, db);
+            if (authors.Count == 0)
+            {
+                throw new InvalidOperationException("At least one author is required to save a Work.");
+            }
             var firstPub = PartialDateParser.TryParse(WorkInput.FirstPublishedDate) ?? PartialDate.Empty;
             var work = new Work
             {
                 Title = (WorkInput.Title ?? BookInput.Title)!.Trim(),
                 Subtitle = string.IsNullOrWhiteSpace(WorkInput.Subtitle) ? null : WorkInput.Subtitle!.Trim(),
-                Author = author,
                 FirstPublishedDate = firstPub.Date,
                 FirstPublishedDatePrecision = firstPub.Precision,
                 Genres = selectedGenres,
             };
+            // Dual-write: Work.Author = lead chip (legacy FK compat); Work.WorkAuthors
+            // = all chips with Order ascending. PR2 will drop Author/AuthorId and
+            // switch reads to the join.
+            AuthorResolver.AssignAuthors(work, authors);
 
             // Attach to the accepted series, if any. AcceptedSeriesId points at
             // an existing local Series row; AcceptedSeriesName (without an Id)

--- a/BookTracker.Web/ViewModels/BookEditViewModel.cs
+++ b/BookTracker.Web/ViewModels/BookEditViewModel.cs
@@ -77,6 +77,9 @@ public class BookEditViewModel(
                 .ThenInclude(w => w.Genres)
             .Include(b => b.Works)
                 .ThenInclude(w => w.Author)
+            .Include(b => b.Works)
+                .ThenInclude(w => w.WorkAuthors)
+                    .ThenInclude(wa => wa.Author)
             .FirstOrDefaultAsync(b => b.Id == bookId);
 
         if (book is null)
@@ -99,11 +102,19 @@ public class BookEditViewModel(
         if (primary is not null)
         {
             PrimaryWorkId = primary.Id;
+            // Hydrate the chip list from WorkAuthors (Order ascending so the
+            // lead is first). Fallback to the legacy single Author if for some
+            // reason the join row is missing — shouldn'\''t happen post-backfill
+            // but defensive against corrupted state.
+            var authorNames = primary.WorkAuthors.Count > 0
+                ? primary.WorkAuthors.OrderBy(wa => wa.Order).Select(wa => wa.Author.Name).ToList()
+                : [primary.Author.Name];
+
             PrimaryWorkInput = new WorkFormViewModel.WorkFormInput
             {
                 Title = primary.Title,
                 Subtitle = primary.Subtitle,
-                Author = primary.Author.Name,
+                Authors = authorNames,
                 FirstPublishedDate = PartialDateParser.Format(primary.FirstPublishedDate, primary.FirstPublishedDatePrecision),
             };
             SelectedGenreIds = primary.Genres.Select(g => g.Id).ToList();
@@ -478,6 +489,7 @@ public class BookEditViewModel(
                 .Include(b => b.Tags)
                 .Include(b => b.Works).ThenInclude(w => w.Genres)
                 .Include(b => b.Works).ThenInclude(w => w.Author)
+                .Include(b => b.Works).ThenInclude(w => w.WorkAuthors).ThenInclude(wa => wa.Author)
                 .FirstOrDefaultAsync(b => b.Id == bookId);
 
             if (book is null) { NotFound = true; return; }
@@ -505,7 +517,18 @@ public class BookEditViewModel(
             {
                 primary.Title = PrimaryWorkInput.Title!.Trim();
                 primary.Subtitle = string.IsNullOrWhiteSpace(PrimaryWorkInput.Subtitle) ? null : PrimaryWorkInput.Subtitle.Trim();
-                primary.Author = await AuthorResolver.FindOrCreateAsync(PrimaryWorkInput.Author!, db);
+
+                // Need WorkAuthors loaded for the dual-write to replace the
+                // existing chip set rather than appending. The Include chain
+                // in InitializeAsync covers the read; the Save reload below
+                // mirrors it so AssignAuthors can Clear() safely.
+                var authors = await AuthorResolver.FindOrCreateAllAsync(PrimaryWorkInput.Authors, db);
+                if (authors.Count == 0)
+                {
+                    throw new InvalidOperationException("At least one author is required to save a Work.");
+                }
+                AuthorResolver.AssignAuthors(primary, authors);
+
                 var firstPub = PartialDateParser.TryParse(PrimaryWorkInput.FirstPublishedDate) ?? PartialDate.Empty;
                 primary.FirstPublishedDate = firstPub.Date;
                 primary.FirstPublishedDatePrecision = firstPub.Precision;

--- a/BookTracker.Web/ViewModels/BulkAddViewModel.cs
+++ b/BookTracker.Web/ViewModels/BulkAddViewModel.cs
@@ -163,13 +163,20 @@ public class BulkAddViewModel(
         }
 
         var bookTitle = (row.Title ?? $"Unknown book — {row.Isbn}").Trim();
-        var author = await AuthorResolver.FindOrCreateAsync(row.Author ?? "Unknown", db);
+        // row.Author can be a comma- or ampersand-separated list of names from
+        // the inline cell (Drew typing "Preston, Lincoln Child"). ParseNames
+        // splits + trims; the fallback to "Unknown" matches the prior single-
+        // author behaviour for not-found / blank rows.
+        var authorNames = AuthorResolver.ParseNames(row.Author);
+        if (authorNames.Count == 0) authorNames = ["Unknown"];
+        var authors = await AuthorResolver.FindOrCreateAllAsync(authorNames, db);
         var work = new Work
         {
             Title = bookTitle,
             Subtitle = row.Subtitle,
-            Author = author,
         };
+        // Dual-write: Work.Author = lead (legacy compat); Work.WorkAuthors = all.
+        AuthorResolver.AssignAuthors(work, authors);
 
         // Series attachment if the user accepted the suggestion on this row.
         // Mirrors BookAddViewModel.SaveAsync: existing local series wins via

--- a/BookTracker.Web/ViewModels/WorkEditDialogViewModel.cs
+++ b/BookTracker.Web/ViewModels/WorkEditDialogViewModel.cs
@@ -16,7 +16,10 @@ public class WorkEditDialogViewModel(IDbContextFactory<BookTrackerDbContext> dbF
 
     public string Title { get; set; } = "";
     public string? Subtitle { get; set; }
-    public string AuthorName { get; set; } = "";
+    // Multi-author chip list — populated from WorkAuthors on init, dual-
+    // written on save. Lead = AuthorNames[0] for legacy Work.AuthorId compat
+    // during the PR1/PR2 cutover.
+    public List<string> AuthorNames { get; set; } = [];
     public string FirstPublishedDate { get; set; } = "";
     public int? SelectedSeriesId { get; set; }
     public int? SeriesOrder { get; set; }
@@ -31,13 +34,19 @@ public class WorkEditDialogViewModel(IDbContextFactory<BookTrackerDbContext> dbF
         await using var db = await dbFactory.CreateDbContextAsync();
         var work = await db.Works
             .Include(w => w.Author)
+            .Include(w => w.WorkAuthors).ThenInclude(wa => wa.Author)
             .Include(w => w.Genres)
             .FirstOrDefaultAsync(w => w.Id == workId);
         if (work is null) { NotFound = true; return; }
 
         Title = work.Title;
         Subtitle = work.Subtitle;
-        AuthorName = work.Author.Name;
+        // Order ascending so the lead author shows first in the chip list.
+        // Fallback to the legacy single Author if WorkAuthors is empty —
+        // shouldn'\''t happen post-backfill but defensive.
+        AuthorNames = work.WorkAuthors.Count > 0
+            ? work.WorkAuthors.OrderBy(wa => wa.Order).Select(wa => wa.Author.Name).ToList()
+            : [work.Author.Name];
         FirstPublishedDate = PartialDateParser.Format(work.FirstPublishedDate, work.FirstPublishedDatePrecision);
         SelectedSeriesId = work.SeriesId;
         SeriesOrder = work.SeriesOrder;
@@ -71,18 +80,22 @@ public class WorkEditDialogViewModel(IDbContextFactory<BookTrackerDbContext> dbF
 
     public async Task SaveAsync()
     {
-        if (NotFound || string.IsNullOrWhiteSpace(Title) || string.IsNullOrWhiteSpace(AuthorName)) return;
+        if (NotFound || string.IsNullOrWhiteSpace(Title) || AuthorNames.All(string.IsNullOrWhiteSpace)) return;
 
         await using var db = await dbFactory.CreateDbContextAsync();
         var work = await db.Works
             .Include(w => w.Author)
+            .Include(w => w.WorkAuthors).ThenInclude(wa => wa.Author)
             .Include(w => w.Genres)
             .FirstOrDefaultAsync(w => w.Id == WorkId);
         if (work is null) return;
 
         work.Title = Title.Trim();
         work.Subtitle = string.IsNullOrWhiteSpace(Subtitle) ? null : Subtitle.Trim();
-        work.Author = await AuthorResolver.FindOrCreateAsync(AuthorName, db);
+
+        var authors = await AuthorResolver.FindOrCreateAllAsync(AuthorNames, db);
+        if (authors.Count == 0) return;
+        AuthorResolver.AssignAuthors(work, authors);
 
         var parsed = PartialDateParser.TryParse(FirstPublishedDate) ?? PartialDate.Empty;
         work.FirstPublishedDate = parsed.Date;

--- a/BookTracker.Web/ViewModels/WorkFormViewModel.cs
+++ b/BookTracker.Web/ViewModels/WorkFormViewModel.cs
@@ -15,8 +15,13 @@ public class WorkFormViewModel
         [StringLength(300)]
         public string? Subtitle { get; set; }
 
-        [Required, StringLength(200)]
-        public string? Author { get; set; }
+        // Multi-author input — populated by MudAuthorPicker as the user adds
+        // chips. Save path requires at least one entry; uses the list to
+        // dual-write Work.Author (legacy lead-author FK) and Work.WorkAuthors
+        // (the new M:N join with Order). DataAnnotations [Required] doesn'\''t
+        // map cleanly to "non-empty list of non-empty strings", so this is
+        // validated at save time rather than via the validator.
+        public List<string> Authors { get; set; } = [];
 
         // Free-form text — accepts "1973", "Oct 1973", "12 Oct 1973",
         // "1973-10", "1973-10-12". Parsed into Work.FirstPublishedDate +


### PR DESCRIPTION
- **feat(model): WorkAuthor join entity (PR1 additive — schema + backfill)**
- **feat(authors): multi-author capture UI + dual-write at save sites (PR1 of #14)**
- **fix(authors): clear MudAuthorPicker autocomplete after each chip pick**
