### PR TITLE
feat(observability): wire App Insights SDK + per-user telemetry enrichment (PR1 of #8)

### DIFF
--- a/BookTracker.Tests/Telemetry/UserTelemetryInitializerTests.cs
+++ b/BookTracker.Tests/Telemetry/UserTelemetryInitializerTests.cs
@@ -1,0 +1,60 @@
+using System.Security.Claims;
+using BookTracker.Web.Telemetry;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.AspNetCore.Http;
+using NSubstitute;
+
+namespace BookTracker.Tests.Telemetry;
+
+public class UserTelemetryInitializerTests
+{
+    [Fact]
+    public void Initialize_WithAuthenticatedUser_SetsAuthenticatedUserId()
+    {
+        var accessor = Substitute.For<IHttpContextAccessor>();
+        var ctx = new DefaultHttpContext
+        {
+            User = new ClaimsPrincipal(new ClaimsIdentity(
+                [new Claim(ClaimTypes.Name, "drew@silly.ninja")],
+                authenticationType: "TestAuth"))
+        };
+        accessor.HttpContext.Returns(ctx);
+
+        var initializer = new UserTelemetryInitializer(accessor);
+        var telemetry = new TraceTelemetry();
+        initializer.Initialize(telemetry);
+
+        Assert.Equal("drew@silly.ninja", telemetry.Context.User.AuthenticatedUserId);
+    }
+
+    [Fact]
+    public void Initialize_WithAnonymousUser_LeavesAuthenticatedUserIdNull()
+    {
+        var accessor = Substitute.For<IHttpContextAccessor>();
+        // Anonymous: no authentication type → Identity.Name is null.
+        accessor.HttpContext.Returns(new DefaultHttpContext());
+
+        var initializer = new UserTelemetryInitializer(accessor);
+        var telemetry = new TraceTelemetry();
+        initializer.Initialize(telemetry);
+
+        Assert.Null(telemetry.Context.User.AuthenticatedUserId);
+    }
+
+    [Fact]
+    public void Initialize_WithNullHttpContext_DoesNotThrow()
+    {
+        // Background services / startup tasks invoke logging outside any
+        // request — HttpContextAccessor returns null then. The initializer
+        // must no-op rather than NRE the whole request pipeline.
+        var accessor = Substitute.For<IHttpContextAccessor>();
+        accessor.HttpContext.Returns((HttpContext?)null);
+
+        var initializer = new UserTelemetryInitializer(accessor);
+        var telemetry = new TraceTelemetry();
+        var ex = Record.Exception(() => initializer.Initialize(telemetry));
+
+        Assert.Null(ex);
+        Assert.Null(telemetry.Context.User.AuthenticatedUserId);
+    }
+}

--- a/BookTracker.Web/BookTracker.Web.csproj
+++ b/BookTracker.Web/BookTracker.Web.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Anthropic.SDK" Version="5.10.0" />
     <PackageReference Include="Azure.AI.OpenAI" Version="2.1.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/BookTracker.Web/Program.cs
+++ b/BookTracker.Web/Program.cs
@@ -1,12 +1,24 @@
 using BookTracker.Data;
 using BookTracker.Web.Components;
 using BookTracker.Web.Services;
+using BookTracker.Web.Telemetry;
 using BookTracker.Web.ViewModels;
+using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using MudBlazor.Services;
 
 var builder = WebApplication.CreateBuilder(args);
+
+// Application Insights: explicit SDK registration (the App Service codeless
+// attach gives baseline request/dependency telemetry but NOT structured
+// ILogger output — message-template properties like {Isbn} only become
+// custom dimensions once the SDK is wired here). Connection string
+// resolves from APPLICATIONINSIGHTS_CONNECTION_STRING (set in
+// app-config.bicep).
+builder.Services.AddApplicationInsightsTelemetry();
+builder.Services.AddHttpContextAccessor();
+builder.Services.AddSingleton<ITelemetryInitializer, UserTelemetryInitializer>();
 
 // TODO: evaluate a Blazor-native component library (MudBlazor, Radzen, FluentUI)
 // instead of hand-rolling Bootstrap markup in every component. The current pages

--- a/BookTracker.Web/Telemetry/UserTelemetryInitializer.cs
+++ b/BookTracker.Web/Telemetry/UserTelemetryInitializer.cs
@@ -1,0 +1,22 @@
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.Extensibility;
+
+namespace BookTracker.Web.Telemetry;
+
+/// <summary>
+/// Stamps the Easy Auth-authenticated user's name onto every telemetry
+/// item so traces, requests, and exceptions are filterable per user in
+/// App Insights. Single-user app today; the enrichment is forward-cover
+/// so when a second user appears their telemetry is already segmentable.
+/// </summary>
+public class UserTelemetryInitializer(IHttpContextAccessor httpContextAccessor) : ITelemetryInitializer
+{
+    public void Initialize(ITelemetry telemetry)
+    {
+        var name = httpContextAccessor.HttpContext?.User?.Identity?.Name;
+        if (!string.IsNullOrEmpty(name))
+        {
+            telemetry.Context.User.AuthenticatedUserId = name;
+        }
+    }
+}


### PR DESCRIPTION
Connection string was already plumbed via app-config.bicep but the App
Service codeless attach only captures baseline request/dependency
telemetry — ILogger calls and message-template properties (e.g.
{Isbn}) didn't flow as structured `traces`. Registering
AddApplicationInsightsTelemetry() in Program.cs hooks the SDK into the
existing pipeline so existing call sites benefit immediately without
any service-level edits.

UserTelemetryInitializer stamps the Easy Auth-authenticated user name
onto every telemetry item so `customDimensions['user_AuthenticatedId']`
in App Insights is filterable per user. Single-user app today; the
enrichment is forward-cover for future multi-user.

PR2 (error pages + 404 split + book-themed image) lands in a follow-up
branch.
