### PR TITLE
chore(memory): capture encoded-PowerShell-args footgun

### DIFF
--- a/.claude-memory/MEMORY.md
+++ b/.claude-memory/MEMORY.md
@@ -5,6 +5,7 @@
 - [Delete merged branches](feedback_delete_merged_branch.md) — delete local feature branch after pulling the merge into main.
 - [Branch from main](feedback_branch_from_main.md) — always start a new branch from a fresh `main` pull; never from a sibling branch (squash-merge would bundle content).
 - [Use PowerShell tool](feedback_use_powershell.md) — default shell for this project is PowerShell 7, not Bash; CLAUDE.md mandates Windows shell and Drew works in PowerShell.
+- [Avoid encoded PowerShell args](feedback_avoid_encoded_powershell.md) — long PS here-strings get base64-encoded by the tool layer and trigger Drew's security scanner. For multi-line commit messages, prefer Bash heredoc or temp file + `git commit -F`.
 - [Ask about mobile priority](feedback_mobile_priority.md) — when planning features, ask if mobile+web or web-only.
 - [Feature planning conventions](feedback_planning_conventions.md) — always plan first, PR breakdown for medium+, flag 5+ file changes as complex.
 - [Testing conventions](feedback_testing_conventions.md) — minimal tests for new logic to prevent regression; skip for pure markup.

--- a/.claude-memory/feedback_avoid_encoded_powershell.md
+++ b/.claude-memory/feedback_avoid_encoded_powershell.md
@@ -1,0 +1,23 @@
+---
+name: Avoid encoded PowerShell command-line args
+description: PowerShell here-strings and other long inline args get serialised as `-EncodedCommand <base64>` by the tool layer, which Drew's security tooling flags as a malware indicator. Prefer file-based or short inline alternatives for long commands (especially git commit messages).
+type: feedback
+originSessionId: 21e97fa1-cba4-4b67-9d43-dc109098d6b2
+---
+Long inline arguments to PowerShell — multi-line here-strings (`@'...'@`), big multi-line `-Command` payloads, or `git commit -m` with a long here-string body — are serialised by the tool layer as `powershell.exe -EncodedCommand <base64-blob>`. Security tooling on Windows flags base64 command-line args as a malware indicator (legitimate use; it's a common obfuscation pattern). Drew has surfaced this triggering during a session.
+
+**Why:** the encoded-command form is the standard way long PowerShell args get passed through tool boundaries safely; it's not malicious, but it's indistinguishable from malware on the wire to a scanner. The flag is reliable, not a false positive in the strict sense — the encoded form is what the scanner is configured to flag.
+
+**How to apply:** for any command that would otherwise need a multi-line here-string or a long inline argument, in priority order:
+
+- **Temp file (the reliable default).** Write the message to a file via the Write tool, then run a short `git commit -F path/to/file` via either shell, then delete the file. The long string never crosses any shell command line, so no encoded-command path can be triggered. Worked first try on this project.
+- **Short inline `-m`.** Keep commit messages to a single line short enough that PowerShell can pass them as a normal arg. Reasonable for tight bug fixes; not for substantial features.
+- **Bash heredoc — does NOT work for git on Windows.** `git commit -F /dev/stdin <<'EOF' ... EOF` fails with `fatal: could not read log file '/proc/self/fd/0'` because Git for Windows is a Windows-native binary that can't open POSIX paths. Don't reach for this; jump straight to the temp-file approach. (For non-git commands that read stdin natively, Bash heredoc may still work — but git is the common case where this comes up, and it doesn't.)
+
+**Specifically NOT:**
+
+- `git commit -m @'multi-line here-string'@` via PowerShell — this is the exact pattern that triggered the flag.
+- Long multi-line PR body text inline to `gh pr create` via PowerShell — same shape, same problem. Use `--body-file <path>` instead.
+- Long inline scripts via `powershell -Command "..."` with embedded newlines.
+
+Temp-file is the durable answer on this project even though the standing convention is PowerShell-first per `feedback_use_powershell.md`. The two rules complement: PowerShell for everyday short operations, temp-file commit-message workflow for anything multi-line. The temp file lives one command (Write tool); the next command uses it; the third deletes it. No long string ever crosses a process boundary in serialised form.


### PR DESCRIPTION
PowerShell here-strings (and other long inline args) get serialised by the tool layer as `powershell.exe -EncodedCommand <base64-blob>`, which Drew's security tooling correctly flags as a malware-shaped pattern. The new feedback memory captures the lesson: temp-file is the reliable default for multi-line git commit messages, short inline -m for one-liners, and Bash heredoc with /dev/stdin does NOT work for git on Windows (Git for Windows is a native binary that can't open POSIX paths) so don't reach for it.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
