### PR TITLE
feat(authors): cutover reads to WorkAuthor join, drop legacy AuthorId (PR2 of #14)

### DIFF
--- a/BookTracker.Data/BookTrackerDbContext.cs
+++ b/BookTracker.Data/BookTrackerDbContext.cs
@@ -102,35 +102,29 @@ public class BookTrackerDbContext(DbContextOptions<BookTrackerDbContext> options
             .HasForeignKey(w => w.SeriesId)
             .OnDelete(DeleteBehavior.SetNull);
 
-        // Each Work belongs to exactly one Author entity (which itself may
-        // be a pen-name alias of another canonical Author). Legacy single-
-        // author FK kept during PR1 of the multi-author cutover; PR2 will
-        // drop this and switch reads to the WorkAuthors join below.
-        modelBuilder.Entity<Work>()
-            .HasOne(w => w.Author)
-            .WithMany(a => a.Works)
-            .HasForeignKey(w => w.AuthorId)
-            .OnDelete(DeleteBehavior.Restrict);
-
-        // WorkAuthor join entity for the Work ↔ Author M:N relationship.
+        // Work ↔ Author is many-to-many through the WorkAuthor join entity.
         // Composite PK on (WorkId, AuthorId) — the same Author can't appear
         // twice on a single Work. Cascade on Work delete (the join row only
         // exists as long as the Work does); Restrict on Author delete (don't
         // allow deleting an Author that's still credited on a Work).
-        modelBuilder.Entity<WorkAuthor>()
-            .HasKey(wa => new { wa.WorkId, wa.AuthorId });
-
-        modelBuilder.Entity<WorkAuthor>()
-            .HasOne(wa => wa.Work)
-            .WithMany(w => w.WorkAuthors)
-            .HasForeignKey(wa => wa.WorkId)
-            .OnDelete(DeleteBehavior.Cascade);
-
-        modelBuilder.Entity<WorkAuthor>()
-            .HasOne(wa => wa.Author)
-            .WithMany(a => a.WorkAuthors)
-            .HasForeignKey(wa => wa.AuthorId)
-            .OnDelete(DeleteBehavior.Restrict);
+        //
+        // Both skip-navigations (Work.Authors, Author.Works) and the explicit
+        // join collections (Work.WorkAuthors, Author.WorkAuthors) are kept —
+        // skip-nav for "any author of this work" semantics, explicit join for
+        // ordered display via WorkAuthor.Order.
+        modelBuilder.Entity<Work>()
+            .HasMany(w => w.Authors)
+            .WithMany(a => a.Works)
+            .UsingEntity<WorkAuthor>(
+                j => j.HasOne(wa => wa.Author)
+                      .WithMany(a => a.WorkAuthors)
+                      .HasForeignKey(wa => wa.AuthorId)
+                      .OnDelete(DeleteBehavior.Restrict),
+                j => j.HasOne(wa => wa.Work)
+                      .WithMany(w => w.WorkAuthors)
+                      .HasForeignKey(wa => wa.WorkId)
+                      .OnDelete(DeleteBehavior.Cascade),
+                j => j.HasKey(wa => new { wa.WorkId, wa.AuthorId }));
 
         modelBuilder.Entity<Author>()
             .HasIndex(a => a.Name)

--- a/BookTracker.Data/Migrations/20260504101635_DropWorkAuthorId.Designer.cs
+++ b/BookTracker.Data/Migrations/20260504101635_DropWorkAuthorId.Designer.cs
@@ -4,6 +4,7 @@ using BookTracker.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BookTracker.Data.Migrations
 {
     [DbContext(typeof(BookTrackerDbContext))]
-    partial class BookTrackerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260504101635_DropWorkAuthorId")]
+    partial class DropWorkAuthorId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BookTracker.Data/Migrations/20260504101635_DropWorkAuthorId.cs
+++ b/BookTracker.Data/Migrations/20260504101635_DropWorkAuthorId.cs
@@ -1,0 +1,66 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BookTracker.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class DropWorkAuthorId : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Works_Authors_AuthorId",
+                table: "Works");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Works_AuthorId",
+                table: "Works");
+
+            migrationBuilder.DropColumn(
+                name: "AuthorId",
+                table: "Works");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "AuthorId",
+                table: "Works",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            // Reseed AuthorId from WorkAuthors (lead author by Order ascending)
+            // so the column carries valid FK values before the FK is restored.
+            // Defensive — Down() is only run for emergency rollback, but if
+            // it runs after PR2 ships, FK creation needs valid AuthorIds for
+            // every row. Every Work has at least one WorkAuthor row post-PR1
+            // backfill; rows without one (impossible by current invariants)
+            // would block the FK creation here.
+            migrationBuilder.Sql(@"
+UPDATE [Works]
+SET [AuthorId] = (
+    SELECT TOP 1 wa.[AuthorId]
+    FROM [WorkAuthors] wa
+    WHERE wa.[WorkId] = [Works].[Id]
+    ORDER BY wa.[Order]
+);");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Works_AuthorId",
+                table: "Works",
+                column: "AuthorId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Works_Authors_AuthorId",
+                table: "Works",
+                column: "AuthorId",
+                principalTable: "Authors",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+    }
+}

--- a/BookTracker.Data/Models/Author.cs
+++ b/BookTracker.Data/Models/Author.cs
@@ -26,8 +26,9 @@ public class Author
     /// <summary>Inverse of CanonicalAuthorId — pen names that resolve to this Author.</summary>
     public List<Author> Aliases { get; set; } = [];
 
+    /// <summary>Skip-navigation through WorkAuthor (M:N). Includes works where this Author is a co-author, not just the lead.</summary>
     public List<Work> Works { get; set; } = [];
 
-    /// <summary>Multi-author join entries — every Work this Author is credited on, including co-authored ones.</summary>
+    /// <summary>Explicit join collection — useful when the Order field matters or when iterating join rows directly.</summary>
     public List<WorkAuthor> WorkAuthors { get; set; } = [];
 }

--- a/BookTracker.Data/Models/Work.cs
+++ b/BookTracker.Data/Models/Work.cs
@@ -7,10 +7,13 @@ namespace BookTracker.Data.Models;
 // reprinted across several compendiums), and a single Book can contain
 // multiple Works (a short-story collection).
 //
-// AuthorId points at the SPECIFIC Author entity used (Stephen King vs.
-// the Richard Bachman alias) so the book is shown the way it was
-// actually published. Aggregations roll aliases up under their canonical
-// via Author.CanonicalAuthorId.
+// Authorship is many-to-many via the WorkAuthor join entity (PR2 of
+// the multi-author cutover). Each WorkAuthor row points at the SPECIFIC
+// Author entity used (Stephen King vs. the Richard Bachman alias) so the
+// book is shown as actually published; aggregations roll aliases up via
+// Author.CanonicalAuthorId. WorkAuthor.Order keeps the lead author first
+// on display ("Preston & Child" stays in that order rather than being
+// alphabetised).
 public class Work
 {
     public int Id { get; set; }
@@ -21,15 +24,11 @@ public class Work
     [MaxLength(300)]
     public string? Subtitle { get; set; }
 
-    // Legacy single-author FK — kept during PR1 of the multi-author cutover
-    // for dual-write. Reads still go through this; the new WorkAuthors
-    // collection populates in parallel until PR2 cuts reads over and drops
-    // this column.
-    public int AuthorId { get; set; }
-    public Author Author { get; set; } = null!;
-
-    /// <summary>Multi-author join. Populated alongside AuthorId during the cutover; primary read source after PR2.</summary>
+    /// <summary>Explicit join with Order. The canonical read source for ordered display ("Preston & Child").</summary>
     public List<WorkAuthor> WorkAuthors { get; set; } = [];
+
+    /// <summary>Skip-navigation through WorkAuthor — convenient for "any author of this work" semantics; does NOT preserve Order.</summary>
+    public List<Author> Authors { get; set; } = [];
 
     /// <summary>The year/date the Work was first published — distinct from any specific Edition's print date.</summary>
     public DateOnly? FirstPublishedDate { get; set; }

--- a/BookTracker.Tests/Services/AuthorMergeServiceTests.cs
+++ b/BookTracker.Tests/Services/AuthorMergeServiceTests.cs
@@ -80,7 +80,7 @@ public class AuthorMergeServiceTests
         Assert.Equal("Doug Preston", result.LoserName);
 
         using var db = _factory.CreateDbContext();
-        Assert.Equal(3, db.Works.Count(w => w.AuthorId == ids[0]));
+        Assert.Equal(3, db.Works.Count(w => w.WorkAuthors.Any(wa => wa.AuthorId == ids[0])));
         Assert.Null(db.Authors.FirstOrDefault(a => a.Id == ids[1]));
     }
 
@@ -220,7 +220,7 @@ public class AuthorMergeServiceTests
                 db.Books.Add(new Book
                 {
                     Title = t,
-                    Works = [new Work { Title = t, Author = author }]
+                    Works = [new Work { Title = t, WorkAuthors = [new WorkAuthor { Author = author, Order = 0 }] }]
                 });
             }
             authors.Add(author);

--- a/BookTracker.Tests/Services/AuthorResolverTests.cs
+++ b/BookTracker.Tests/Services/AuthorResolverTests.cs
@@ -80,7 +80,6 @@ public class AuthorResolverTests
 
         AuthorResolver.AssignAuthors(work, [preston, child]);
 
-        Assert.Equal(preston, work.Author);
         Assert.Equal(2, work.WorkAuthors.Count);
         Assert.Equal(preston, work.WorkAuthors[0].Author);
         Assert.Equal(0, work.WorkAuthors[0].Order);

