### PR TITLE
fix(ai): tighten ISBN OCR prompt for X check digit + add OCR trace (#19)

### DIFF
--- a/BookTracker.Web/ProgramSetup.cs
+++ b/BookTracker.Web/ProgramSetup.cs
@@ -108,7 +108,8 @@ public static class ProgramSetup
         {
             var factory = new AIProviderFactory(
                 sp.GetRequiredService<IDbContextFactory<BookTrackerDbContext>>(),
-                sp.GetRequiredService<IOptions<AIOptions>>());
+                sp.GetRequiredService<IOptions<AIOptions>>(),
+                sp.GetRequiredService<ILoggerFactory>());
             factory.Initialize();
             return factory;
         });

--- a/BookTracker.Web/Services/AIAssistantService.cs
+++ b/BookTracker.Web/Services/AIAssistantService.cs
@@ -11,7 +11,8 @@ namespace BookTracker.Web.Services;
 /// </summary>
 public class AnthropicAIAssistantService(
     IDbContextFactory<BookTrackerDbContext> dbFactory,
-    AnthropicOptions options) : IAIAssistantService
+    AnthropicOptions options,
+    ILogger<AnthropicAIAssistantService> logger) : IAIAssistantService
 {
     private AnthropicClient? _client;
 
@@ -42,7 +43,23 @@ public class AnthropicAIAssistantService(
                     },
                     new TextContent
                     {
-                        Text = "Extract the ISBN number from this image. Return ONLY the ISBN (10 or 13 characters). ISBN-10 may end with the letter X as a check digit — include it if present. Return nothing else. If you cannot find an ISBN, return the word NONE."
+                        // Stronger X handling than the previous "include if present" —
+                        // Drew was seeing X-ending ISBN-10s come back as 9 digits,
+                        // which then failed the length check and returned null. The
+                        // explicit example + "MUST include" phrasing leans on
+                        // example-following rather than instruction-following, which
+                        // tends to be more reliable.
+                        Text = """
+                            Read the ISBN from this book's image. Reply with just the ISBN — no other text, no explanation, no formatting.
+
+                            ISBNs come in two forms:
+                              - ISBN-13: 13 digits (e.g. 9780123456786)
+                              - ISBN-10: 10 characters where the final character is a check digit that may be the letter X (e.g. 012345678X)
+
+                            If the printed ISBN ends in X, you MUST include the X — without it the ISBN is invalid. Do not normalize, simplify, or 'correct' the ISBN; return exactly what is printed (digits only, no hyphens or spaces).
+
+                            If no ISBN is visible, reply with NONE.
+                            """
                     }
                 }
             }
@@ -52,10 +69,23 @@ public class AnthropicAIAssistantService(
         var responseText = (response.Message?.ToString() ?? "").Trim();
 
         if (responseText.Equals("NONE", StringComparison.OrdinalIgnoreCase))
+        {
+            logger.LogInformation("ISBN OCR: model returned NONE (no ISBN found in image)");
             return null;
+        }
 
         var cleaned = new string(responseText.Where(c => char.IsDigit(c) || c == 'X' || c == 'x').ToArray());
-        return cleaned.Length is 10 or 13 ? cleaned : null;
+        var accepted = cleaned.Length is 10 or 13;
+
+        // Trace both raw and cleaned so post-deploy debugging can tell whether
+        // a rejection (accepted=false) was a model dropping the X check digit
+        // (raw "012345678" length 9), the model adding stray text (raw with
+        // long prefix), or a genuine "couldn't read" case.
+        logger.LogInformation(
+            "ISBN OCR: raw={Raw} cleaned={Cleaned} length={Length} accepted={Accepted}",
+            responseText, cleaned, cleaned.Length, accepted);
+
+        return accepted ? cleaned : null;
     }
 
     public async Task<GenreSuggestionResult> SuggestGenresAsync(

--- a/BookTracker.Web/Services/AIProviderFactory.cs
+++ b/BookTracker.Web/Services/AIProviderFactory.cs
@@ -10,7 +10,8 @@ namespace BookTracker.Web.Services;
 /// </summary>
 public class AIProviderFactory(
     IDbContextFactory<BookTrackerDbContext> dbFactory,
-    IOptions<AIOptions> options)
+    IOptions<AIOptions> options,
+    ILoggerFactory loggerFactory)
 {
     private readonly AIOptions _options = options.Value;
     private AIProvider _activeProvider;
@@ -42,7 +43,7 @@ public class AIProviderFactory(
 
     private IAIAssistantService CreateService(AIProvider provider) => provider switch
     {
-        AIProvider.Anthropic => new AnthropicAIAssistantService(dbFactory, _options.Anthropic),
+        AIProvider.Anthropic => new AnthropicAIAssistantService(dbFactory, _options.Anthropic, loggerFactory.CreateLogger<AnthropicAIAssistantService>()),
         AIProvider.MicrosoftFoundry => new MicrosoftFoundryAIAssistantService(dbFactory, _options.MicrosoftFoundry),
         AIProvider.AzureOpenAI => new AzureOpenAIAssistantService(dbFactory, _options.AzureOpenAI),
         _ => throw new ArgumentOutOfRangeException(nameof(provider))


### PR DESCRIPTION
OCR-via-photo path was returning null for ISBN-10s ending in X — Drew
filed it as "rejects ISBN-10s ending in X." Likely cause is the model
dropping the X despite the prompt's "include it if present" hint;
the post-AI cleanup at the length check then sees 9 digits, returns
null, UI shows "Could not find an ISBN in the photo." User retries,
same result.

Two changes:

1. Prompt rewording. Stronger X handling — explicit example
   ("012345678X"), "MUST include the X" phrasing, "do not normalize,
   simplify, or 'correct' the ISBN" instruction. Leans on
   example-following rather than instruction-following, which tends
   to be more reliable for this kind of edge case.

2. Instrumentation. LogInformation on every OCR attempt with raw
   model output, cleaned form, length, and accepted bool. Post-deploy
   this lets us tell at a glance whether a rejection is the model
   dropping X (raw "012345678" length 9), the model adding stray
   text, or a genuine "couldn't read" case.

Required wiring: ILogger<AnthropicAIAssistantService> through
AIProviderFactory's CreateService (uses ILoggerFactory for the
multi-provider future). No behaviour change to the other providers.

KQL post-deploy:
  traces
  | where message startswith "ISBN OCR:"
  | project timestamp, message, customDimensions
  | order by timestamp desc

Suite: 340/1/0 unchanged.
