### PR TITLE
feat/error handling pages and 404

### DIFF
--- a/BookTracker.Tests/Services/ErrorMessageMapperTests.cs
+++ b/BookTracker.Tests/Services/ErrorMessageMapperTests.cs
@@ -1,0 +1,44 @@
+using BookTracker.Web.Services;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookTracker.Tests.Services;
+
+public class ErrorMessageMapperTests
+{
+    [Fact]
+    public void Map_DbUpdateException_ReturnsCouldntSaveTitle()
+    {
+        var msg = ErrorMessageMapper.Map(new DbUpdateException("conflict"));
+
+        Assert.Equal("Couldn't save your change", msg.Title);
+        Assert.Contains("logged", msg.Body, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Map_HttpRequestException_ReturnsExternalServiceTitle()
+    {
+        var msg = ErrorMessageMapper.Map(new HttpRequestException("timeout"));
+
+        Assert.Equal("Couldn't reach an external service", msg.Title);
+    }
+
+    [Fact]
+    public void Map_GenericException_ReturnsDefaultTitle()
+    {
+        // Any unmapped shape falls through to the generic message.
+        var msg = ErrorMessageMapper.Map(new InvalidOperationException("oops"));
+
+        Assert.Equal("Something went wrong", msg.Title);
+    }
+
+    [Fact]
+    public void Map_NullException_ReturnsDefaultTitle()
+    {
+        // /Error can be hit without a captured exception (e.g. direct
+        // navigation, or a re-execute that lost the feature). The mapper
+        // must still render a sensible message rather than NRE.
+        var msg = ErrorMessageMapper.Map(null);
+
+        Assert.Equal("Something went wrong", msg.Title);
+    }
+}

--- a/BookTracker.Web/Components/Pages/Error.razor
+++ b/BookTracker.Web/Components/Pages/Error.razor
@@ -1,42 +1,54 @@
 @page "/Error"
 @using System.Diagnostics
+@using BookTracker.Web.Services
+@using Microsoft.AspNetCore.Diagnostics
 
-@* TODO: replace the default error page with proper error handling —
-   structured logging, user-friendly categorized messages, a correlation id
-   the user can quote, and distinct templates for 404 / 500 / validation-type
-   failures. Current page is the stock template. *@
+@*
+    Sticks to plain HTML + Bootstrap rather than MudBlazor: this page is
+    rendered when something else has already broken, so depending on as
+    little of the rest of the app as possible is the right defensive
+    posture. Same reasoning as the App.razor PWA-asset paths using
+    direct /icons/* rather than @@Assets[...].
+*@
 
-<PageTitle>Error - BookTracker</PageTitle>
+<PageTitle>Something went wrong - BookTracker</PageTitle>
 
-<h1 class="text-danger">Error.</h1>
-<h2 class="text-danger">An error occurred while processing your request.</h2>
-
-@if (ShowRequestId)
-{
-    <p>
-        <strong>Request ID:</strong> <code>@RequestId</code>
-    </p>
-}
-
-<h3>Development Mode</h3>
-<p>
-    Swapping to the <strong>Development</strong> environment displays detailed information about the error.
-</p>
-<p>
-    <strong>The Development environment shouldn't be enabled for deployed applications.</strong>
-    It can result in displaying sensitive information from exceptions to end users.
-    For local debugging, enable the <strong>Development</strong> environment by setting the
-    <strong>ASPNETCORE_ENVIRONMENT</strong> environment variable to <strong>Development</strong>
-    and restarting the app.
-</p>
+<div class="container py-5">
+    <div class="card shadow-sm mx-auto" style="max-width: 600px;">
+        <div class="card-body p-4 p-md-5">
+            <h1 class="h3 mb-3">@Message.Title</h1>
+            <p class="mb-3">@Message.Body</p>
+            @if (!string.IsNullOrEmpty(TraceId))
+            {
+                <p class="text-muted small mb-4">
+                    Trace ID: <code>@TraceId</code>
+                </p>
+            }
+            <div class="d-flex gap-2 flex-wrap">
+                <a href="/" class="btn btn-primary">Home</a>
+                <a href="/books" class="btn btn-outline-secondary">Library</a>
+            </div>
+        </div>
+    </div>
+</div>
 
 @code {
     [CascadingParameter]
     private HttpContext? HttpContext { get; set; }
 
-    private string? RequestId { get; set; }
-    private bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
+    private ErrorMessageMapper.FriendlyMessage Message { get; set; } =
+        new("Something went wrong", "");
+    private string? TraceId { get; set; }
 
-    protected override void OnInitialized() =>
-        RequestId = Activity.Current?.Id ?? HttpContext?.TraceIdentifier;
+    protected override void OnInitialized()
+    {
+        // Activity.Current.TraceId is the W3C trace id (32-hex), which
+        // is what App Insights uses for `operation_Id` correlation.
+        // Falls back to HttpContext.TraceIdentifier if no Activity is
+        // active (shouldn't happen post-PR1 but cheap to be defensive).
+        TraceId = Activity.Current?.TraceId.ToString() ?? HttpContext?.TraceIdentifier;
+
+        var ex = HttpContext?.Features.Get<IExceptionHandlerFeature>()?.Error;
+        Message = ErrorMessageMapper.Map(ex);
+    }
 }

--- a/BookTracker.Web/Components/Pages/NotFound.razor
+++ b/BookTracker.Web/Components/Pages/NotFound.razor
@@ -1,0 +1,27 @@
+@page "/NotFound"
+
+@*
+    Hit by UseStatusCodePagesWithReExecute("/NotFound") when routing
+    fails to match. Plain HTML + Bootstrap by the same defensive
+    reasoning as Error.razor — and direct /icons/icon.svg path because
+    the icon is in Easy Auth's excludedPaths and reachable without
+    going through the @@Assets[] pipeline.
+*@
+
+<PageTitle>Page not found - BookTracker</PageTitle>
+
+<div class="container py-5">
+    <div class="card shadow-sm mx-auto" style="max-width: 600px;">
+        <div class="card-body text-center p-4 p-md-5">
+            <img src="/icons/icon.svg" alt="" width="120" height="120" class="mb-4" />
+            <h1 class="h3 mb-3">Looks like that page wandered off the shelf</h1>
+            <p class="text-muted mb-4">
+                We couldn't find the page you were looking for. It might have moved, or never existed.
+            </p>
+            <div class="d-flex gap-2 justify-content-center flex-wrap">
+                <a href="/" class="btn btn-primary">Home</a>
+                <a href="/books" class="btn btn-outline-secondary">Library</a>
+            </div>
+        </div>
+    </div>
+</div>

--- a/BookTracker.Web/Components/Pages/NotFound.razor
+++ b/BookTracker.Web/Components/Pages/NotFound.razor
@@ -1,27 +1,13 @@
 @page "/NotFound"
+@using BookTracker.Web.Components.Shared
 
 @*
     Hit by UseStatusCodePagesWithReExecute("/NotFound") when routing
-    fails to match. Plain HTML + Bootstrap by the same defensive
-    reasoning as Error.razor — and direct /icons/icon.svg path because
-    the icon is in Easy Auth's excludedPaths and reachable without
-    going through the @@Assets[] pipeline.
+    fails to match. Markup lives in Shared/NotFoundContent.razor so it
+    can also render from Blazor's <Router><NotFound> fallback for
+    in-app navigations to unmatched routes.
 *@
 
 <PageTitle>Page not found - BookTracker</PageTitle>
 
-<div class="container py-5">
-    <div class="card shadow-sm mx-auto" style="max-width: 600px;">
-        <div class="card-body text-center p-4 p-md-5">
-            <img src="/icons/icon.svg" alt="" width="120" height="120" class="mb-4" />
-            <h1 class="h3 mb-3">Looks like that page wandered off the shelf</h1>
-            <p class="text-muted mb-4">
-                We couldn't find the page you were looking for. It might have moved, or never existed.
-            </p>
-            <div class="d-flex gap-2 justify-content-center flex-wrap">
-                <a href="/" class="btn btn-primary">Home</a>
-                <a href="/books" class="btn btn-outline-secondary">Library</a>
-            </div>
-        </div>
-    </div>
-</div>
+<NotFoundContent />

--- a/BookTracker.Web/Components/Routes.razor
+++ b/BookTracker.Web/Components/Routes.razor
@@ -1,8 +1,24 @@
 @using BookTracker.Web.Components.Layout
+@using BookTracker.Web.Components.Shared
 
 <Router AppAssembly="typeof(Program).Assembly">
     <Found Context="routeData">
         <RouteView RouteData="routeData" DefaultLayout="typeof(MainLayout)" />
         <FocusOnNavigate RouteData="routeData" Selector="h1" />
     </Found>
+    <NotFound>
+        @*
+            Stops the framework default blank "Not found" text from
+            briefly replacing the server-rendered /NotFound page after
+            Blazor's client-side router takes over a re-executed request
+            whose URL doesn't match any @page directive. Wraps in
+            LayoutView because <NotFound> bypasses RouteView's
+            DefaultLayout, so without it the friendly content would
+            render outside MainLayout.
+        *@
+        <PageTitle>Page not found - BookTracker</PageTitle>
+        <LayoutView Layout="typeof(MainLayout)">
+            <NotFoundContent />
+        </LayoutView>
+    </NotFound>
 </Router>

--- a/BookTracker.Web/Components/Shared/NotFoundContent.razor
+++ b/BookTracker.Web/Components/Shared/NotFoundContent.razor
@@ -1,0 +1,28 @@
+@*
+    Shared 404 markup. Rendered in two places:
+      1. /NotFound page (Pages/NotFound.razor) — what the server-side
+         UseStatusCodePagesWithReExecute middleware lands on for cold
+         loads of bad URLs (correct HTTP 404 status).
+      2. Routes.razor <NotFound> template — what Blazor's client-side
+         router renders when an in-app navigation hits an unmatched
+         route, so the user doesn't briefly see (1) then have Blazor
+         fall back to the framework's default blank "Not found" text.
+
+    Both code paths land on the same friendly view.
+*@
+
+<div class="container py-5">
+    <div class="card shadow-sm mx-auto" style="max-width: 600px;">
+        <div class="card-body text-center p-4 p-md-5">
+            <img src="/icons/icon.svg" alt="" width="120" height="120" class="mb-4" />
+            <h1 class="h3 mb-3">Looks like that page wandered off the shelf</h1>
+            <p class="text-muted mb-4">
+                We couldn't find the page you were looking for. It might have moved, or never existed.
+            </p>
+            <div class="d-flex gap-2 justify-content-center flex-wrap">
+                <a href="/" class="btn btn-primary">Home</a>
+                <a href="/books" class="btn btn-outline-secondary">Library</a>
+            </div>
+        </div>
+    </div>
+</div>

--- a/BookTracker.Web/Program.cs
+++ b/BookTracker.Web/Program.cs
@@ -126,14 +126,17 @@ using (var scope = app.Services.CreateScope())
     await db.Database.MigrateAsync();
 }
 
-// TODO: replace the default /Error page and exception handler with proper error
-// handling — structured logging, user-friendly messages by category, correlation
-// ids surfaced to the user, and separate 404 handling.
 if (!app.Environment.IsDevelopment())
 {
     app.UseExceptionHandler("/Error", createScopeForErrors: true);
     app.UseHsts();
 }
+
+// 404s re-execute through /NotFound so the user lands on the friendly
+// "page wandered off the shelf" view rather than the framework default.
+// Outside the if-block so dev gets the friendly page too — the dev
+// exception page only handles thrown exceptions, not 404s.
+app.UseStatusCodePagesWithReExecute("/NotFound");
 
 app.UseHttpsRedirection();
 

--- a/BookTracker.Web/Services/ErrorMessageMapper.cs
+++ b/BookTracker.Web/Services/ErrorMessageMapper.cs
@@ -1,0 +1,34 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace BookTracker.Web.Services;
+
+/// <summary>
+/// Maps thrown exceptions surfaced on /Error to a user-readable
+/// (Title, Body) pair. Stays terse on purpose: production errors get a
+/// trace id alongside this so support can quote the technical detail
+/// from App Insights — the message is the human-facing layer.
+///
+/// Categories cover the two repeat shapes BookTracker actually hits:
+/// EF save failures (DbUpdateException — unique-index, FK, conversion)
+/// and external-service flakes (HttpRequestException — Open Library /
+/// Google Books / Trove / Anthropic timeouts). Everything else falls
+/// through to the generic message; new categories get added when real
+/// production logs surface a third shape worth distinguishing.
+/// </summary>
+public static class ErrorMessageMapper
+{
+    public record FriendlyMessage(string Title, string Body);
+
+    public static FriendlyMessage Map(Exception? ex) => ex switch
+    {
+        DbUpdateException => new(
+            "Couldn't save your change",
+            "The database couldn't accept that update. The error has been logged. Try again, and if it keeps failing quote the trace ID below to support."),
+        HttpRequestException => new(
+            "Couldn't reach an external service",
+            "BookTracker depends on a few external services for ISBN lookup and AI features — one of them didn't respond in time. The error has been logged."),
+        _ => new(
+            "Something went wrong",
+            "An unexpected error occurred. The error has been logged. Quote the trace ID below to support and we'll take a look."),
+    };
+}


### PR DESCRIPTION
- **feat(errors): friendly /Error + /NotFound pages with trace ID (PR2 of #8)**
- **fix(errors): wire Blazor Router NotFound template so it doesn't override the friendly page**
