### PR TITLE
chore(tests): introduce whitelist category trait convention

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,4 +15,9 @@ jobs:
           dotnet-version: '10.0.x'
       - run: dotnet restore BookTracker.slnx
       - run: dotnet build BookTracker.slnx --configuration Release --no-restore
-      - run: dotnet test BookTracker.slnx --configuration Release --no-build --verbosity normal
+      # Whitelist of test categories the PR job runs. E2E (Playwright) is
+      # deliberately excluded — it'll get its own job once the Playwright
+      # POC lands. Adding a new category is opt-in: append it here when
+      # CI should run it. See BookTracker.Tests/README.md for the
+      # category contract.
+      - run: dotnet test BookTracker.slnx --configuration Release --no-build --verbosity normal --filter "Category=Unit|Category=Component|Category=Integration"

--- a/BookTracker.Tests/Components/MudAuthorPickerTests.cs
+++ b/BookTracker.Tests/Components/MudAuthorPickerTests.cs
@@ -22,6 +22,7 @@ namespace BookTracker.Tests.Components;
 /// directly from tests, which covers everything that crosses the
 /// JS↔.NET boundary on the .NET side.
 /// </summary>
+[Trait("Category", TestCategories.Component)]
 public class MudAuthorPickerTests : ComponentTestBase
 {
     public MudAuthorPickerTests()

--- a/BookTracker.Tests/README.md
+++ b/BookTracker.Tests/README.md
@@ -1,0 +1,55 @@
+# BookTracker.Tests
+
+Test project for BookTracker. xUnit + Testcontainers SQL Server + bUnit + (planned) Playwright.
+
+## Test category contract
+
+Every test class must carry a `[Trait("Category", TestCategories.X)]` attribute. CI filters by category — the convention is **whitelist** (you opt IN to which categories a job runs) rather than blacklist (forgetting to exclude a new category type is the failure mode).
+
+The constants are defined in [`TestCategories.cs`](TestCategories.cs):
+
+| Constant | What | Speed | Examples |
+|---|---|---|---|
+| `Unit` | Pure C# logic. No DB, no Razor render, no browser. NSubstitute mocks for collaborators are fine. | <10ms each | `ErrorMessageMapperTests`, `UserTelemetryInitializerTests`, the merge-VM tests using mocked services |
+| `Component` | bUnit Razor render with MudBlazor wired. Mid-tier — fast but heavier than `Unit` because of component-rendering setup. | mid-tier | `MudAuthorPickerTests` |
+| `Integration` | Real EF Core against `Testcontainers.MsSql` + Respawn. Slower per test once the container is up. | ~24s suite startup; fast per-test thereafter | most `ViewModels/*Tests`, most `Services/*Tests` |
+| `E2E` | Playwright browser tests. Slowest tier — full request/response including JS interop. | minutes | (none yet — the Playwright POC adds the first) |
+| `Load` | _Reserved_ for future perf / load-shape work. No tests use it yet. | n/a | n/a |
+
+Trait at the **class level**, not the method level. A few classes have mixed-need methods (e.g., `GenrePickerViewModelTests` has both pure-logic and DB-using methods); class-level tagging picks the slowest of the methods, which is the safe side to err on.
+
+## Running subsets
+
+Run all tests in a category:
+```powershell
+dotnet test --filter "Category=Unit"
+dotnet test --filter "Category=Integration"
+dotnet test --filter "Category=E2E"
+```
+
+Combine multiple categories (xUnit's filter syntax uses `|` for OR within a key):
+```powershell
+dotnet test --filter "Category=Unit|Category=Component"
+dotnet test --filter "Category=Unit|Category=Component|Category=Integration"
+```
+
+Fast-feedback loop while iterating on a single test class:
+```powershell
+dotnet test --filter "FullyQualifiedName~MudAuthorPickerTests"
+```
+
+## CI behaviour
+
+The PR job in `.github/workflows/ci.yml` runs `Category=Unit|Category=Component|Category=Integration` — i.e. everything except `E2E` and `Load`. When the Playwright POC ships, `E2E` will get its own job (likely scheduled / on-demand rather than per-PR, given the runtime cost).
+
+## Testcontainers prerequisite
+
+Integration tests use a single process-scoped SQL Server container (`SqlServerContainer.cs`) reused across the test run, with Respawn wiping data between tests. Docker Desktop must be running locally for Integration tests to start.
+
+## Adding a new test class
+
+1. Pick the category that matches the slowest thing the class does (use TestDbContextFactory? → `Integration`. bUnit `RenderComponent`? → `Component`. Pure logic? → `Unit`.)
+2. Add `[Trait("Category", TestCategories.X)]` immediately above the `public class` declaration.
+3. Run `dotnet test --filter "Category=X"` to confirm it picks up the new test.
+
+If you forget the trait, the test silently doesn't run in CI — that's the failure mode the whitelist convention chooses over the alternative (forgetting to exclude in a blacklist, which would slow CI but still catch bugs). Worth a glance at the test count after merge.

--- a/BookTracker.Tests/Services/AuthorMergeServiceTests.cs
+++ b/BookTracker.Tests/Services/AuthorMergeServiceTests.cs
@@ -3,6 +3,7 @@ using BookTracker.Web.Services;
 
 namespace BookTracker.Tests.Services;
 
+[Trait("Category", TestCategories.Integration)]
 public class AuthorMergeServiceTests
 {
     private readonly TestDbContextFactory _factory = new();

--- a/BookTracker.Tests/Services/AuthorResolverTests.cs
+++ b/BookTracker.Tests/Services/AuthorResolverTests.cs
@@ -3,6 +3,7 @@ using BookTracker.Web.Services;
 
 namespace BookTracker.Tests.Services;
 
+[Trait("Category", TestCategories.Integration)]
 public class AuthorResolverTests
 {
     private readonly TestDbContextFactory _factory = new();

--- a/BookTracker.Tests/Services/BookFormatNormalizerTests.cs
+++ b/BookTracker.Tests/Services/BookFormatNormalizerTests.cs
@@ -3,6 +3,7 @@ using BookTracker.Web.Services;
 
 namespace BookTracker.Tests.Services;
 
+[Trait("Category", TestCategories.Unit)]
 public class BookFormatNormalizerTests
 {
     [Theory]

--- a/BookTracker.Tests/Services/BookLookupServiceTests.cs
+++ b/BookTracker.Tests/Services/BookLookupServiceTests.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Options;
 
 namespace BookTracker.Tests.Services;
 
+[Trait("Category", TestCategories.Unit)]
 public class BookLookupServiceTests
 {
     private const string Isbn = "9780645840407";

--- a/BookTracker.Tests/Services/BookMergeServiceTests.cs
+++ b/BookTracker.Tests/Services/BookMergeServiceTests.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace BookTracker.Tests.Services;
 
+[Trait("Category", TestCategories.Integration)]
 public class BookMergeServiceTests
 {
     private readonly TestDbContextFactory _factory = new();

--- a/BookTracker.Tests/Services/DuplicateDetectionServiceTests.cs
+++ b/BookTracker.Tests/Services/DuplicateDetectionServiceTests.cs
@@ -3,6 +3,7 @@ using BookTracker.Web.Services;
 
 namespace BookTracker.Tests.Services;
 
+[Trait("Category", TestCategories.Integration)]
 public class DuplicateDetectionServiceTests
 {
     private readonly TestDbContextFactory _factory = new();

--- a/BookTracker.Tests/Services/EditionFormatBackfillServiceTests.cs
+++ b/BookTracker.Tests/Services/EditionFormatBackfillServiceTests.cs
@@ -5,6 +5,7 @@ using NSubstitute;
 
 namespace BookTracker.Tests.Services;
 
+[Trait("Category", TestCategories.Integration)]
 public class EditionFormatBackfillServiceTests
 {
     private readonly TestDbContextFactory _factory = new();

--- a/BookTracker.Tests/Services/EditionMergeServiceTests.cs
+++ b/BookTracker.Tests/Services/EditionMergeServiceTests.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace BookTracker.Tests.Services;
 
+[Trait("Category", TestCategories.Integration)]
 public class EditionMergeServiceTests
 {
     private readonly TestDbContextFactory _factory = new();

--- a/BookTracker.Tests/Services/ErrorMessageMapperTests.cs
+++ b/BookTracker.Tests/Services/ErrorMessageMapperTests.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace BookTracker.Tests.Services;
 
+[Trait("Category", TestCategories.Unit)]
 public class ErrorMessageMapperTests
 {
     [Fact]

--- a/BookTracker.Tests/Services/GenreCandidateCleanerTests.cs
+++ b/BookTracker.Tests/Services/GenreCandidateCleanerTests.cs
@@ -2,6 +2,7 @@ using BookTracker.Web.Services;
 
 namespace BookTracker.Tests.Services;
 
+[Trait("Category", TestCategories.Unit)]
 public class GenreCandidateCleanerTests
 {
     [Theory]

--- a/BookTracker.Tests/Services/PartialDateParserTests.cs
+++ b/BookTracker.Tests/Services/PartialDateParserTests.cs
@@ -3,6 +3,7 @@ using BookTracker.Web.Services;
 
 namespace BookTracker.Tests.Services;
 
+[Trait("Category", TestCategories.Unit)]
 public class PartialDateParserTests
 {
     [Theory]

--- a/BookTracker.Tests/Services/SeriesMatchServiceTests.cs
+++ b/BookTracker.Tests/Services/SeriesMatchServiceTests.cs
@@ -3,6 +3,7 @@ using BookTracker.Web.Services;
 
 namespace BookTracker.Tests.Services;
 
+[Trait("Category", TestCategories.Integration)]
 public class SeriesMatchServiceTests
 {
     [Fact]

--- a/BookTracker.Tests/Services/WorkMergeServiceTests.cs
+++ b/BookTracker.Tests/Services/WorkMergeServiceTests.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace BookTracker.Tests.Services;
 
+[Trait("Category", TestCategories.Integration)]
 public class WorkMergeServiceTests
 {
     private readonly TestDbContextFactory _factory = new();

--- a/BookTracker.Tests/Services/WorkSearchServiceTests.cs
+++ b/BookTracker.Tests/Services/WorkSearchServiceTests.cs
@@ -3,6 +3,7 @@ using BookTracker.Web.Services;
 
 namespace BookTracker.Tests.Services;
 
+[Trait("Category", TestCategories.Integration)]
 public class WorkSearchServiceTests
 {
     private readonly TestDbContextFactory _factory = new();

--- a/BookTracker.Tests/Telemetry/UserTelemetryInitializerTests.cs
+++ b/BookTracker.Tests/Telemetry/UserTelemetryInitializerTests.cs
@@ -6,6 +6,7 @@ using NSubstitute;
 
 namespace BookTracker.Tests.Telemetry;
 
+[Trait("Category", TestCategories.Unit)]
 public class UserTelemetryInitializerTests
 {
     [Fact]

--- a/BookTracker.Tests/TestCategories.cs
+++ b/BookTracker.Tests/TestCategories.cs
@@ -1,0 +1,28 @@
+namespace BookTracker.Tests;
+
+/// <summary>
+/// Test category constants for <see cref="Xunit.TraitAttribute"/> usage.
+/// CI filters tests by category; the convention is whitelist (you opt
+/// IN to the categories a job runs) rather than blacklist (forgetting
+/// to exclude a new category type is the failure mode).
+///
+/// See <c>BookTracker.Tests/README.md</c> for what each category means
+/// and how to run subsets locally.
+/// </summary>
+public static class TestCategories
+{
+    /// <summary>Pure C# logic. No DB, no Razor render, no browser. Fast (&lt;10ms each).</summary>
+    public const string Unit = "Unit";
+
+    /// <summary>bUnit Razor render with MudBlazor wired. Mid-tier; fast but heavier than Unit.</summary>
+    public const string Component = "Component";
+
+    /// <summary>Real EF Core against Testcontainers SQL Server + Respawn. ~24s suite startup, fast per-test thereafter.</summary>
+    public const string Integration = "Integration";
+
+    /// <summary>Playwright browser tests. Slowest tier — full request/response including JS interop.</summary>
+    public const string E2E = "E2E";
+
+    // Reserved for future use (perf / load-shape testing). No tests use it yet.
+    public const string Load = "Load";
+}

--- a/BookTracker.Tests/ViewModels/AuthorListViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/AuthorListViewModelTests.cs
@@ -3,6 +3,7 @@ using BookTracker.Web.ViewModels;
 
 namespace BookTracker.Tests.ViewModels;
 
+[Trait("Category", TestCategories.Integration)]
 public class AuthorListViewModelTests
 {
     [Fact]

--- a/BookTracker.Tests/ViewModels/AuthorMergeViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/AuthorMergeViewModelTests.cs
@@ -4,6 +4,7 @@ using NSubstitute;
 
 namespace BookTracker.Tests.ViewModels;
 
+[Trait("Category", TestCategories.Unit)]
 public class AuthorMergeViewModelTests
 {
     private readonly IAuthorMergeService _merger = Substitute.For<IAuthorMergeService>();

--- a/BookTracker.Tests/ViewModels/BookAddViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/BookAddViewModelTests.cs
@@ -6,6 +6,7 @@ using NSubstitute;
 
 namespace BookTracker.Tests.ViewModels;
 
+[Trait("Category", TestCategories.Integration)]
 public class BookAddViewModelTests
 {
     private readonly TestDbContextFactory _factory = new();

--- a/BookTracker.Tests/ViewModels/BookDetailViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/BookDetailViewModelTests.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace BookTracker.Tests.ViewModels;
 
+[Trait("Category", TestCategories.Integration)]
 public class BookDetailViewModelTests
 {
     [Fact]

--- a/BookTracker.Tests/ViewModels/BookEditDialogViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/BookEditDialogViewModelTests.cs
@@ -3,6 +3,7 @@ using BookTracker.Web.ViewModels;
 
 namespace BookTracker.Tests.ViewModels;
 
+[Trait("Category", TestCategories.Integration)]
 public class BookEditDialogViewModelTests
 {
     [Fact]

--- a/BookTracker.Tests/ViewModels/BookListViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/BookListViewModelTests.cs
@@ -7,6 +7,7 @@ namespace BookTracker.Tests.ViewModels;
 // The flat-list path is exercised indirectly elsewhere; here we cover the
 // new GroupBy enum + canonical-author rollup + (no genre)/(no series)
 // trailing buckets.
+[Trait("Category", TestCategories.Integration)]
 public class BookListViewModelTests
 {
     private static async Task SeedSampleLibraryAsync(TestDbContextFactory factory)

--- a/BookTracker.Tests/ViewModels/BookMergeViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/BookMergeViewModelTests.cs
@@ -5,6 +5,7 @@ using NSubstitute;
 
 namespace BookTracker.Tests.ViewModels;
 
+[Trait("Category", TestCategories.Unit)]
 public class BookMergeViewModelTests
 {
     private readonly IBookMergeService _merger = Substitute.For<IBookMergeService>();

--- a/BookTracker.Tests/ViewModels/BulkAddViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/BulkAddViewModelTests.cs
@@ -6,6 +6,7 @@ using NSubstitute;
 
 namespace BookTracker.Tests.ViewModels;
 
+[Trait("Category", TestCategories.Integration)]
 public class BulkAddViewModelTests
 {
     private readonly TestDbContextFactory _factory = new();

--- a/BookTracker.Tests/ViewModels/CopyFormDialogViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/CopyFormDialogViewModelTests.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace BookTracker.Tests.ViewModels;
 
+[Trait("Category", TestCategories.Integration)]
 public class CopyFormDialogViewModelTests
 {
     [Fact]

--- a/BookTracker.Tests/ViewModels/DuplicatesViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/DuplicatesViewModelTests.cs
@@ -5,6 +5,7 @@ using NSubstitute;
 
 namespace BookTracker.Tests.ViewModels;
 
+[Trait("Category", TestCategories.Unit)]
 public class DuplicatesViewModelTests
 {
     private readonly IDuplicateDetectionService _detector = Substitute.For<IDuplicateDetectionService>();

--- a/BookTracker.Tests/ViewModels/EditionFormDialogViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/EditionFormDialogViewModelTests.cs
@@ -6,6 +6,7 @@ using NSubstitute;
 
 namespace BookTracker.Tests.ViewModels;
 
+[Trait("Category", TestCategories.Integration)]
 public class EditionFormDialogViewModelTests
 {
     private readonly IBookLookupService _lookup = Substitute.For<IBookLookupService>();

--- a/BookTracker.Tests/ViewModels/EditionMergeViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/EditionMergeViewModelTests.cs
@@ -5,6 +5,7 @@ using NSubstitute;
 
 namespace BookTracker.Tests.ViewModels;
 
+[Trait("Category", TestCategories.Unit)]
 public class EditionMergeViewModelTests
 {
     private readonly IEditionMergeService _merger = Substitute.For<IEditionMergeService>();

--- a/BookTracker.Tests/ViewModels/GenrePickerViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/GenrePickerViewModelTests.cs
@@ -3,6 +3,7 @@ using BookTracker.Web.ViewModels;
 
 namespace BookTracker.Tests.ViewModels;
 
+[Trait("Category", TestCategories.Integration)]
 public class GenrePickerViewModelTests
 {
     [Fact]

--- a/BookTracker.Tests/ViewModels/HomeViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/HomeViewModelTests.cs
@@ -3,6 +3,7 @@ using BookTracker.Web.ViewModels;
 
 namespace BookTracker.Tests.ViewModels;
 
+[Trait("Category", TestCategories.Integration)]
 public class HomeViewModelTests
 {
     [Fact]

--- a/BookTracker.Tests/ViewModels/MudGenrePickerViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/MudGenrePickerViewModelTests.cs
@@ -3,6 +3,7 @@ using BookTracker.Web.ViewModels;
 
 namespace BookTracker.Tests.ViewModels;
 
+[Trait("Category", TestCategories.Integration)]
 public class MudGenrePickerViewModelTests
 {
     [Fact]

--- a/BookTracker.Tests/ViewModels/PublisherListViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/PublisherListViewModelTests.cs
@@ -3,6 +3,7 @@ using BookTracker.Web.ViewModels;
 
 namespace BookTracker.Tests.ViewModels;
 
+[Trait("Category", TestCategories.Integration)]
 public class PublisherListViewModelTests
 {
     [Fact]

--- a/BookTracker.Tests/ViewModels/ShoppingViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/ShoppingViewModelTests.cs
@@ -3,6 +3,7 @@ using BookTracker.Web.ViewModels;
 
 namespace BookTracker.Tests.ViewModels;
 
+[Trait("Category", TestCategories.Integration)]
 public class ShoppingViewModelTests
 {
     [Fact]

--- a/BookTracker.Tests/ViewModels/WorkEditDialogViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/WorkEditDialogViewModelTests.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace BookTracker.Tests.ViewModels;
 
+[Trait("Category", TestCategories.Integration)]
 public class WorkEditDialogViewModelTests
 {
     [Fact]

--- a/BookTracker.Tests/ViewModels/WorkMergeViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/WorkMergeViewModelTests.cs
@@ -4,6 +4,7 @@ using NSubstitute;
 
 namespace BookTracker.Tests.ViewModels;
 
+[Trait("Category", TestCategories.Unit)]
 public class WorkMergeViewModelTests
 {
     private readonly IWorkMergeService _merger = Substitute.For<IWorkMergeService>();


### PR DESCRIPTION
Adds Trait-based test categorisation so CI can opt IN to specific
categories rather than maintaining a blacklist of exclusions. The
chip-picker arc and the Series-redirect arc both surfaced that
exclusion lists fail under "new category arrives" — whitelist scales
as we add Component / E2E / Load tiers.

Five categories defined in BookTracker.Tests/TestCategories.cs:
  - Unit (pure C#, no DB / Razor / browser)
  - Component (bUnit + MudBlazor)
  - Integration (EF + Testcontainers SQL)
  - E2E (Playwright — POC lands next)
  - Load (reserved)

All 35 existing test classes traited at class level. Methods within
mixed classes (GenrePickerViewModelTests has both pure-logic and
DB-using methods) get the slowest-of-the-class trait — safe-side
default rather than splitting files.

CI workflow filter set to Category=Unit|Component|Integration. E2E
gets its own job when Playwright lands. README documents the
contract.

Verified suite-runs unchanged: full whitelist filter shows 340/1/0
matching the prior unfiltered baseline. Unit-only filter runs 112
tests in 0.5s — useful inner-loop speed.