--- a/BookTracker.Tests/Services/BookMergeServiceTests.cs
+++ b/BookTracker.Tests/Services/BookMergeServiceTests.cs
@@ -30,7 +30,7 @@ public class BookMergeServiceTests
     {
         using var db = _factory.CreateDbContext();
         var author = new Author { Name = "A" };
-        var work = new Work { Title = "T", Author = author };
+        var work = new Work { Title = "T", WorkAuthors = [new WorkAuthor { Author = author, Order = 0 }] };
         var winner = new Book { Title = "B", Works = [work] };
         var loser = new Book { Title = "B", Works = [work] };
         var loserEdition = new Edition
@@ -61,8 +61,8 @@ public class BookMergeServiceTests
     {
         using var db = _factory.CreateDbContext();
         var author = new Author { Name = "A" };
-        var sharedWork = new Work { Title = "Shared", Author = author };
-        var loserOnlyWork = new Work { Title = "LoserOnly", Author = author };
+        var sharedWork = new Work { Title = "Shared", WorkAuthors = [new WorkAuthor { Author = author, Order = 0 }] };
+        var loserOnlyWork = new Work { Title = "LoserOnly", WorkAuthors = [new WorkAuthor { Author = author, Order = 0 }] };
         var winner = new Book { Title = "B", Works = [sharedWork] };
         var loser = new Book { Title = "B", Works = [sharedWork, loserOnlyWork] };
         db.Books.AddRange(winner, loser);
@@ -82,7 +82,7 @@ public class BookMergeServiceTests
     {
         using var db = _factory.CreateDbContext();
         var author = new Author { Name = "A" };
-        var work = new Work { Title = "T", Author = author };
+        var work = new Work { Title = "T", WorkAuthors = [new WorkAuthor { Author = author, Order = 0 }] };
         var tagA = new Tag { Name = "tag-a" };
         var tagB = new Tag { Name = "tag-b" };
         db.Tags.AddRange(tagA, tagB);
@@ -105,7 +105,7 @@ public class BookMergeServiceTests
     {
         using var db = _factory.CreateDbContext();
         var author = new Author { Name = "A" };
-        var work = new Work { Title = "T", Author = author };
+        var work = new Work { Title = "T", WorkAuthors = [new WorkAuthor { Author = author, Order = 0 }] };
         var winner = new Book
         {
             Title = "B",
@@ -142,7 +142,7 @@ public class BookMergeServiceTests
     {
         using var db = _factory.CreateDbContext();
         var author = new Author { Name = "A" };
-        var work = new Work { Title = "T", Author = author };
+        var work = new Work { Title = "T", WorkAuthors = [new WorkAuthor { Author = author, Order = 0 }] };
         var winner = new Book
         {
             Title = "B", Works = [work],
@@ -172,7 +172,7 @@ public class BookMergeServiceTests
     {
         using var db = _factory.CreateDbContext();
         var author = new Author { Name = "A" };
-        var work = new Work { Title = "T", Author = author };
+        var work = new Work { Title = "T", WorkAuthors = [new WorkAuthor { Author = author, Order = 0 }] };
         var winner = new Book { Title = "B", Works = [work], Rating = 0 };
         var loser = new Book { Title = "B", Works = [work], Rating = 3 };
         db.Books.AddRange(winner, loser);
@@ -189,7 +189,7 @@ public class BookMergeServiceTests
     {
         using var db = _factory.CreateDbContext();
         var author = new Author { Name = "A" };
-        var work = new Work { Title = "T", Author = author };
+        var work = new Work { Title = "T", WorkAuthors = [new WorkAuthor { Author = author, Order = 0 }] };
         var winner = new Book { Title = "B", Works = [work], Rating = 0 };
         var loser = new Book { Title = "B", Works = [work], Rating = 0 };
         db.Books.AddRange(winner, loser);
@@ -248,7 +248,7 @@ public class BookMergeServiceTests
     {
         using var db = _factory.CreateDbContext();
         var author = new Author { Name = "Shared" };
-        var work = new Work { Title = "T", Author = author };
+        var work = new Work { Title = "T", WorkAuthors = [new WorkAuthor { Author = author, Order = 0 }] };
         var winner = new Book { Title = "B", Works = [work] };
         var loser = new Book { Title = "B", Works = [work] };
         db.Books.AddRange(winner, loser);

--- a/BookTracker.Tests/Services/DuplicateDetectionServiceTests.cs
+++ b/BookTracker.Tests/Services/DuplicateDetectionServiceTests.cs
@@ -150,7 +150,7 @@ public class DuplicateDetectionServiceTests
         // have been one Book with two Editions" case.
         using var db = _factory.CreateDbContext();
         var author = new Author { Name = "J.R.R. Tolkien" };
-        var work = new Work { Title = "The Hobbit", Author = author };
+        var work = new Work { Title = "The Hobbit", WorkAuthors = [new WorkAuthor { Author = author, Order = 0 }] };
         db.Books.Add(new Book { Title = "Hobbit HB", Works = [work] });
         db.Books.Add(new Book { Title = "Hobbit PB", Works = [work] });
         await db.SaveChangesAsync();
@@ -167,7 +167,7 @@ public class DuplicateDetectionServiceTests
         // Same title AND same work-set: dedup so the pair appears once.
         using var db = _factory.CreateDbContext();
         var author = new Author { Name = "J.R.R. Tolkien" };
-        var work = new Work { Title = "The Hobbit", Author = author };
+        var work = new Work { Title = "The Hobbit", WorkAuthors = [new WorkAuthor { Author = author, Order = 0 }] };
         db.Books.Add(new Book { Title = "The Hobbit", Works = [work] });
         db.Books.Add(new Book { Title = "The Hobbit", Works = [work] });
         await db.SaveChangesAsync();
@@ -184,7 +184,7 @@ public class DuplicateDetectionServiceTests
     {
         using var db = _factory.CreateDbContext();
         var author = new Author { Name = "Agatha Christie" };
-        var work = new Work { Title = "Murder on the Orient Express", Author = author };
+        var work = new Work { Title = "Murder on the Orient Express", WorkAuthors = [new WorkAuthor { Author = author, Order = 0 }] };
         var publisher = new Publisher { Name = "Collins Crime Club" };
         var book = new Book
         {
@@ -209,7 +209,7 @@ public class DuplicateDetectionServiceTests
     {
         using var db = _factory.CreateDbContext();
         var author = new Author { Name = "Agatha Christie" };
-        var work = new Work { Title = "Murder on the Orient Express", Author = author };
+        var work = new Work { Title = "Murder on the Orient Express", WorkAuthors = [new WorkAuthor { Author = author, Order = 0 }] };
         var publisher = new Publisher { Name = "Collins Crime Club" };
         var book = new Book
         {
@@ -333,7 +333,7 @@ public class DuplicateDetectionServiceTests
         var book = new Book
         {
             Title = title,
-            Works = [new Work { Title = title, Author = author }]
+            Works = [new Work { Title = title, WorkAuthors = [new WorkAuthor { Author = author, Order = 0 }] }]
         };
         db.Books.Add(book);
         await db.SaveChangesAsync();

--- a/BookTracker.Tests/Services/EditionFormatBackfillServiceTests.cs
+++ b/BookTracker.Tests/Services/EditionFormatBackfillServiceTests.cs
@@ -111,7 +111,7 @@ public class EditionFormatBackfillServiceTests
             db.Books.Add(new Book
             {
                 Title = "Test",
-                Works = [new Work { Title = "Test", Author = new Author { Name = "Test" } }],
+                Works = [new Work { Title = "Test", WorkAuthors = [new WorkAuthor { Author = new Author { Name = "Test" }, Order = 0 }] }],
                 Editions = [new Edition { Isbn = isbn, Format = format, Copies = [new Copy { Condition = BookCondition.Good }] }]
             });
         }

--- a/BookTracker.Tests/Services/EditionMergeServiceTests.cs
+++ b/BookTracker.Tests/Services/EditionMergeServiceTests.cs
@@ -29,8 +29,8 @@ public class EditionMergeServiceTests
     {
         using var db = _factory.CreateDbContext();
         var author = new Author { Name = "A" };
-        var w1 = new Work { Title = "A1", Author = author };
-        var w2 = new Work { Title = "A2", Author = author };
+        var w1 = new Work { Title = "A1", WorkAuthors = [new WorkAuthor { Author = author, Order = 0 }] };
+        var w2 = new Work { Title = "A2", WorkAuthors = [new WorkAuthor { Author = author, Order = 0 }] };
         var b1 = new Book { Title = "B1", Works = [w1] };
         var b2 = new Book { Title = "B2", Works = [w2] };
         var e1 = new Edition { Book = b1, Isbn = "9780000000001", Format = BookFormat.Hardcover };
@@ -74,7 +74,7 @@ public class EditionMergeServiceTests
     {
         using var db = _factory.CreateDbContext();
         var author = new Author { Name = "A" };
-        var work = new Work { Title = "T", Author = author };
+        var work = new Work { Title = "T", WorkAuthors = [new WorkAuthor { Author = author, Order = 0 }] };
         var publisher = new Publisher { Name = "Acme Press" };
         var book = new Book { Title = "B", Works = [work] };
         // Winner has no date, no cover, no publisher, no ISBN.
@@ -113,7 +113,7 @@ public class EditionMergeServiceTests
     {
         using var db = _factory.CreateDbContext();
         var author = new Author { Name = "A" };
-        var work = new Work { Title = "T", Author = author };
+        var work = new Work { Title = "T", WorkAuthors = [new WorkAuthor { Author = author, Order = 0 }] };
         var pubA = new Publisher { Name = "Keep" };
         var pubB = new Publisher { Name = "Ignored" };
         var book = new Book { Title = "B", Works = [work] };
@@ -199,8 +199,8 @@ public class EditionMergeServiceTests
     {
         using var db = _factory.CreateDbContext();
         var author = new Author { Name = "A" };
-        var w1 = new Work { Title = "A1", Author = author };
-        var w2 = new Work { Title = "A2", Author = author };
+        var w1 = new Work { Title = "A1", WorkAuthors = [new WorkAuthor { Author = author, Order = 0 }] };
+        var w2 = new Work { Title = "A2", WorkAuthors = [new WorkAuthor { Author = author, Order = 0 }] };
         var b1 = new Book { Title = "B1", Works = [w1] };
         var b2 = new Book { Title = "B2", Works = [w2] };
         var e1 = new Edition { Book = b1, Isbn = "9780000000001", Format = BookFormat.Hardcover };
@@ -220,7 +220,7 @@ public class EditionMergeServiceTests
     {
         using var db = _factory.CreateDbContext();
         var author = new Author { Name = "Shared" };
-        var work = new Work { Title = "T", Author = author };
+        var work = new Work { Title = "T", WorkAuthors = [new WorkAuthor { Author = author, Order = 0 }] };
         var book = new Book { Title = "B", Works = [work] };
         var winner = new Edition { Book = book, Isbn = "9780000000001", Format = BookFormat.Hardcover };
         var loser = new Edition { Book = book, Isbn = "9780000000002", Format = BookFormat.Hardcover };

--- a/BookTracker.Tests/Services/SeriesMatchServiceTests.cs
+++ b/BookTracker.Tests/Services/SeriesMatchServiceTests.cs
@@ -51,8 +51,8 @@ public class SeriesMatchServiceTests
         {
             var someAuthor = new Author { Name = "Some Author" };
             db.Books.AddRange(
-                new Book { Title = "Book A", Works = [new Work { Title = "Book A", Author = someAuthor }] },
-                new Book { Title = "Book B", Works = [new Work { Title = "Book B", Author = someAuthor }] }
+                new Book { Title = "Book A", Works = [new Work { Title = "Book A", WorkAuthors = [new WorkAuthor { Author = someAuthor, Order = 0 }] }] },
+                new Book { Title = "Book B", Works = [new Work { Title = "Book B", WorkAuthors = [new WorkAuthor { Author = someAuthor, Order = 0 }] }] }
             );
             await db.SaveChangesAsync();
         }

--- a/BookTracker.Tests/Services/WorkMergeServiceTests.cs
+++ b/BookTracker.Tests/Services/WorkMergeServiceTests.cs
@@ -33,8 +33,8 @@ public class WorkMergeServiceTests
         using var db = _factory.CreateDbContext();
         var tolkien = new Author { Name = "J.R.R. Tolkien" };
         var notTolkien = new Author { Name = "Imposter" };
-        var w1 = new Work { Title = "The Hobbit", Author = tolkien };
-        var w2 = new Work { Title = "The Hobbit", Author = notTolkien };
+        var w1 = new Work { Title = "The Hobbit", WorkAuthors = [new WorkAuthor { Author = tolkien, Order = 0 }] };
+        var w2 = new Work { Title = "The Hobbit", WorkAuthors = [new WorkAuthor { Author = notTolkien, Order = 0 }] };
         db.Books.Add(new Book { Title = "A", Works = [w1] });
         db.Books.Add(new Book { Title = "B", Works = [w2] });
         await db.SaveChangesAsync();
@@ -51,8 +51,8 @@ public class WorkMergeServiceTests
         // flag that so the merge confirmation surfaces the overlap.
         using var db = _factory.CreateDbContext();
         var author = new Author { Name = "Agatha Christie" };
-        var w1 = new Work { Title = "A", Author = author };
-        var w2 = new Work { Title = "A", Author = author };
+        var w1 = new Work { Title = "A", WorkAuthors = [new WorkAuthor { Author = author, Order = 0 }] };
+        var w2 = new Work { Title = "A", WorkAuthors = [new WorkAuthor { Author = author, Order = 0 }] };
         db.Books.Add(new Book { Title = "Solo W1", Works = [w1] });
         db.Books.Add(new Book { Title = "Solo W2", Works = [w2] });
         db.Books.Add(new Book { Title = "Compendium", Works = [w1, w2] });
@@ -93,8 +93,8 @@ public class WorkMergeServiceTests
         // winner — the loser-side BookWork row gets dropped. No PK violation.
         using var db = _factory.CreateDbContext();
         var author = new Author { Name = "Agatha Christie" };
-        var winner = new Work { Title = "Style", Author = author };
-        var loser = new Work { Title = "Style", Author = author };
+        var winner = new Work { Title = "Style", WorkAuthors = [new WorkAuthor { Author = author, Order = 0 }] };
+        var loser = new Work { Title = "Style", WorkAuthors = [new WorkAuthor { Author = author, Order = 0 }] };
         db.Books.Add(new Book { Title = "Solo W2", Works = [loser] });
         db.Books.Add(new Book { Title = "Compendium", Works = [winner, loser] });
         await db.SaveChangesAsync();
@@ -172,8 +172,8 @@ public class WorkMergeServiceTests
         using var db = _factory.CreateDbContext();
         var tolkien = new Author { Name = "J.R.R. Tolkien" };
         var notTolkien = new Author { Name = "Imposter" };
-        var w1 = new Work { Title = "The Hobbit", Author = tolkien };
-        var w2 = new Work { Title = "The Hobbit", Author = notTolkien };
+        var w1 = new Work { Title = "The Hobbit", WorkAuthors = [new WorkAuthor { Author = tolkien, Order = 0 }] };
+        var w2 = new Work { Title = "The Hobbit", WorkAuthors = [new WorkAuthor { Author = notTolkien, Order = 0 }] };
         db.Books.Add(new Book { Title = "A", Works = [w1] });
         db.Books.Add(new Book { Title = "B", Works = [w2] });
         await db.SaveChangesAsync();
@@ -198,11 +198,11 @@ public class WorkMergeServiceTests
         await db.SaveChangesAsync();
 
         // Winner: bare title and author only.
-        var winner = new Work { Title = "Gunslinger", Author = author };
+        var winner = new Work { Title = "Gunslinger", WorkAuthors = [new WorkAuthor { Author = author, Order = 0 }] };
         // Loser: subtitle, first-pub date, series, genres.
         var loser = new Work
         {
-            Title = "Gunslinger", Author = author,
+            Title = "Gunslinger", WorkAuthors = [new WorkAuthor { Author = author, Order = 0 }],
             Subtitle = "Dark Tower I",
             FirstPublishedDate = new DateOnly(1982, 6, 10),
             FirstPublishedDatePrecision = DatePrecision.Day,
@@ -243,7 +243,7 @@ public class WorkMergeServiceTests
 
         var winner = new Work
         {
-            Title = "T", Author = author,
+            Title = "T", WorkAuthors = [new WorkAuthor { Author = author, Order = 0 }],
             Subtitle = "Keep Me",
             FirstPublishedDate = new DateOnly(2000, 1, 1),
             FirstPublishedDatePrecision = DatePrecision.Day,
@@ -251,7 +251,7 @@ public class WorkMergeServiceTests
         };
         var loser = new Work
         {
-            Title = "T", Author = author,
+            Title = "T", WorkAuthors = [new WorkAuthor { Author = author, Order = 0 }],
             Subtitle = "Ignored",
             FirstPublishedDate = new DateOnly(1900, 1, 1),
             Series = ignoreSeries, SeriesOrder = 7
@@ -284,8 +284,8 @@ public class WorkMergeServiceTests
         db.Genres.AddRange(horror, fantasy, mystery);
         await db.SaveChangesAsync();
 
-        var winner = new Work { Title = "T", Author = author, Genres = [horror, fantasy] };
-        var loser = new Work { Title = "T", Author = author, Genres = [fantasy, mystery] };
+        var winner = new Work { Title = "T", WorkAuthors = [new WorkAuthor { Author = author, Order = 0 }], Genres = [horror, fantasy] };
+        var loser = new Work { Title = "T", WorkAuthors = [new WorkAuthor { Author = author, Order = 0 }], Genres = [fantasy, mystery] };
         db.Books.Add(new Book { Title = "BW", Works = [winner] });
         db.Books.Add(new Book { Title = "BL", Works = [loser] });
         await db.SaveChangesAsync();
@@ -305,8 +305,8 @@ public class WorkMergeServiceTests
     {
         using var db = _factory.CreateDbContext();
         var author = new Author { Name = "Shared Author" };
-        var winner = new Work { Title = winnerTitle, Author = author };
-        var loser = new Work { Title = loserTitle, Author = author };
+        var winner = new Work { Title = winnerTitle, WorkAuthors = [new WorkAuthor { Author = author, Order = 0 }] };
+        var loser = new Work { Title = loserTitle, WorkAuthors = [new WorkAuthor { Author = author, Order = 0 }] };
         foreach (var t in winnerBooks)
         {
             db.Books.Add(new Book { Title = t, Works = [winner] });
@@ -323,9 +323,9 @@ public class WorkMergeServiceTests
     {
         using var db = _factory.CreateDbContext();
         var author = new Author { Name = "Shared Author" };
-        var winner = new Work { Title = "W", Author = author };
-        var loser = new Work { Title = "L", Author = author };
-        var other = new Work { Title = "O", Author = author };
+        var winner = new Work { Title = "W", WorkAuthors = [new WorkAuthor { Author = author, Order = 0 }] };
+        var loser = new Work { Title = "L", WorkAuthors = [new WorkAuthor { Author = author, Order = 0 }] };
+        var other = new Work { Title = "O", WorkAuthors = [new WorkAuthor { Author = author, Order = 0 }] };
         db.Books.Add(new Book { Title = "BW", Works = [winner] });
         db.Books.Add(new Book { Title = "BL", Works = [loser] });
         db.Books.Add(new Book { Title = "BO", Works = [other] });

--- a/BookTracker.Tests/Services/WorkSearchServiceTests.cs
+++ b/BookTracker.Tests/Services/WorkSearchServiceTests.cs
@@ -52,8 +52,8 @@ public class WorkSearchServiceTests
     {
         using var db = _factory.CreateDbContext();
         var author = new Author { Name = "Tolkien" };
-        var hobbit = new Work { Title = "The Hobbit", Author = author };
-        var fellowship = new Work { Title = "Fellowship", Author = author };
+        var hobbit = new Work { Title = "The Hobbit", WorkAuthors = [new WorkAuthor { Author = author, Order = 0 }] };
+        var fellowship = new Work { Title = "Fellowship", WorkAuthors = [new WorkAuthor { Author = author, Order = 0 }] };
         db.Books.Add(new Book { Title = "Compendium", Works = [hobbit] });
         db.Books.Add(new Book { Title = "Other", Works = [fellowship] });
         await db.SaveChangesAsync();
@@ -89,7 +89,7 @@ public class WorkSearchServiceTests
             db.Books.Add(new Book
             {
                 Title = title,
-                Works = [new Work { Title = title, Author = author }]
+                Works = [new Work { Title = title, WorkAuthors = [new WorkAuthor { Author = author, Order = 0 }] }]
             });
         }
         await db.SaveChangesAsync();

--- a/BookTracker.Tests/ViewModels/AuthorListViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/AuthorListViewModelTests.cs
@@ -14,8 +14,8 @@ public class AuthorListViewModelTests
             var king = new Author { Name = "Stephen King" };
             var bachman = new Author { Name = "Richard Bachman", CanonicalAuthor = king };
             db.Authors.AddRange(king, bachman);
-            db.Books.Add(new Book { Title = "Carrie", Works = [new Work { Title = "Carrie", Author = king }] });
-            db.Books.Add(new Book { Title = "Thinner", Works = [new Work { Title = "Thinner", Author = bachman }] });
+            db.Books.Add(new Book { Title = "Carrie", Works = [new Work { Title = "Carrie", WorkAuthors = [new WorkAuthor { Author = king, Order = 0 }] }] });
+            db.Books.Add(new Book { Title = "Thinner", Works = [new Work { Title = "Thinner", WorkAuthors = [new WorkAuthor { Author = bachman, Order = 0 }] }] });
             await db.SaveChangesAsync();
         }
 
@@ -39,8 +39,8 @@ public class AuthorListViewModelTests
             var king = new Author { Name = "Stephen King" };
             var bachman = new Author { Name = "Richard Bachman", CanonicalAuthor = king };
             db.Authors.AddRange(king, bachman);
-            db.Books.Add(new Book { Title = "Carrie", Works = [new Work { Title = "Carrie", Author = king }] });
-            db.Books.Add(new Book { Title = "Thinner", Works = [new Work { Title = "Thinner", Author = bachman }] });
+            db.Books.Add(new Book { Title = "Carrie", Works = [new Work { Title = "Carrie", WorkAuthors = [new WorkAuthor { Author = king, Order = 0 }] }] });
+            db.Books.Add(new Book { Title = "Thinner", Works = [new Work { Title = "Thinner", WorkAuthors = [new WorkAuthor { Author = bachman, Order = 0 }] }] });
             await db.SaveChangesAsync();
             kingId = king.Id;
         }
@@ -71,8 +71,8 @@ public class AuthorListViewModelTests
             var king = new Author { Name = "Stephen King" };
             var bachman = new Author { Name = "Richard Bachman", CanonicalAuthor = king };
             db.Authors.AddRange(king, bachman);
-            db.Books.Add(new Book { Title = "Carrie", Works = [new Work { Title = "Carrie", Author = king }] });
-            db.Books.Add(new Book { Title = "Thinner", Works = [new Work { Title = "Thinner", Author = bachman }] });
+            db.Books.Add(new Book { Title = "Carrie", Works = [new Work { Title = "Carrie", WorkAuthors = [new WorkAuthor { Author = king, Order = 0 }] }] });
+            db.Books.Add(new Book { Title = "Thinner", Works = [new Work { Title = "Thinner", WorkAuthors = [new WorkAuthor { Author = bachman, Order = 0 }] }] });
             await db.SaveChangesAsync();
             bachmanId = bachman.Id;
         }
@@ -97,7 +97,7 @@ public class AuthorListViewModelTests
         {
             var author = new Author { Name = "A" };
             db.Authors.Add(author);
-            db.Books.Add(new Book { Title = "B", Works = [new Work { Title = "W", Author = author }] });
+            db.Books.Add(new Book { Title = "B", Works = [new Work { Title = "W", WorkAuthors = [new WorkAuthor { Author = author, Order = 0 }] }] });
             await db.SaveChangesAsync();
             authorId = author.Id;
         }
@@ -138,8 +138,8 @@ public class AuthorListViewModelTests
             var king = new Author { Name = "Stephen King" };
             var bachman = new Author { Name = "Richard Bachman" }; // NOT an alias yet
             db.Authors.AddRange(king, bachman);
-            db.Books.Add(new Book { Title = "Carrie", Works = [new Work { Title = "Carrie", Author = king }] });
-            db.Books.Add(new Book { Title = "Thinner", Works = [new Work { Title = "Thinner", Author = bachman }] });
+            db.Books.Add(new Book { Title = "Carrie", Works = [new Work { Title = "Carrie", WorkAuthors = [new WorkAuthor { Author = king, Order = 0 }] }] });
+            db.Books.Add(new Book { Title = "Thinner", Works = [new Work { Title = "Thinner", WorkAuthors = [new WorkAuthor { Author = bachman, Order = 0 }] }] });
             await db.SaveChangesAsync();
             kingId = king.Id;
             bachmanId = bachman.Id;

--- a/BookTracker.Tests/ViewModels/BookAddViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/BookAddViewModelTests.cs
@@ -168,7 +168,7 @@ public class BookAddViewModelTests
             db.Books.Add(new Book
             {
                 Title = "The Hobbit",
-                Works = [new Work { Title = "The Hobbit", Author = new Author { Name = "Tolkien" } }],
+                Works = [new Work { Title = "The Hobbit", WorkAuthors = [new WorkAuthor { Author = new Author { Name = "Tolkien" }, Order = 0 }] }],
                 Editions = [new Edition { Isbn = "9780345391803", Copies = [new Copy { Condition = BookCondition.Good }] }]
             });
             await db.SaveChangesAsync();
@@ -199,7 +199,7 @@ public class BookAddViewModelTests
             var book = new Book
             {
                 Title = "The Hobbit",
-                Works = [new Work { Title = "The Hobbit", Author = new Author { Name = "Tolkien" } }],
+                Works = [new Work { Title = "The Hobbit", WorkAuthors = [new WorkAuthor { Author = new Author { Name = "Tolkien" }, Order = 0 }] }],
                 Editions = [new Edition { Isbn = "9780345391803", Copies = [new Copy { Condition = BookCondition.Good }] }]
             };
             db.Books.Add(book);
@@ -232,10 +232,10 @@ public class BookAddViewModelTests
 
         Assert.NotNull(ok);
         using var db = _factory.CreateDbContext();
-        var book = db.Books.Include(b => b.Works).ThenInclude(w => w.Author).Single();
+        var book = db.Books.Include(b => b.Works).ThenInclude(w => w.WorkAuthors).ThenInclude(wa => wa.Author).Single();
         var work = Assert.Single(book.Works);
         Assert.Equal("The Hobbit", work.Title);
-        Assert.Equal("J.R.R. Tolkien", work.Author.Name);
+        Assert.Equal("J.R.R. Tolkien", work.WorkAuthors.OrderBy(wa => wa.Order).First().Author.Name);
         Assert.Equal(new DateOnly(1937, 9, 21), work.FirstPublishedDate);
         Assert.Equal(DatePrecision.Day, work.FirstPublishedDatePrecision);
     }
@@ -258,10 +258,8 @@ public class BookAddViewModelTests
         Assert.NotNull(ok);
         using var db = _factory.CreateDbContext();
         var work = db.Works
-            .Include(w => w.Author)
             .Include(w => w.WorkAuthors).ThenInclude(wa => wa.Author)
             .Single();
-        Assert.Equal("Douglas Preston", work.Author.Name);
         Assert.Equal(2, work.WorkAuthors.Count);
         var ordered = work.WorkAuthors.OrderBy(wa => wa.Order).ToList();
         Assert.Equal("Douglas Preston", ordered[0].Author.Name);
@@ -383,8 +381,8 @@ public class BookAddViewModelTests
         {
             var author = new Author { Name = "Some Author" };
             db.Books.AddRange(
-                new Book { Title = "Book A", Works = [new Work { Title = "Book A", Author = author }] },
-                new Book { Title = "Book B", Works = [new Work { Title = "Book B", Author = author }] });
+                new Book { Title = "Book A", Works = [new Work { Title = "Book A", WorkAuthors = [new WorkAuthor { Author = author, Order = 0 }] }] },
+                new Book { Title = "Book B", Works = [new Work { Title = "Book B", WorkAuthors = [new WorkAuthor { Author = author, Order = 0 }] }] });
             await db.SaveChangesAsync();
         }
 

--- a/BookTracker.Tests/ViewModels/BookDetailViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/BookDetailViewModelTests.cs
@@ -39,7 +39,7 @@ public class BookDetailViewModelTests
                     new Work
                     {
                         Title = "A Wizard of Earthsea",
-                        Author = author,
+                        WorkAuthors = [new WorkAuthor { Author = author, Order = 0 }],
                         Genres = [genre],
                     }
                 ],
@@ -79,9 +79,9 @@ public class BookDetailViewModelTests
                 Works =
                 [
                     // Intentionally out of order — VM should sort by SeriesOrder.
-                    new Work { Title = "Macbeth", Author = author, Series = series, SeriesOrder = 3 },
-                    new Work { Title = "Hamlet", Author = author, Series = series, SeriesOrder = 1 },
-                    new Work { Title = "Othello", Author = author, Series = series, SeriesOrder = 2 },
+                    new Work { Title = "Macbeth", WorkAuthors = [new WorkAuthor { Author = author, Order = 0 }], Series = series, SeriesOrder = 3 },
+                    new Work { Title = "Hamlet", WorkAuthors = [new WorkAuthor { Author = author, Order = 0 }], Series = series, SeriesOrder = 1 },
+                    new Work { Title = "Othello", WorkAuthors = [new WorkAuthor { Author = author, Order = 0 }], Series = series, SeriesOrder = 2 },
                 ],
             };
             db.Books.Add(book);
@@ -111,7 +111,7 @@ public class BookDetailViewModelTests
             var book = new Book
             {
                 Title = "Mort",
-                Works = [new Work { Title = "Mort", Author = author }],
+                Works = [new Work { Title = "Mort", WorkAuthors = [new WorkAuthor { Author = author, Order = 0 }] }],
                 Editions =
                 [
                     new Edition
@@ -252,7 +252,7 @@ public class BookDetailViewModelTests
             var book = new Book
             {
                 Title = "T",
-                Works = [new Work { Title = "T", Author = new Author { Name = "A" } }],
+                Works = [new Work { Title = "T", WorkAuthors = [new WorkAuthor { Author = new Author { Name = "A" }, Order = 0 }] }],
             };
             db.Books.Add(book);
             await db.SaveChangesAsync();
@@ -279,7 +279,7 @@ public class BookDetailViewModelTests
             var book = new Book
             {
                 Title = "T",
-                Works = [new Work { Title = "T", Author = new Author { Name = "A" } }],
+                Works = [new Work { Title = "T", WorkAuthors = [new WorkAuthor { Author = new Author { Name = "A" }, Order = 0 }] }],
                 Tags = [tag],
             };
             db.Books.Add(book);
@@ -307,7 +307,7 @@ public class BookDetailViewModelTests
             var book = new Book
             {
                 Title = "T",
-                Works = [new Work { Title = "T", Author = new Author { Name = "A" } }],
+                Works = [new Work { Title = "T", WorkAuthors = [new WorkAuthor { Author = new Author { Name = "A" }, Order = 0 }] }],
                 Tags = [tag],
             };
             db.Books.Add(book);
@@ -348,7 +348,7 @@ public class BookDetailViewModelTests
             var book = new Book
             {
                 Title = "B",
-                Works = [new Work { Title = "B", Author = new Author { Name = "A" } }],
+                Works = [new Work { Title = "B", WorkAuthors = [new WorkAuthor { Author = new Author { Name = "A" }, Order = 0 }] }],
                 Editions = [edition],
             };
             db.Books.Add(book);
@@ -380,7 +380,7 @@ public class BookDetailViewModelTests
             var book = new Book
             {
                 Title = "B",
-                Works = [new Work { Title = "B", Author = new Author { Name = "A" } }],
+                Works = [new Work { Title = "B", WorkAuthors = [new WorkAuthor { Author = new Author { Name = "A" }, Order = 0 }] }],
                 Editions = [edition],
             };
             db.Books.Add(book);
@@ -412,7 +412,7 @@ public class BookDetailViewModelTests
             var book = new Book
             {
                 Title = "T",
-                Works = [new Work { Title = "T", Author = new Author { Name = "A" } }],
+                Works = [new Work { Title = "T", WorkAuthors = [new WorkAuthor { Author = new Author { Name = "A" }, Order = 0 }] }],
                 Tags = [assigned],
             };
             db.Books.Add(book);
@@ -442,7 +442,7 @@ public class BookDetailViewModelTests
             Status = status,
             Rating = rating,
             Notes = notes,
-            Works = [new Work { Title = "Seed", Author = new Author { Name = "Seed Author" } }],
+            Works = [new Work { Title = "Seed", WorkAuthors = [new WorkAuthor { Author = new Author { Name = "Seed Author" }, Order = 0 }] }],
         };
         db.Books.Add(book);
         await db.SaveChangesAsync();
@@ -461,7 +461,7 @@ public class BookDetailViewModelTests
             var book = new Book
             {
                 Title = "Tagged",
-                Works = [new Work { Title = "Tagged", Author = author }],
+                Works = [new Work { Title = "Tagged", WorkAuthors = [new WorkAuthor { Author = author, Order = 0 }] }],
                 Tags =
                 [
                     new Tag { Name = "signed" },

--- a/BookTracker.Tests/ViewModels/BookEditDialogViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/BookEditDialogViewModelTests.cs
@@ -28,7 +28,7 @@ public class BookEditDialogViewModelTests
                 Title = "Mort",
                 Category = BookCategory.Fiction,
                 DefaultCoverArtUrl = "https://example.com/mort.jpg",
-                Works = [new Work { Title = "Mort", Author = new Author { Name = "Pratchett" } }],
+                Works = [new Work { Title = "Mort", WorkAuthors = [new WorkAuthor { Author = new Author { Name = "Pratchett" }, Order = 0 }] }],
             };
             db.Books.Add(book);
             await db.SaveChangesAsync();
@@ -55,7 +55,7 @@ public class BookEditDialogViewModelTests
             {
                 Title = "Old title",
                 Category = BookCategory.Fiction,
-                Works = [new Work { Title = "w", Author = new Author { Name = "a" } }],
+                Works = [new Work { Title = "w", WorkAuthors = [new WorkAuthor { Author = new Author { Name = "a" }, Order = 0 }] }],
             };
             db.Books.Add(book);
             await db.SaveChangesAsync();
@@ -87,7 +87,7 @@ public class BookEditDialogViewModelTests
             {
                 Title = "T",
                 DefaultCoverArtUrl = "https://old.example.com",
-                Works = [new Work { Title = "w", Author = new Author { Name = "a" } }],
+                Works = [new Work { Title = "w", WorkAuthors = [new WorkAuthor { Author = new Author { Name = "a" }, Order = 0 }] }],
             };
             db.Books.Add(book);
             await db.SaveChangesAsync();
@@ -113,7 +113,7 @@ public class BookEditDialogViewModelTests
             var book = new Book
             {
                 Title = "Untouched",
-                Works = [new Work { Title = "w", Author = new Author { Name = "a" } }],
+                Works = [new Work { Title = "w", WorkAuthors = [new WorkAuthor { Author = new Author { Name = "a" }, Order = 0 }] }],
             };
             db.Books.Add(book);
             await db.SaveChangesAsync();

--- a/BookTracker.Tests/ViewModels/BookListViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/BookListViewModelTests.cs
@@ -33,23 +33,23 @@ public class BookListViewModelTests
             new Book
             {
                 Title = "Carrie",
-                Works = [new Work { Title = "Carrie", Author = king, Genres = [horror] }]
+                Works = [new Work { Title = "Carrie", WorkAuthors = [new WorkAuthor { Author = king, Order = 0 }], Genres = [horror] }]
             },
             new Book
             {
                 Title = "The Long Walk",
-                Works = [new Work { Title = "The Long Walk", Author = bachman, Genres = [horror] }]
+                Works = [new Work { Title = "The Long Walk", WorkAuthors = [new WorkAuthor { Author = bachman, Order = 0 }], Genres = [horror] }]
             },
             new Book
             {
                 Title = "Murder on the Orient Express",
-                Works = [new Work { Title = "Murder on the Orient Express", Author = christie, Genres = [mystery], Series = poirot, SeriesOrder = 9 }]
+                Works = [new Work { Title = "Murder on the Orient Express", WorkAuthors = [new WorkAuthor { Author = christie, Order = 0 }], Genres = [mystery], Series = poirot, SeriesOrder = 9 }]
             },
             new Book
             {
                 // No genre, no series — exercises the trailing buckets.
                 Title = "Mystery Book Without Tags",
-                Works = [new Work { Title = "Mystery Book Without Tags", Author = christie }]
+                Works = [new Work { Title = "Mystery Book Without Tags", WorkAuthors = [new WorkAuthor { Author = christie, Order = 0 }] }]
             });
 
         await db.SaveChangesAsync();

--- a/BookTracker.Tests/ViewModels/BulkAddViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/BulkAddViewModelTests.cs
@@ -93,7 +93,7 @@ public class BulkAddViewModelTests
             db.Books.Add(new Book
             {
                 Title = "Existing",
-                Works = [new Work { Title = "Existing", Author = new Author { Name = "Author" } }],
+                Works = [new Work { Title = "Existing", WorkAuthors = [new WorkAuthor { Author = new Author { Name = "Author" }, Order = 0 }] }],
                 Editions = [new Edition { Isbn = "9780345391803", Copies = [new Copy { Condition = BookCondition.Good }] }]
             });
             await db.SaveChangesAsync();
@@ -137,9 +137,9 @@ public class BulkAddViewModelTests
         Assert.Equal(BulkAddViewModel.RowAction.Accepted, row.Action);
 
         using var db = _factory.CreateDbContext();
-        var book = db.Books.Include(b => b.Works).ThenInclude(w => w.Author).FirstOrDefault(b => b.Title == "The Hobbit");
+        var book = db.Books.Include(b => b.Works).ThenInclude(w => w.WorkAuthors).ThenInclude(wa => wa.Author).FirstOrDefault(b => b.Title == "The Hobbit");
         Assert.NotNull(book);
-        Assert.Equal("J.R.R. Tolkien", book.Works.Single().Author.Name);
+        Assert.Equal("J.R.R. Tolkien", book.Works.Single().WorkAuthors.OrderBy(wa => wa.Order).First().Author.Name);
     }
 
     [Fact]
@@ -160,10 +160,10 @@ public class BulkAddViewModelTests
         await vm.AcceptRowAsync(row);
 
         using var db = _factory.CreateDbContext();
-        var book = db.Books.Include(b => b.Works).ThenInclude(w => w.Author).Single(b => b.Title == "The Hobbit");
+        var book = db.Books.Include(b => b.Works).ThenInclude(w => w.WorkAuthors).ThenInclude(wa => wa.Author).Single(b => b.Title == "The Hobbit");
         var work = Assert.Single(book.Works);
         Assert.Equal("The Hobbit", work.Title);
-        Assert.Equal("J.R.R. Tolkien", work.Author.Name);
+        Assert.Equal("J.R.R. Tolkien", work.WorkAuthors.OrderBy(wa => wa.Order).First().Author.Name);
     }
 
     [Fact]

--- a/BookTracker.Tests/ViewModels/CopyFormDialogViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/CopyFormDialogViewModelTests.cs
@@ -48,7 +48,7 @@ public class CopyFormDialogViewModelTests
             db.Books.Add(new Book
             {
                 Title = "B",
-                Works = [new Work { Title = "B", Author = new Author { Name = "A" } }],
+                Works = [new Work { Title = "B", WorkAuthors = [new WorkAuthor { Author = new Author { Name = "A" }, Order = 0 }] }],
                 Editions = [edition],
             });
             await db.SaveChangesAsync();
@@ -76,7 +76,7 @@ public class CopyFormDialogViewModelTests
             db.Books.Add(new Book
             {
                 Title = "B",
-                Works = [new Work { Title = "B", Author = new Author { Name = "A" } }],
+                Works = [new Work { Title = "B", WorkAuthors = [new WorkAuthor { Author = new Author { Name = "A" }, Order = 0 }] }],
                 Editions = [seedEdition],
             });
             await db.SaveChangesAsync();
@@ -110,7 +110,7 @@ public class CopyFormDialogViewModelTests
             db.Books.Add(new Book
             {
                 Title = "B",
-                Works = [new Work { Title = "B", Author = new Author { Name = "A" } }],
+                Works = [new Work { Title = "B", WorkAuthors = [new WorkAuthor { Author = new Author { Name = "A" }, Order = 0 }] }],
                 Editions = [edition],
             });
             await db.SaveChangesAsync();

--- a/BookTracker.Tests/ViewModels/EditionFormDialogViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/EditionFormDialogViewModelTests.cs
@@ -54,7 +54,7 @@ public class EditionFormDialogViewModelTests
             db.Books.Add(new Book
             {
                 Title = "Mort",
-                Works = [new Work { Title = "Mort", Author = new Author { Name = "Pratchett" } }],
+                Works = [new Work { Title = "Mort", WorkAuthors = [new WorkAuthor { Author = new Author { Name = "Pratchett" }, Order = 0 }] }],
                 Editions = [edition],
             });
             await db.SaveChangesAsync();
@@ -82,7 +82,7 @@ public class EditionFormDialogViewModelTests
             var book = new Book
             {
                 Title = "B",
-                Works = [new Work { Title = "B", Author = new Author { Name = "A" } }],
+                Works = [new Work { Title = "B", WorkAuthors = [new WorkAuthor { Author = new Author { Name = "A" }, Order = 0 }] }],
             };
             db.Books.Add(book);
             await db.SaveChangesAsync();
@@ -118,7 +118,7 @@ public class EditionFormDialogViewModelTests
             var book = new Book
             {
                 Title = "B",
-                Works = [new Work { Title = "B", Author = new Author { Name = "A" } }],
+                Works = [new Work { Title = "B", WorkAuthors = [new WorkAuthor { Author = new Author { Name = "A" }, Order = 0 }] }],
             };
             db.Books.Add(book);
             await db.SaveChangesAsync();
@@ -150,7 +150,7 @@ public class EditionFormDialogViewModelTests
             var book = new Book
             {
                 Title = "B",
-                Works = [new Work { Title = "B", Author = new Author { Name = "A" } }],
+                Works = [new Work { Title = "B", WorkAuthors = [new WorkAuthor { Author = new Author { Name = "A" }, Order = 0 }] }],
             };
             db.Books.Add(book);
             await db.SaveChangesAsync();
@@ -186,7 +186,7 @@ public class EditionFormDialogViewModelTests
             db.Books.Add(new Book
             {
                 Title = "B",
-                Works = [new Work { Title = "B", Author = new Author { Name = "A" } }],
+                Works = [new Work { Title = "B", WorkAuthors = [new WorkAuthor { Author = new Author { Name = "A" }, Order = 0 }] }],
                 Editions = [seedEdition],
             });
             await db.SaveChangesAsync();
@@ -222,7 +222,7 @@ public class EditionFormDialogViewModelTests
             var book = new Book
             {
                 Title = "B",
-                Works = [new Work { Title = "B", Author = new Author { Name = "A" } }],
+                Works = [new Work { Title = "B", WorkAuthors = [new WorkAuthor { Author = new Author { Name = "A" }, Order = 0 }] }],
             };
             db.Books.Add(book);
             await db.SaveChangesAsync();

--- a/BookTracker.Tests/ViewModels/HomeViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/HomeViewModelTests.cs
@@ -32,9 +32,9 @@ public class HomeViewModelTests
             var author1 = new Author { Name = "Author 1" };
             var author2 = new Author { Name = "Author 2" };
             db.Books.AddRange(
-                new Book { Title = "Book A", Works = [new Work { Title = "Book A", Author = author1 }] },
-                new Book { Title = "Book B", Works = [new Work { Title = "Book B", Author = author1 }] },
-                new Book { Title = "Book C", Works = [new Work { Title = "Book C", Author = author2 }] }
+                new Book { Title = "Book A", Works = [new Work { Title = "Book A", WorkAuthors = [new WorkAuthor { Author = author1, Order = 0 }] }] },
+                new Book { Title = "Book B", Works = [new Work { Title = "Book B", WorkAuthors = [new WorkAuthor { Author = author1, Order = 0 }] }] },
+                new Book { Title = "Book C", Works = [new Work { Title = "Book C", WorkAuthors = [new WorkAuthor { Author = author2, Order = 0 }] }] }
             );
             await db.SaveChangesAsync();
         }
@@ -65,8 +65,8 @@ public class HomeViewModelTests
             var bachman = new Author { Name = "Richard Bachman", CanonicalAuthorId = king.Id };
             db.Authors.Add(bachman);
 
-            db.Books.Add(new Book { Title = "Carrie", Works = [new Work { Title = "Carrie", Author = king }] });
-            db.Books.Add(new Book { Title = "The Long Walk", Works = [new Work { Title = "The Long Walk", Author = bachman }] });
+            db.Books.Add(new Book { Title = "Carrie", Works = [new Work { Title = "Carrie", WorkAuthors = [new WorkAuthor { Author = king, Order = 0 }] }] });
+            db.Books.Add(new Book { Title = "The Long Walk", Works = [new Work { Title = "The Long Walk", WorkAuthors = [new WorkAuthor { Author = bachman, Order = 0 }] }] });
             await db.SaveChangesAsync();
         }
 
@@ -92,9 +92,9 @@ public class HomeViewModelTests
             var c = new Author { Name = "C" };
 
             db.Books.AddRange(
-                new Book { Title = "Book A", Works = [new Work { Title = "Book A", Author = a, Genres = [fantasy] }] },
-                new Book { Title = "Book B", Works = [new Work { Title = "Book B", Author = b, Genres = [fantasy, sciFi] }] },
-                new Book { Title = "Book C", Works = [new Work { Title = "Book C", Author = c, Genres = [sciFi] }] }
+                new Book { Title = "Book A", Works = [new Work { Title = "Book A", WorkAuthors = [new WorkAuthor { Author = a, Order = 0 }], Genres = [fantasy] }] },
+                new Book { Title = "Book B", Works = [new Work { Title = "Book B", WorkAuthors = [new WorkAuthor { Author = b, Order = 0 }], Genres = [fantasy, sciFi] }] },
+                new Book { Title = "Book C", Works = [new Work { Title = "Book C", WorkAuthors = [new WorkAuthor { Author = c, Order = 0 }], Genres = [sciFi] }] }
             );
             await db.SaveChangesAsync();
         }

--- a/BookTracker.Tests/ViewModels/ShoppingViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/ShoppingViewModelTests.cs
@@ -10,7 +10,7 @@ public class ShoppingViewModelTests
     {
         // Regression for the NullReferenceException that surfaced on the
         // Shopping page when an ISBN matched an existing edition. The query
-        // was missing .Include(w => w.Author), so PrimaryAuthor dereferenced
+        // was missing .Include(w => w.WorkAuthors).ThenInclude(wa => wa.Author), so PrimaryAuthor dereferenced
         // a null navigation property. This test seeds a book + edition and
         // ensures the result comes back with the author populated.
         var factory = new TestDbContextFactory();
@@ -22,7 +22,7 @@ public class ShoppingViewModelTests
             var book = new Book
             {
                 Title = "Mort",
-                Works = [new Work { Title = "Mort", Author = author }],
+                Works = [new Work { Title = "Mort", WorkAuthors = [new WorkAuthor { Author = author, Order = 0 }] }],
                 Editions =
                 [
                     new Edition
@@ -71,7 +71,7 @@ public class ShoppingViewModelTests
             var book = new Book
             {
                 Title = "Good Omens",
-                Works = [new Work { Title = "Good Omens", Author = new Author { Name = "Terry Pratchett & Neil Gaiman" } }],
+                Works = [new Work { Title = "Good Omens", WorkAuthors = [new WorkAuthor { Author = new Author { Name = "Terry Pratchett & Neil Gaiman" }, Order = 0 }] }],
                 Editions = [new Edition { Isbn = "x", Copies = [new Copy { Condition = BookCondition.Good }] }],
             };
             db.Books.Add(book);

--- a/BookTracker.Tests/ViewModels/WorkEditDialogViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/WorkEditDialogViewModelTests.cs
@@ -29,7 +29,7 @@ public class WorkEditDialogViewModelTests
             {
                 Title = "Mort",
                 Subtitle = "A Discworld Novel",
-                Author = new Author { Name = "Terry Pratchett" },
+                WorkAuthors = [new WorkAuthor { Author = new Author { Name = "Terry Pratchett" }, Order = 0 }],
                 FirstPublishedDate = new DateOnly(1987, 11, 12),
                 FirstPublishedDatePrecision = DatePrecision.Day,
                 Series = series,
@@ -63,7 +63,7 @@ public class WorkEditDialogViewModelTests
             var work = new Work
             {
                 Title = "Old",
-                Author = new Author { Name = "Old Author" },
+                WorkAuthors = [new WorkAuthor { Author = new Author { Name = "Old Author" }, Order = 0 }],
             };
             db.Books.Add(new Book { Title = "B", Works = [work] });
             await db.SaveChangesAsync();
@@ -79,7 +79,7 @@ public class WorkEditDialogViewModelTests
         await vm.SaveAsync();
 
         using var db2 = factory.CreateDbContext();
-        var saved = db2.Works.Include(w => w.Author).Single(w => w.Id == workId);
+        var saved = db2.Works.Include(w => w.WorkAuthors).ThenInclude(wa => wa.Author).Single(w => w.Id == workId);
         Assert.Equal("Mort", saved.Title);
         Assert.Equal("A Discworld Novel", saved.Subtitle);
         Assert.Equal(new DateOnly(1987, 1, 1), saved.FirstPublishedDate);
@@ -96,7 +96,7 @@ public class WorkEditDialogViewModelTests
         {
             var a1 = new Author { Name = "Terry Pratchett" };
             var a2 = new Author { Name = "Placeholder" };
-            var work = new Work { Title = "w", Author = a2 };
+            var work = new Work { Title = "w", WorkAuthors = [new WorkAuthor { Author = a2, Order = 0 }] };
             db.Books.Add(new Book { Title = "B", Works = [work] });
             db.Authors.Add(a1);
             await db.SaveChangesAsync();
@@ -110,8 +110,8 @@ public class WorkEditDialogViewModelTests
         await vm.SaveAsync();
 
         using var db2 = factory.CreateDbContext();
-        var saved = db2.Works.Include(w => w.Author).Single(w => w.Id == workId);
-        Assert.Equal(existingAuthorId, saved.Author.Id);
+        var saved = db2.Works.Include(w => w.WorkAuthors).ThenInclude(wa => wa.Author).Single(w => w.Id == workId);
+        Assert.Equal(existingAuthorId, saved.WorkAuthors.OrderBy(wa => wa.Order).First().Author.Id);
         Assert.Equal(2, db2.Authors.Count());
     }
 
@@ -122,7 +122,7 @@ public class WorkEditDialogViewModelTests
         int workId;
         using (var db = factory.CreateDbContext())
         {
-            var work = new Work { Title = "w", Author = new Author { Name = "Old Author" } };
+            var work = new Work { Title = "w", WorkAuthors = [new WorkAuthor { Author = new Author { Name = "Old Author" }, Order = 0 }] };
             db.Books.Add(new Book { Title = "B", Works = [work] });
             await db.SaveChangesAsync();
             workId = work.Id;
@@ -148,7 +148,7 @@ public class WorkEditDialogViewModelTests
             var work = new Work
             {
                 Title = "w",
-                Author = new Author { Name = "a" },
+                WorkAuthors = [new WorkAuthor { Author = new Author { Name = "a" }, Order = 0 }],
                 Series = series,
                 SeriesOrder = 3,
             };
@@ -180,7 +180,7 @@ public class WorkEditDialogViewModelTests
             var work = new Work
             {
                 Title = "w",
-                Author = new Author { Name = "a" },
+                WorkAuthors = [new WorkAuthor { Author = new Author { Name = "a" }, Order = 0 }],
                 Genres = [fantasy],
             };
             db.Books.Add(new Book { Title = "B", Works = [work] });
@@ -211,7 +211,7 @@ public class WorkEditDialogViewModelTests
             var work = new Work
             {
                 Title = "w",
-                Author = new Author { Name = "a" },
+                WorkAuthors = [new WorkAuthor { Author = new Author { Name = "a" }, Order = 0 }],
                 Genres = [fantasy], // starts with Fantasy
             };
             db.Books.Add(new Book { Title = "B", Works = [work] });
@@ -244,7 +244,7 @@ public class WorkEditDialogViewModelTests
                 new Author { Name = "Terry Pratchett" },
                 new Author { Name = "Neil Gaiman" },
                 new Author { Name = "Pratchett & Gaiman" });
-            var work = new Work { Title = "w", Author = new Author { Name = "Seed" } };
+            var work = new Work { Title = "w", WorkAuthors = [new WorkAuthor { Author = new Author { Name = "Seed" }, Order = 0 }] };
             db.Books.Add(new Book { Title = "B", Works = [work] });
             await db.SaveChangesAsync();
             workId = work.Id;

--- a/BookTracker.Web/Services/AIAssistantService.cs
+++ b/BookTracker.Web/Services/AIAssistantService.cs
@@ -108,7 +108,7 @@ Rules:
             .Select(b => new
             {
                 b.Title,
-                Author = string.Join(", ", b.Works.Select(w => w.Author).Distinct())
+                Author = string.Join(", ", b.Works.SelectMany(w => w.Authors.Select(a => a.Name)).Distinct())
             })
             .ToListAsync(ct);
 
@@ -151,7 +151,7 @@ Rules:
             .Select(b => new
             {
                 b.Title,
-                Author = string.Join(", ", b.Works.Select(w => w.Author).Distinct()),
+                Author = string.Join(", ", b.Works.SelectMany(w => w.Authors.Select(a => a.Name)).Distinct()),
                 b.Rating,
                 Genres = b.Works.SelectMany(w => w.Genres).Select(g => g.Name).Distinct().ToList()
             })

--- a/BookTracker.Web/Services/AuthorMergeService.cs
+++ b/BookTracker.Web/Services/AuthorMergeService.cs
@@ -95,11 +95,36 @@ public class AuthorMergeService(IDbContextFactory<BookTrackerDbContext> dbFactor
             winner.CanonicalAuthorId = null;
         }
 
-        var works = await db.Works.Where(w => w.AuthorId == loser.Id).ToListAsync(ct);
-        foreach (var w in works)
+        // Reassign every WorkAuthor row from loser to winner. Composite PK
+        // (WorkId, AuthorId) means we can'\''t UPDATE the AuthorId column —
+        // delete + add. If winner is already credited on the same Work, drop
+        // the loser row to avoid a duplicate composite key (the merge
+        // collapses both into one credit).
+        var loserWorkAuthors = await db.WorkAuthors
+            .Where(wa => wa.AuthorId == loser.Id)
+            .ToListAsync(ct);
+
+        var winnerCreditedWorkIds = (await db.WorkAuthors
+            .Where(wa => wa.AuthorId == winner.Id)
+            .Select(wa => wa.WorkId)
+            .ToListAsync(ct))
+            .ToHashSet();
+
+        foreach (var wa in loserWorkAuthors)
         {
-            w.AuthorId = winner.Id;
+            db.WorkAuthors.Remove(wa);
+            if (!winnerCreditedWorkIds.Contains(wa.WorkId))
+            {
+                db.WorkAuthors.Add(new WorkAuthor
+                {
+                    WorkId = wa.WorkId,
+                    AuthorId = winner.Id,
+                    Order = wa.Order,
+                });
+                winnerCreditedWorkIds.Add(wa.WorkId);
+            }
         }
+        var worksReassignedCount = loserWorkAuthors.Count;
 
         // External aliases of the loser become aliases of the winner. Must
         // exclude the winner explicitly — if winner was an alias of loser its
@@ -131,7 +156,7 @@ public class AuthorMergeService(IDbContextFactory<BookTrackerDbContext> dbFactor
         return new AuthorMergeResult(
             Success: true,
             ErrorMessage: null,
-            WorksReassigned: works.Count,
+            WorksReassigned: worksReassignedCount,
             AliasesReassigned: aliases.Count,
             WinnerPromotedToCanonical: winnerWasAliasOfLoser,
             WinnerName: winner.Name,
@@ -145,25 +170,25 @@ public class AuthorMergeService(IDbContextFactory<BookTrackerDbContext> dbFactor
             .FirstOrDefaultAsync(a => a.Id == id, ct);
         if (author is null) return null;
 
-        var workCount = await db.Works.CountAsync(w => w.AuthorId == id, ct);
+        var workCount = await db.Works.CountAsync(w => w.Authors.Any(a => a.Id == id), ct);
         var aliasCount = await db.Authors.CountAsync(a => a.CanonicalAuthorId == id, ct);
         var sampleTitles = await db.Works
-            .Where(w => w.AuthorId == id)
+            .Where(w => w.Authors.Any(a => a.Id == id))
             .OrderBy(w => w.Title)
             .Take(SampleWorkLimit)
             .Select(w => w.Title)
             .ToListAsync(ct);
 
-        // Cover pick: prefer a Book that contains a single Work by this
-        // author (its cover faithfully represents one of the author's
+        // Cover pick: prefer a Book that contains a single Work credited to
+        // this author (its cover faithfully represents one of the author's
         // Works); fall back to any Book by the author.
         var singleWorkBookCover = await db.Books
-            .Where(b => b.Works.Any(w => w.AuthorId == id) && b.Works.Count == 1)
+            .Where(b => b.Works.Any(w => w.Authors.Any(a => a.Id == id)) && b.Works.Count == 1)
             .Select(b => b.DefaultCoverArtUrl)
             .FirstOrDefaultAsync(ct);
         var cover = singleWorkBookCover is null
             ? await db.Books
-                .Where(b => b.Works.Any(w => w.AuthorId == id))
+                .Where(b => b.Works.Any(w => w.Authors.Any(a => a.Id == id)))
                 .Select(b => b.DefaultCoverArtUrl)
                 .FirstOrDefaultAsync(ct)
             : singleWorkBookCover;

--- a/BookTracker.Web/Services/AuthorResolver.cs
+++ b/BookTracker.Web/Services/AuthorResolver.cs
@@ -69,11 +69,10 @@ public static class AuthorResolver
     }
 
     /// <summary>
-    /// PR1 dual-write helper. Sets Work.Author to the lead (first) author for
-    /// legacy-FK compat AND replaces Work.WorkAuthors with one join row per
-    /// author, Order ascending from 0. Caller is responsible for ensuring
-    /// authors come from FindOrCreateAllAsync (so brand-new ones are
-    /// already attached to the DbContext) and for SaveChangesAsync.
+    /// Replace Work.WorkAuthors with one join row per author, Order ascending
+    /// from 0. Caller is responsible for ensuring authors come from
+    /// FindOrCreateAllAsync (so brand-new ones are already attached to the
+    /// DbContext) and for SaveChangesAsync.
     /// </summary>
     public static void AssignAuthors(Work work, IReadOnlyList<Author> authors)
     {
@@ -81,8 +80,6 @@ public static class AuthorResolver
         {
             throw new ArgumentException("At least one author required.", nameof(authors));
         }
-
-        work.Author = authors[0];
 
         work.WorkAuthors.Clear();
         for (var i = 0; i < authors.Count; i++)

--- a/BookTracker.Web/Services/AzureOpenAIAssistantService.cs
+++ b/BookTracker.Web/Services/AzureOpenAIAssistantService.cs
@@ -105,7 +105,7 @@ Rules:
             .Select(b => new
             {
                 b.Title,
-                Author = string.Join(", ", b.Works.Select(w => w.Author).Distinct())
+                Author = string.Join(", ", b.Works.SelectMany(w => w.Authors.Select(a => a.Name)).Distinct())
             })
             .ToListAsync(ct);
 
@@ -145,7 +145,7 @@ Rules:
             .Select(b => new
             {
                 b.Title,
-                Author = string.Join(", ", b.Works.Select(w => w.Author).Distinct()),
+                Author = string.Join(", ", b.Works.SelectMany(w => w.Authors.Select(a => a.Name)).Distinct()),
                 b.Rating,
                 Genres = b.Works.SelectMany(w => w.Genres).Select(g => g.Name).Distinct().ToList()
             })

--- a/BookTracker.Web/Services/BookMergeService.cs
+++ b/BookTracker.Web/Services/BookMergeService.cs
@@ -165,7 +165,7 @@ public class BookMergeService(IDbContextFactory<BookTrackerDbContext> dbFactory)
     {
         var book = await db.Books
             .Include(b => b.Editions)
-            .Include(b => b.Works).ThenInclude(w => w.Author)
+            .Include(b => b.Works).ThenInclude(w => w.WorkAuthors).ThenInclude(wa => wa.Author)
             .Include(b => b.Tags)
             .FirstOrDefaultAsync(b => b.Id == id, ct);
         if (book is null) return null;
@@ -178,7 +178,11 @@ public class BookMergeService(IDbContextFactory<BookTrackerDbContext> dbFactory)
             ? book.DefaultCoverArtUrl
             : book.Editions.Select(e => e.CoverUrl).FirstOrDefault(c => !string.IsNullOrWhiteSpace(c));
 
-        var firstAuthor = book.Works.FirstOrDefault()?.Author.Name;
+        // First Work's authorship for the merge dialog headline. Multi-Work
+        // books show the first Work's display string; the user can drill into
+        // BookDetail for the full picture.
+        var primaryWork = book.Works.FirstOrDefault();
+        var firstAuthor = primaryWork is null ? null : WorkAuthorshipFormatter.Display(primaryWork);
 
         return new BookMergeDetail(
             book.Id, book.Title, firstAuthor,

--- a/BookTracker.Web/Services/DuplicateDetectionService.cs
+++ b/BookTracker.Web/Services/DuplicateDetectionService.cs
@@ -209,28 +209,32 @@ public class DuplicateDetectionService(IDbContextFactory<BookTrackerDbContext> d
         Dictionary<(int Lower, int Higher), IgnoredDuplicate>? ignored,
         CancellationToken ct)
     {
+        // Project an Author "fingerprint" — sorted, comma-joined Author IDs —
+        // so works with the same author SET (regardless of order or co-author
+        // count) bucket together for duplicate detection. Single-author works
+        // get a single-id fingerprint; "Preston, Child" works share a
+        // fingerprint distinct from a "Preston" solo work.
         var works = (await db.Works
-            .Include(w => w.Author)
             .Select(w => new
             {
                 w.Id,
                 w.Title,
                 w.Subtitle,
-                w.AuthorId,
-                AuthorName = w.Author.Name,
+                AuthorIdsJoined = string.Join(",", w.WorkAuthors.OrderBy(wa => wa.AuthorId).Select(wa => wa.AuthorId)),
+                AuthorNames = string.Join(", ", w.WorkAuthors.OrderBy(wa => wa.Order).Select(wa => wa.Author.Name)),
                 BookCount = w.Books.Count,
                 FirstPublishedDate = w.FirstPublishedDate
             })
             .ToListAsync(ct))
             .Select(w => new
             {
-                w.Id, w.Title, w.Subtitle, w.AuthorId, w.AuthorName, w.BookCount,
+                w.Id, w.Title, w.Subtitle, w.AuthorIdsJoined, w.AuthorNames, w.BookCount,
                 FirstPublishedYear = w.FirstPublishedDate?.Year
             })
             .ToList();
 
         var pairs = new List<WorkDuplicatePair>();
-        foreach (var group in works.GroupBy(w => (w.AuthorId, DuplicateNormalization.Title(w.Title))))
+        foreach (var group in works.GroupBy(w => (w.AuthorIdsJoined, DuplicateNormalization.Title(w.Title))))
         {
             if (string.IsNullOrEmpty(group.Key.Item2) || group.Count() < 2) continue;
 
@@ -241,8 +245,8 @@ public class DuplicateDetectionService(IDbContextFactory<BookTrackerDbContext> d
                 {
                     var a = members[i];
                     var b = members[j];
-                    var snapA = new WorkSnapshot(a.Id, a.Title, a.Subtitle, a.AuthorName, a.BookCount, a.FirstPublishedYear);
-                    var snapB = new WorkSnapshot(b.Id, b.Title, b.Subtitle, b.AuthorName, b.BookCount, b.FirstPublishedYear);
+                    var snapA = new WorkSnapshot(a.Id, a.Title, a.Subtitle, a.AuthorNames, a.BookCount, a.FirstPublishedYear);
+                    var snapB = new WorkSnapshot(b.Id, b.Title, b.Subtitle, b.AuthorNames, b.BookCount, b.FirstPublishedYear);
                     pairs.Add(new WorkDuplicatePair(
                         Lower: snapA,
                         Higher: snapB,
@@ -269,8 +273,12 @@ public class DuplicateDetectionService(IDbContextFactory<BookTrackerDbContext> d
                 EditionCount = b.Editions.Count,
                 CopyCount = b.Editions.SelectMany(e => e.Copies).Count(),
                 WorkIds = b.Works.Select(w => w.Id).ToList(),
-                FirstAuthorId = b.Works.Select(w => (int?)w.AuthorId).FirstOrDefault(),
-                FirstAuthorName = b.Works.Select(w => w.Author.Name).FirstOrDefault()
+                FirstAuthorId = b.Works
+                    .SelectMany(w => w.WorkAuthors.OrderBy(wa => wa.Order).Select(wa => (int?)wa.AuthorId))
+                    .FirstOrDefault(),
+                FirstAuthorName = b.Works
+                    .SelectMany(w => w.WorkAuthors.OrderBy(wa => wa.Order).Select(wa => wa.Author.Name))
+                    .FirstOrDefault()
             })
             .ToListAsync(ct);
 

--- a/BookTracker.Web/Services/MicrosoftFoundryAIAssistantService.cs
+++ b/BookTracker.Web/Services/MicrosoftFoundryAIAssistantService.cs
@@ -112,7 +112,7 @@ Rules:
             .Select(b => new
             {
                 b.Title,
-                Author = string.Join(", ", b.Works.Select(w => w.Author).Distinct())
+                Author = string.Join(", ", b.Works.SelectMany(w => w.Authors.Select(a => a.Name)).Distinct())
             })
             .ToListAsync(ct);
 
@@ -154,7 +154,7 @@ Rules:
             .Select(b => new
             {
                 b.Title,
-                Author = string.Join(", ", b.Works.Select(w => w.Author).Distinct()),
+                Author = string.Join(", ", b.Works.SelectMany(w => w.Authors.Select(a => a.Name)).Distinct()),
                 b.Rating,
                 Genres = b.Works.SelectMany(w => w.Genres).Select(g => g.Name).Distinct().ToList()
             })

--- a/BookTracker.Web/Services/SeriesMatchService.cs
+++ b/BookTracker.Web/Services/SeriesMatchService.cs
@@ -114,7 +114,7 @@ public partial class SeriesMatchService(IDbContextFactory<BookTrackerDbContext> 
         // that might suggest grouping
         var authorName = author.Trim();
         var authorWorkCount = await db.Works
-            .CountAsync(w => w.Author.Name == authorName && w.SeriesId == null);
+            .CountAsync(w => w.Authors.Any(a => a.Name == authorName) && w.SeriesId == null);
 
         if (authorWorkCount >= 2)
         {

--- a/BookTracker.Web/Services/SharedParsers.cs
+++ b/BookTracker.Web/Services/SharedParsers.cs
@@ -193,16 +193,17 @@ Rules:
 
     public static async Task<string> BuildLibraryContextAsync(BookTrackerDbContext db, CancellationToken ct)
     {
-        // Author stats come from Works — author-per-work is the model now,
-        // and a compendium contributes one entry per contained work to the
-        // author's tally, which matches the reader's reading experience.
-        var topAuthors = await db.Works
-            .GroupBy(w => w.Author)
+        // Author stats: each WorkAuthor row contributes one tally to its Author.
+        // Co-authored Works contribute to BOTH credited authors (post-PR2);
+        // pen-names stay separate (no canonical rollup here — this is the
+        // AI-prompt context where preserving published author names matters).
+        var topAuthors = await db.WorkAuthors
+            .GroupBy(wa => wa.Author.Name)
             .Select(g => new
             {
                 Author = g.Key,
                 Count = g.Count(),
-                AvgRating = g.SelectMany(w => w.Books).Average(b => (double?)b.Rating) ?? 0.0
+                AvgRating = g.SelectMany(wa => wa.Work.Books).Average(b => (double?)b.Rating) ?? 0.0
             })
             .OrderByDescending(a => a.Count)
             .Take(15)
@@ -223,7 +224,7 @@ Rules:
             .Select(b => new
             {
                 b.Title,
-                Author = string.Join(", ", b.Works.Select(w => w.Author).Distinct()),
+                Author = string.Join(", ", b.Works.SelectMany(w => w.Authors.Select(a => a.Name)).Distinct()),
                 b.Rating
             })
             .ToListAsync(ct);

--- a/BookTracker.Web/Services/WorkAuthorshipFormatter.cs
+++ b/BookTracker.Web/Services/WorkAuthorshipFormatter.cs
@@ -1,0 +1,46 @@
+using BookTracker.Data.Models;
+
+namespace BookTracker.Web.Services;
+
+// Display-string formatter for multi-author Works. Centralised so every
+// read site renders authorship the same way:
+//   1 author:  "Preston"
+//   2 authors: "Preston & Child"
+//   3+:        "Preston, Child, Pendergast"
+//
+// Matches publishing convention — the ampersand for two reads naturally
+// for co-authored books on covers; comma-list for three+ matches what
+// anthology spines do.
+//
+// Sites: BookListViewModel, BookDetailViewModel, AuthorListViewModel,
+// SeriesEditViewModel, ShoppingViewModel, HomeViewModel, the Library
+// list / BookDetail / Shopping Razor surfaces, and the merge dialogs.
+// Anywhere that previously read `work.Author.Name` reads through this
+// helper post-cutover.
+public static class WorkAuthorshipFormatter
+{
+    /// <summary>
+    /// Format an ordered sequence of author names for display.
+    /// Empty input returns "(unknown author)" — defensive; shouldn't happen
+    /// post-cutover because every Work has at least one WorkAuthor row.
+    /// </summary>
+    public static string Display(IEnumerable<string> names)
+    {
+        var list = names?.Where(n => !string.IsNullOrWhiteSpace(n)).ToList() ?? [];
+        return list.Count switch
+        {
+            0 => "(unknown author)",
+            1 => list[0],
+            2 => $"{list[0]} & {list[1]}",
+            _ => string.Join(", ", list),
+        };
+    }
+
+    /// <summary>
+    /// Convenience overload: pull names directly from a Work's WorkAuthors
+    /// collection in Order ascending. Caller is responsible for having
+    /// loaded WorkAuthors + Author.
+    /// </summary>
+    public static string Display(Work work) =>
+        Display(work.WorkAuthors.OrderBy(wa => wa.Order).Select(wa => wa.Author.Name));
+}

--- a/BookTracker.Web/Services/WorkMergeService.cs
+++ b/BookTracker.Web/Services/WorkMergeService.cs
@@ -66,11 +66,21 @@ public class WorkMergeService(IDbContextFactory<BookTrackerDbContext> dbFactory)
 
         if (lower is not null && higher is not null)
         {
-            // Detection already blocks by AuthorId so this is mostly a
-            // defensive check for direct URL hits.
-            var lowerRaw = await db.Works.AsNoTracking().FirstAsync(w => w.Id == lowerId, ct);
-            var higherRaw = await db.Works.AsNoTracking().FirstAsync(w => w.Id == higherId, ct);
-            if (lowerRaw.AuthorId != higherRaw.AuthorId)
+            // Detection already blocks by author set, so this is a defensive
+            // check for direct URL hits. Both Works must credit the same set
+            // of authors (post-PR2 multi-author cutover); a single mismatch
+            // anywhere blocks the merge with the same message as before.
+            var lowerAuthorIds = await db.WorkAuthors
+                .Where(wa => wa.WorkId == lowerId)
+                .Select(wa => wa.AuthorId)
+                .OrderBy(id => id)
+                .ToListAsync(ct);
+            var higherAuthorIds = await db.WorkAuthors
+                .Where(wa => wa.WorkId == higherId)
+                .Select(wa => wa.AuthorId)
+                .OrderBy(id => id)
+                .ToListAsync(ct);
+            if (!lowerAuthorIds.SequenceEqual(higherAuthorIds))
             {
                 incompatibility = "Works belong to different authors. Merge the authors on /duplicates first, then come back.";
             }
@@ -95,17 +105,25 @@ public class WorkMergeService(IDbContextFactory<BookTrackerDbContext> dbFactory)
         var winner = await db.Works
             .Include(w => w.Books)
             .Include(w => w.Genres)
+            .Include(w => w.WorkAuthors)
             .FirstOrDefaultAsync(w => w.Id == winnerId, ct);
         var loser = await db.Works
             .Include(w => w.Books)
             .Include(w => w.Genres)
+            .Include(w => w.WorkAuthors)
             .FirstOrDefaultAsync(w => w.Id == loserId, ct);
         if (winner is null || loser is null)
         {
             return Failure("One or both Works could not be found — they may already have been merged or deleted.");
         }
 
-        if (winner.AuthorId != loser.AuthorId)
+        // Author sets must match — two Works with different authorship can'\''t
+        // be merged into one (the result would conflate distinct creative
+        // credits). User'\''s expected to merge authors first if pen-name aliases
+        // are involved.
+        var winnerAuthorIds = winner.WorkAuthors.Select(wa => wa.AuthorId).OrderBy(id => id).ToList();
+        var loserAuthorIds = loser.WorkAuthors.Select(wa => wa.AuthorId).OrderBy(id => id).ToList();
+        if (!winnerAuthorIds.SequenceEqual(loserAuthorIds))
         {
             return Failure("Works belong to different authors. Merge the authors first on /duplicates.");
         }
@@ -195,7 +213,7 @@ public class WorkMergeService(IDbContextFactory<BookTrackerDbContext> dbFactory)
     private static async Task<WorkMergeDetail?> LoadDetailAsync(BookTrackerDbContext db, int id, CancellationToken ct)
     {
         var work = await db.Works
-            .Include(w => w.Author)
+            .Include(w => w.WorkAuthors).ThenInclude(wa => wa.Author)
             .Include(w => w.Series)
             .Include(w => w.Genres)
             .FirstOrDefaultAsync(w => w.Id == id, ct);
@@ -224,7 +242,7 @@ public class WorkMergeService(IDbContextFactory<BookTrackerDbContext> dbFactory)
 
         return new WorkMergeDetail(
             work.Id, work.Title, work.Subtitle,
-            work.Author.Name,
+            WorkAuthorshipFormatter.Display(work),
             work.FirstPublishedDate?.Year,
             work.Series?.Name,
             work.SeriesOrder,

--- a/BookTracker.Web/Services/WorkSearchService.cs
+++ b/BookTracker.Web/Services/WorkSearchService.cs
@@ -55,7 +55,10 @@ public class WorkSearchService(IDbContextFactory<BookTrackerDbContext> dbFactory
                 w.Id,
                 w.Title,
                 w.Subtitle,
-                AuthorName = w.Author.Name,
+                // Lead-author name only — the search dropdown row is tight, so
+                // co-authors are elided here. The full multi-author display
+                // appears once the user picks the work and lands on BookDetail.
+                AuthorName = w.WorkAuthors.OrderBy(wa => wa.Order).Select(wa => wa.Author.Name).FirstOrDefault() ?? "",
                 BookCount = w.Books.Count,
                 TitleLower = w.Title.ToLower()
             })

--- a/BookTracker.Web/ViewModels/AIAssistantViewModel.cs
+++ b/BookTracker.Web/ViewModels/AIAssistantViewModel.cs
@@ -35,7 +35,7 @@ public class AIAssistantViewModel(
         // is tracked in TODO.md.
         BooksNeedingGenres = await db.Books
             .Include(b => b.Works).ThenInclude(w => w.Genres)
-            .Include(b => b.Works).ThenInclude(w => w.Author)
+            .Include(b => b.Works).ThenInclude(w => w.WorkAuthors).ThenInclude(wa => wa.Author)
             .OrderBy(b => b.Works.SelectMany(w => w.Genres).Count())
             .ThenBy(b => b.Title)
             .Take(50)
@@ -43,7 +43,10 @@ public class AIAssistantViewModel(
                 b.Id,
                 b.Title,
                 b.Works.FirstOrDefault()!.Subtitle,
-                b.Works.FirstOrDefault()!.Author.Name,
+                // Lead author name only — the AI prompt context is per-Work, and
+                // the genre suggestion service still takes a single author string.
+                // Multi-author surfaces use the formatter; this row is internal.
+                b.Works.FirstOrDefault()!.WorkAuthors.OrderBy(wa => wa.Order).Select(wa => wa.Author.Name).FirstOrDefault() ?? "",
                 b.Works.SelectMany(w => w.Genres).Select(g => g.Name).Distinct().ToList()))
             .ToListAsync();
 
@@ -165,12 +168,12 @@ public class AIAssistantViewModel(
         // Try to set the author if all matched books' primary works share one
         var matchedBooks = await db.Books
             .Include(b => b.Works).ThenInclude(w => w.Series)
-            .Include(b => b.Works).ThenInclude(w => w.Author)
+            .Include(b => b.Works).ThenInclude(w => w.WorkAuthors).ThenInclude(wa => wa.Author)
             .Where(b => grouping.BookTitles.Contains(b.Title))
             .ToListAsync();
 
         var authorNames = matchedBooks
-            .SelectMany(b => b.Works.Select(w => w.Author.Name))
+            .SelectMany(b => b.Works.SelectMany(w => w.WorkAuthors.OrderBy(wa => wa.Order).Select(wa => wa.Author.Name)))
             .Distinct()
             .ToList();
         if (authorNames.Count == 1)

--- a/BookTracker.Web/ViewModels/AuthorListViewModel.cs
+++ b/BookTracker.Web/ViewModels/AuthorListViewModel.cs
@@ -101,10 +101,10 @@ public class AuthorListViewModel(IDbContextFactory<BookTrackerDbContext> dbFacto
         }
 
         var works = await db.Works
-            .Include(w => w.Author)
+            .Include(w => w.WorkAuthors).ThenInclude(wa => wa.Author)
             .Include(w => w.Books)
             .Include(w => w.Series)
-            .Where(w => ids.Contains(w.AuthorId))
+            .Where(w => w.WorkAuthors.Any(wa => ids.Contains(wa.AuthorId)))
             .OrderBy(w => w.Title)
             .ToListAsync();
 
@@ -114,8 +114,15 @@ public class AuthorListViewModel(IDbContextFactory<BookTrackerDbContext> dbFacto
             w.Subtitle,
             // Flag which alias a work was written as, but only on canonical
             // rows (on an alias row the author is always itself). For single-
-            // identity canonicals this is always null.
-            isCanonical && w.AuthorId != authorId ? w.Author.Name : null,
+            // identity canonicals this is always null. Picks the *lead*
+            // author for the alias label — co-authored works under a canonical
+            // get labelled by their lead's pen name, which is how booksellers
+            // typically attribute them.
+            isCanonical
+                ? w.WorkAuthors.OrderBy(wa => wa.Order).Select(wa => wa.Author).FirstOrDefault() is { } leadAuthor && leadAuthor.Id != authorId
+                    ? leadAuthor.Name
+                    : null
+                : null,
             PartialDateParser.Format(w.FirstPublishedDate, w.FirstPublishedDatePrecision),
             w.Series?.Name,
             w.Series?.Type,

--- a/BookTracker.Web/ViewModels/BookAddViewModel.cs
+++ b/BookTracker.Web/ViewModels/BookAddViewModel.cs
@@ -100,7 +100,7 @@ public class BookAddViewModel(
             {
                 var existing = await db.Editions
                     .Include(e => e.Book)
-                        .ThenInclude(b => b.Works).ThenInclude(w => w.Author)
+                        .ThenInclude(b => b.Works).ThenInclude(w => w.WorkAuthors).ThenInclude(wa => wa.Author)
                     .Include(e => e.Copies)
                     .FirstOrDefaultAsync(e => e.Isbn == cleanIsbn);
 
@@ -110,7 +110,9 @@ public class BookAddViewModel(
                         existing.Book.Id,
                         existing.Id,
                         existing.Book.Title,
-                        string.Join(", ", existing.Book.Works.Select(w => w.Author.Name).Distinct()),
+                        string.Join(", ", existing.Book.Works
+                            .SelectMany(w => w.WorkAuthors.OrderBy(wa => wa.Order).Select(wa => wa.Author.Name))
+                            .Distinct()),
                         existing.Copies.Count);
                     LookupMessage = null;
                     return;

--- a/BookTracker.Web/ViewModels/BookDetailViewModel.cs
+++ b/BookTracker.Web/ViewModels/BookDetailViewModel.cs
@@ -45,7 +45,7 @@ public class BookDetailViewModel(IDbContextFactory<BookTrackerDbContext> dbFacto
             .Include(b => b.Editions)
                 .ThenInclude(e => e.Publisher)
             .Include(b => b.Works)
-                .ThenInclude(w => w.Author)
+                .ThenInclude(w => w.WorkAuthors).ThenInclude(wa => wa.Author)
             .Include(b => b.Works)
                 .ThenInclude(w => w.Genres)
             .Include(b => b.Works)
@@ -232,8 +232,12 @@ public class BookDetailViewModel(IDbContextFactory<BookTrackerDbContext> dbFacto
         w.Id,
         w.Title,
         w.Subtitle,
-        w.Author.Name,
-        w.AuthorId,
+        // AuthorName carries the formatted multi-author display ("Preston & Child")
+        // post-PR2; the field name stays so Razor consumers don't have to change.
+        WorkAuthorshipFormatter.Display(w),
+        // LeadAuthorId is the first WorkAuthor entry's Author — used by the
+        // BookDetail '+author' link to deep-link into the /authors page.
+        w.WorkAuthors.OrderBy(wa => wa.Order).Select(wa => wa.AuthorId).FirstOrDefault(),
         PartialDateParser.Format(w.FirstPublishedDate, w.FirstPublishedDatePrecision),
         w.Genres.OrderBy(g => g.Name).Select(g => g.Name).ToList(),
         w.Series is null ? null : new SeriesInfo(w.Series.Id, w.Series.Name, w.Series.Type, w.SeriesOrder));
@@ -269,8 +273,10 @@ public class BookDetailViewModel(IDbContextFactory<BookTrackerDbContext> dbFacto
         int Id,
         string Title,
         string? Subtitle,
+        /// <summary>Formatted display string ("Preston" / "Preston &amp; Child" / "Preston, Child, Pendergast").</summary>
         string AuthorName,
-        int AuthorId,
+        /// <summary>The lead author'\''s Id — used for /authors/{id} deep-links from the BookDetail page.</summary>
+        int LeadAuthorId,
         string FirstPublishedDisplay,
         IReadOnlyList<string> Genres,
         SeriesInfo? Series);

--- a/BookTracker.Web/ViewModels/BookEditViewModel.cs
+++ b/BookTracker.Web/ViewModels/BookEditViewModel.cs
@@ -76,8 +76,6 @@ public class BookEditViewModel(
             .Include(b => b.Works)
                 .ThenInclude(w => w.Genres)
             .Include(b => b.Works)
-                .ThenInclude(w => w.Author)
-            .Include(b => b.Works)
                 .ThenInclude(w => w.WorkAuthors)
                     .ThenInclude(wa => wa.Author)
             .FirstOrDefaultAsync(b => b.Id == bookId);
@@ -103,12 +101,12 @@ public class BookEditViewModel(
         {
             PrimaryWorkId = primary.Id;
             // Hydrate the chip list from WorkAuthors (Order ascending so the
-            // lead is first). Fallback to the legacy single Author if for some
-            // reason the join row is missing — shouldn'\''t happen post-backfill
-            // but defensive against corrupted state.
-            var authorNames = primary.WorkAuthors.Count > 0
-                ? primary.WorkAuthors.OrderBy(wa => wa.Order).Select(wa => wa.Author.Name).ToList()
-                : [primary.Author.Name];
+            // lead is first). Every Work has at least one WorkAuthor row
+            // post-PR1 backfill, so no legacy fallback needed post-PR2.
+            var authorNames = primary.WorkAuthors
+                .OrderBy(wa => wa.Order)
+                .Select(wa => wa.Author.Name)
+                .ToList();
 
             PrimaryWorkInput = new WorkFormViewModel.WorkFormInput
             {
@@ -128,7 +126,7 @@ public class BookEditViewModel(
         }
 
         OtherWorks = book.Works.Skip(1)
-            .Select(w => new WorkSummary(w.Id, w.Title, w.Author.Name, w.Genres.Count))
+            .Select(w => new WorkSummary(w.Id, w.Title, WorkAuthorshipFormatter.Display(w), w.Genres.Count))
             .ToList();
 
         AssignedTags = book.Tags.Select(t => new TagItem(t.Id, t.Name)).ToList();
@@ -407,8 +405,8 @@ public class BookEditViewModel(
         var work = new Work
         {
             Title = NewWorkTitle.Trim(),
-            Author = author,
         };
+        AuthorResolver.AssignAuthors(work, [author]);
         book.Works.Add(work);
         await db.SaveChangesAsync();
 
@@ -434,7 +432,10 @@ public class BookEditViewModel(
     {
         await using var db = await dbFactory.CreateDbContextAsync();
         var book = await db.Books.Include(b => b.Works).FirstOrDefaultAsync(b => b.Id == bookId);
-        var work = await db.Works.Include(w => w.Author).Include(w => w.Genres).FirstOrDefaultAsync(w => w.Id == workId);
+        var work = await db.Works
+            .Include(w => w.WorkAuthors).ThenInclude(wa => wa.Author)
+            .Include(w => w.Genres)
+            .FirstOrDefaultAsync(w => w.Id == workId);
         if (book is null || work is null) return;
 
         // Defensive: exclude-by-bookId already filters attached Works out of
@@ -445,7 +446,7 @@ public class BookEditViewModel(
         book.Works.Add(work);
         await db.SaveChangesAsync();
 
-        OtherWorks.Add(new WorkSummary(work.Id, work.Title, work.Author.Name, work.Genres.Count));
+        OtherWorks.Add(new WorkSummary(work.Id, work.Title, WorkAuthorshipFormatter.Display(work), work.Genres.Count));
         AttachWorkQuery = "";
         AttachWorkResults = [];
         SuccessMessage = $"Attached \"{work.Title}\" to this book.";
@@ -488,7 +489,6 @@ public class BookEditViewModel(
             var book = await db.Books
                 .Include(b => b.Tags)
                 .Include(b => b.Works).ThenInclude(w => w.Genres)
-                .Include(b => b.Works).ThenInclude(w => w.Author)
                 .Include(b => b.Works).ThenInclude(w => w.WorkAuthors).ThenInclude(wa => wa.Author)
                 .FirstOrDefaultAsync(b => b.Id == bookId);
 

--- a/BookTracker.Web/ViewModels/BookListViewModel.cs
+++ b/BookTracker.Web/ViewModels/BookListViewModel.cs
@@ -179,9 +179,9 @@ public class BookListViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
         return SelectedGroupBy switch
         {
             // Author key is the CANONICAL author id — match any Work whose
-            // Author is the canonical OR an alias of it.
+            // Authors include the canonical OR an alias of it.
             LibraryGroupBy.Author => q.Where(b => b.Works.Any(w =>
-                w.Author.Id == id || w.Author.CanonicalAuthorId == id)),
+                w.Authors.Any(a => a.Id == id || a.CanonicalAuthorId == id))),
             LibraryGroupBy.Genre => q.Where(b => b.Works.Any(w => w.Genres.Any(g => g.Id == id))),
             LibraryGroupBy.Collection => q.Where(b => b.Works.Any(w => w.SeriesId == id)),
             _ => q,
@@ -191,13 +191,15 @@ public class BookListViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
     private async Task<List<GroupRow>> GroupByAuthorAsync(BookTrackerDbContext db, IQueryable<Book> filtered)
     {
         // Roll up by canonical author id (CanonicalAuthorId ?? Id) so a
-        // Bachman title appears under King.
+        // Bachman title appears under King. Co-authored works expand into
+        // one row per credited author — Preston + Child appears under both
+        // canonicals (post-PR2 behaviour change vs the lead-only legacy).
         var raw = await filtered
-            .SelectMany(b => b.Works.Select(w => new
+            .SelectMany(b => b.Works.SelectMany(w => w.Authors.Select(a => new
             {
                 BookId = b.Id,
-                CanonicalId = w.Author.CanonicalAuthorId ?? w.Author.Id,
-            }))
+                CanonicalId = a.CanonicalAuthorId ?? a.Id,
+            })))
             .Distinct() // Avoid double-counting a book whose two Works share a canonical author.
             .GroupBy(x => x.CanonicalId)
             .Select(g => new { CanonicalId = g.Key, Count = g.Count() })
@@ -285,7 +287,7 @@ public class BookListViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
     private IQueryable<Book> BookQueryWithIncludes(BookTrackerDbContext db) => db.Books
         .Include(b => b.Tags)
         .Include(b => b.Works).ThenInclude(w => w.Genres)
-        .Include(b => b.Works).ThenInclude(w => w.Author);
+        .Include(b => b.Works).ThenInclude(w => w.WorkAuthors).ThenInclude(wa => wa.Author);
 
     private IQueryable<Book> ApplyFilters(IQueryable<Book> query)
     {
@@ -294,7 +296,7 @@ public class BookListViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
             var term = SearchTerm.Trim();
             query = query.Where(b =>
                 b.Title.Contains(term) ||
-                b.Works.Any(w => w.Title.Contains(term) || w.Author.Name.Contains(term)));
+                b.Works.Any(w => w.Title.Contains(term) || w.Authors.Any(a => a.Name.Contains(term))));
         }
 
         if (!string.IsNullOrEmpty(SelectedCategory) && Enum.TryParse<BookCategory>(SelectedCategory, out var cat))
@@ -316,8 +318,9 @@ public class BookListViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
         {
             var author = SelectedAuthor.Trim();
             query = query.Where(b => b.Works.Any(w =>
-                w.Author.Name == author ||
-                (w.Author.CanonicalAuthor != null && w.Author.CanonicalAuthor.Name == author)));
+                w.Authors.Any(a =>
+                    a.Name == author ||
+                    (a.CanonicalAuthor != null && a.CanonicalAuthor.Name == author))));
         }
 
         return query;
@@ -327,7 +330,12 @@ public class BookListViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
         b.Id,
         b.Title,
         b.Works.FirstOrDefault()?.Subtitle,
-        string.Join(", ", b.Works.Select(w => w.Author.Name).Distinct()),
+        // Comma-join unique author names across all Works on this Book. For a
+        // single-Work co-authored book this renders "Preston, Child" rather
+        // than the prettier "Preston & Child" — list views stay uniform; the
+        // " & " formatter is reserved for single-book / single-Work surfaces
+        // (BookDetail, dialogs).
+        string.Join(", ", b.Works.SelectMany(w => w.WorkAuthors.OrderBy(wa => wa.Order).Select(wa => wa.Author.Name)).Distinct()),
         b.DefaultCoverArtUrl,
         b.Status,
         b.Rating,

--- a/BookTracker.Web/ViewModels/HomeViewModel.cs
+++ b/BookTracker.Web/ViewModels/HomeViewModel.cs
@@ -24,12 +24,13 @@ public class HomeViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory)
             .Where(a => a.CanonicalAuthorId == null)
             .CountAsync();
 
-        // Group works by their author's canonical id (or own id if canonical),
-        // then look up the canonical name for display. A compendium contributes
-        // one tally per contained Work to its author's count.
-        var authorTotals = await db.Works
-            .Include(w => w.Author).ThenInclude(a => a.CanonicalAuthor)
-            .GroupBy(w => w.Author.CanonicalAuthorId ?? w.Author.Id)
+        // Group authorship records by the canonical author id (or own id if
+        // canonical), then look up the canonical name for display. Each
+        // WorkAuthor row contributes one tally — co-authored works contribute
+        // to BOTH credited authors (post-PR2 behaviour change vs the lead-only
+        // legacy where Preston + Child only counted toward the lead).
+        var authorTotals = await db.WorkAuthors
+            .GroupBy(wa => wa.Author.CanonicalAuthorId ?? wa.AuthorId)
             .Select(g => new { CanonicalId = g.Key, Count = g.Count() })
             .OrderByDescending(x => x.Count)
             .Take(10)

--- a/BookTracker.Web/ViewModels/SeriesEditViewModel.cs
+++ b/BookTracker.Web/ViewModels/SeriesEditViewModel.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel.DataAnnotations;
 using BookTracker.Data;
 using BookTracker.Data.Models;
+using BookTracker.Web.Services;
 using Microsoft.EntityFrameworkCore;
 
 namespace BookTracker.Web.ViewModels;
@@ -38,7 +39,7 @@ public class SeriesEditViewModel(IDbContextFactory<BookTrackerDbContext> dbFacto
 
         var series = await db.Series
             .Include(s => s.Works).ThenInclude(w => w.Books)
-            .Include(s => s.Works).ThenInclude(w => w.Author)
+            .Include(s => s.Works).ThenInclude(w => w.WorkAuthors).ThenInclude(wa => wa.Author)
             .FirstOrDefaultAsync(s => s.Id == seriesId);
 
         if (series is null)
@@ -62,7 +63,7 @@ public class SeriesEditViewModel(IDbContextFactory<BookTrackerDbContext> dbFacto
             .Select(w => new SeriesWorkRow(
                 w.Id,
                 w.Title,
-                w.Author.Name,
+                WorkAuthorshipFormatter.Display(w),
                 w.SeriesOrder,
                 w.Books.Select(b => new ContainingBook(b.Id, b.Title)).ToList()))
             .ToList();
@@ -146,10 +147,14 @@ public class SeriesEditViewModel(IDbContextFactory<BookTrackerDbContext> dbFacto
         await using var db = await dbFactory.CreateDbContextAsync();
         WorkSearchResults = await db.Works
             .Where(w => !currentWorkIds.Contains(w.Id))
-            .Where(w => w.Title.Contains(term) || w.Author.Name.Contains(term))
+            .Where(w => w.Title.Contains(term) || w.Authors.Any(a => a.Name.Contains(term)))
             .OrderBy(w => w.Title)
             .Take(10)
-            .Select(w => new WorkSearchResult(w.Id, w.Title, w.Author.Name, w.SeriesId))
+            .Select(w => new WorkSearchResult(
+                w.Id,
+                w.Title,
+                w.WorkAuthors.OrderBy(wa => wa.Order).Select(wa => wa.Author.Name).FirstOrDefault() ?? "",
+                w.SeriesId))
             .ToListAsync();
     }
 
@@ -158,7 +163,7 @@ public class SeriesEditViewModel(IDbContextFactory<BookTrackerDbContext> dbFacto
         await using var db = await dbFactory.CreateDbContextAsync();
         var work = await db.Works
             .Include(w => w.Books)
-            .Include(w => w.Author)
+            .Include(w => w.WorkAuthors).ThenInclude(wa => wa.Author)
             .FirstOrDefaultAsync(w => w.Id == workId);
         if (work is null) return;
 
@@ -171,7 +176,7 @@ public class SeriesEditViewModel(IDbContextFactory<BookTrackerDbContext> dbFacto
         Works.Add(new SeriesWorkRow(
             work.Id,
             work.Title,
-            work.Author.Name,
+            WorkAuthorshipFormatter.Display(work),
             nextOrder,
             work.Books.Select(b => new ContainingBook(b.Id, b.Title)).ToList()));
         WorkSearchResults.RemoveAll(r => r.Id == workId);

--- a/BookTracker.Web/ViewModels/ShoppingViewModel.cs
+++ b/BookTracker.Web/ViewModels/ShoppingViewModel.cs
@@ -86,7 +86,7 @@ public class ShoppingViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
                 .Include(e => e.Book)
                     .ThenInclude(b => b.Works).ThenInclude(w => w.Series)
                 .Include(e => e.Book)
-                    .ThenInclude(b => b.Works).ThenInclude(w => w.Author)
+                    .ThenInclude(b => b.Works).ThenInclude(w => w.WorkAuthors).ThenInclude(wa => wa.Author)
                 .Include(e => e.Copies)
                 .Where(e => e.Isbn == isbn)
                 .ToListAsync();
@@ -138,8 +138,8 @@ public class ShoppingViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
                 .Include(b => b.Editions)
                     .ThenInclude(e => e.Copies)
                 .Include(b => b.Works).ThenInclude(w => w.Series)
-                .Include(b => b.Works).ThenInclude(w => w.Author)
-                .Where(b => b.Title.Contains(term) || b.Works.Any(w => w.Title.Contains(term) || w.Author.Name.Contains(term)))
+                .Include(b => b.Works).ThenInclude(w => w.WorkAuthors).ThenInclude(wa => wa.Author)
+                .Where(b => b.Title.Contains(term) || b.Works.Any(w => w.Title.Contains(term) || w.Authors.Any(a => a.Name.Contains(term))))
                 .OrderBy(b => b.Title)
                 .Take(10)
                 .ToListAsync();
@@ -196,7 +196,7 @@ public class ShoppingViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
             .Include(b => b.Editions)
                 .ThenInclude(e => e.Copies)
             .Include(b => b.Works).ThenInclude(w => w.Series)
-            .Include(b => b.Works).ThenInclude(w => w.Author)
+            .Include(b => b.Works).ThenInclude(w => w.WorkAuthors).ThenInclude(wa => wa.Author)
             .FirstOrDefaultAsync(b => b.Id == bookId);
 
         if (book is null) return;
@@ -221,11 +221,11 @@ public class ShoppingViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
     private static string PrimaryAuthor(Book book)
     {
         var names = book.Works
-            .Select(w => string.IsNullOrWhiteSpace(w.Author?.Name) ? null : w.Author!.Name)
-            .Where(n => n is not null)
+            .SelectMany(w => w.WorkAuthors.OrderBy(wa => wa.Order).Select(wa => wa.Author?.Name))
+            .Where(n => !string.IsNullOrWhiteSpace(n))
             .Distinct()
             .ToList();
-        return names.Count > 0 ? string.Join(", ", names) : "(unknown)";
+        return names.Count > 0 ? string.Join(", ", names!) : "(unknown)";
     }
 
     private static async Task<SeriesInfo?> GetSeriesInfoAsync(BookTrackerDbContext db, Book book)
@@ -340,12 +340,14 @@ public class ShoppingViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
         }
 
         var author = await AuthorResolver.FindOrCreateAsync(item.Author, db);
+        var work = new Work { Title = item.Title };
+        AuthorResolver.AssignAuthors(work, [author]);
         var book = new Book
         {
             Title = item.Title,
             Tags = [followUpTag],
             Editions = [],
-            Works = [new Work { Title = item.Title, Author = author }]
+            Works = [work]
         };
 
         if (!string.IsNullOrWhiteSpace(item.Isbn))

--- a/BookTracker.Web/ViewModels/WorkEditDialogViewModel.cs
+++ b/BookTracker.Web/ViewModels/WorkEditDialogViewModel.cs
@@ -33,7 +33,6 @@ public class WorkEditDialogViewModel(IDbContextFactory<BookTrackerDbContext> dbF
 
         await using var db = await dbFactory.CreateDbContextAsync();
         var work = await db.Works
-            .Include(w => w.Author)
             .Include(w => w.WorkAuthors).ThenInclude(wa => wa.Author)
             .Include(w => w.Genres)
             .FirstOrDefaultAsync(w => w.Id == workId);
@@ -42,11 +41,11 @@ public class WorkEditDialogViewModel(IDbContextFactory<BookTrackerDbContext> dbF
         Title = work.Title;
         Subtitle = work.Subtitle;
         // Order ascending so the lead author shows first in the chip list.
-        // Fallback to the legacy single Author if WorkAuthors is empty —
-        // shouldn'\''t happen post-backfill but defensive.
-        AuthorNames = work.WorkAuthors.Count > 0
-            ? work.WorkAuthors.OrderBy(wa => wa.Order).Select(wa => wa.Author.Name).ToList()
-            : [work.Author.Name];
+        // Every Work has at least one WorkAuthor post-PR1 backfill.
+        AuthorNames = work.WorkAuthors
+            .OrderBy(wa => wa.Order)
+            .Select(wa => wa.Author.Name)
+            .ToList();
         FirstPublishedDate = PartialDateParser.Format(work.FirstPublishedDate, work.FirstPublishedDatePrecision);
         SelectedSeriesId = work.SeriesId;
         SeriesOrder = work.SeriesOrder;
@@ -84,7 +83,6 @@ public class WorkEditDialogViewModel(IDbContextFactory<BookTrackerDbContext> dbF
 
         await using var db = await dbFactory.CreateDbContextAsync();
         var work = await db.Works
-            .Include(w => w.Author)
             .Include(w => w.WorkAuthors).ThenInclude(wa => wa.Author)
             .Include(w => w.Genres)
             .FirstOrDefaultAsync(w => w.Id == WorkId);


### PR DESCRIPTION
Closes the multi-author cutover. Schema: drop Work.AuthorId column and the Work.Author single-FK navigation. Configure Work ↔ Author as M:N skip-navigation through WorkAuthor in DbContext (Work.Authors and Author.Works are the skip-navs; Work.WorkAuthors and Author.WorkAuthors remain as the explicit join collections, useful where Order matters or for direct iteration).

Migration: DropWorkAuthorId removes the FK + index + column. Down() reseeds AuthorId from WorkAuthors (lead author by Order ascending) before restoring the FK so emergency rollback after PR2 ships doesn't hit FK violations on the recreated column.

Reads cut over everywhere — ~25 files touched:
- ViewModels: Book{Add,Edit,Detail,List}ViewModel, AuthorListViewModel, SeriesEditViewModel, ShoppingViewModel, HomeViewModel, AIAssistantViewModel, BulkAddViewModel, WorkEditDialogViewModel.
- Services: AuthorMergeService, WorkMergeService, BookMergeService, DuplicateDetectionService, AIAssistantService, AzureOpenAIAssistantService, MicrosoftFoundryAIAssistantService, SeriesMatchService, WorkSearchService, SharedParsers, AuthorResolver.
- New: WorkAuthorshipFormatter — single source of truth for display strings (1 author = "Preston", 2 = "Preston & Child", 3+ = "Preston, Child, Pendergast"). Library list and bulk projections still use comma-join across all Works' authors for uniform table cells; per-Work surfaces (BookDetail, dialogs, merge UIs) use the formatter directly.

Behaviour change worth flagging: the /authors page now lists Works where the author is a co-author, not just the lead. Bachman + King and Preston + Child both pivot under either credited canonical. HomeViewModel.TopAuthors counts each WorkAuthor row independently — co-authored Works contribute to both authors' tallies (vs lead-only pre-PR2).

Author merge gains a re-shape: with composite (WorkId, AuthorId) PKs in WorkAuthor, the column can't be UPDATEd in place. AuthorMergeService now deletes the loser's WorkAuthor rows and inserts winner-equivalents, dropping the row when winner is already credited on the same Work to avoid a PK collision. Work merge equality check upgraded from single-author equality to author-set equality (works with mismatched author sets are blocked from merging — same UX, just per-set instead of per-FK).

Test fixtures updated: ~14 test files. Object initializer Author = X patterns rewritten as WorkAuthors = [new WorkAuthor { Author = X, Order = 0 }]; assertions on .Author.Name shifted to .WorkAuthors.OrderBy(wa => wa.Order).First().Author.Name. All 322 tests pass.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
