### PR TITLE
feat(observability): display deployed commit SHA in UI footer

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,11 @@ jobs:
         run: dotnet restore BookTracker.slnx
 
       - name: Build
-        run: dotnet build BookTracker.slnx --configuration Release --no-restore
+        # /p:SourceRevisionId stamps the commit SHA into AssemblyInformationalVersionAttribute
+        # ("1.0.0+<sha>") so the runtime BuildInfo helper can surface the live commit in the
+        # UI footer. Must be set on the build step (the assembly is produced here); publish
+        # runs --no-build and would not pick up a property added there.
+        run: dotnet build BookTracker.slnx --configuration Release --no-restore /p:SourceRevisionId=${{ github.sha }}
 
       - name: Publish
         run: dotnet publish BookTracker.Web/BookTracker.Web.csproj --configuration Release --no-build -o ./publish

--- a/BookTracker.Tests/Services/BuildInfoTests.cs
+++ b/BookTracker.Tests/Services/BuildInfoTests.cs
@@ -1,0 +1,28 @@
+using BookTracker.Web.Services;
+
+namespace BookTracker.Tests.Services;
+
+[Trait("Category", TestCategories.Unit)]
+public class BuildInfoTests
+{
+    [Theory]
+    [InlineData("1.0.0+abcdef0123456789abcdef0123456789abcdef01", "abcdef0123456789abcdef0123456789abcdef01")]
+    [InlineData("1.2.3-pre+abc1234", "abc1234")]
+    [InlineData("0.0.0+a", "a")]
+    public void ParseSha_ExtractsSuffixAfterPlus(string informationalVersion, string expected)
+    {
+        Assert.Equal(expected, BuildInfo.ParseSha(informationalVersion));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("1.0.0")]               // local-dev shape with no SourceRevisionId
+    [InlineData("1.0.0-pre")]
+    [InlineData("1.0.0+")]              // dangling plus, no sha — treat as missing
+    public void ParseSha_ReturnsNull_WhenNoShaSuffix(string? informationalVersion)
+    {
+        Assert.Null(BuildInfo.ParseSha(informationalVersion));
+    }
+}

--- a/BookTracker.Web/Components/Layout/MainLayout.razor
+++ b/BookTracker.Web/Components/Layout/MainLayout.razor
@@ -1,3 +1,4 @@
+@using BookTracker.Web.Services
 @using BookTracker.Web.Theme
 @inherits LayoutComponentBase
 @implements IDisposable
@@ -69,6 +70,10 @@
 <footer class="border-top footer text-muted">
     <div class="container">
         &copy; 2026 - BookTracker - <a href="privacy">Privacy</a>
+        @if (BuildInfo.ShortSha is { } sha)
+        {
+            <span class="ms-2">- Version: <a href="@BuildInfo.CommitUrl" target="_blank" rel="noopener noreferrer" class="text-muted">@sha</a></span>
+        }
     </div>
 </footer>
 

--- a/BookTracker.Web/Services/BuildInfo.cs
+++ b/BookTracker.Web/Services/BuildInfo.cs
@@ -1,0 +1,43 @@
+using System.Reflection;
+
+namespace BookTracker.Web.Services;
+
+// Surfaces the deployed git commit SHA in the UI footer so it's clear which
+// build is live in prod / staging without checking the Azure portal — useful
+// in particular for confirming slot swaps actually moved the bits.
+//
+// SHA injection happens at build time via the SDK's standard plumbing:
+// `dotnet build /p:SourceRevisionId=<sha>` causes the SDK to append `+<sha>`
+// to AssemblyInformationalVersionAttribute. Local `dotnet run` without the
+// property leaves the suffix empty — ShortSha returns null and the footer
+// renders nothing rather than a placeholder.
+public static class BuildInfo
+{
+    private const int ShortShaLength = 7;
+    private const string RepoCommitUrlBase = "https://github.com/N3rdage/the-library/commit/";
+
+    public static string? ShortSha { get; }
+    public static string? CommitUrl { get; }
+
+    static BuildInfo()
+    {
+        var sha = ParseSha(Assembly.GetEntryAssembly()?.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion);
+        if (string.IsNullOrEmpty(sha)) return;
+        ShortSha = sha.Length >= ShortShaLength ? sha[..ShortShaLength] : sha;
+        CommitUrl = RepoCommitUrlBase + sha;
+    }
+
+    /// <summary>
+    /// Parses the SHA suffix from an InformationalVersion string of the shape
+    /// "1.0.0+abcdef0...". Returns null when the input is empty or lacks a
+    /// "+sha" suffix (the local-dev case). Internal so the static initializer
+    /// can stay declarative while tests exercise the parsing rules directly.
+    /// </summary>
+    internal static string? ParseSha(string? informationalVersion)
+    {
+        if (string.IsNullOrWhiteSpace(informationalVersion)) return null;
+        var plus = informationalVersion.IndexOf('+');
+        if (plus < 0 || plus == informationalVersion.Length - 1) return null;
+        return informationalVersion[(plus + 1)..];
+    }
+}


### PR DESCRIPTION
Closes TODO #17. Hard to verify what's actually live in prod / staging without checking the Azure portal — and slot-swap behaviour in particular benefits from confirming the bits moved. Now every page renders a small muted "Version: a1b2c3d" line in the existing footer, linked to the GitHub commit so one click reveals what's deployed.

Implementation:
- Build-time: deploy.yml passes /p:SourceRevisionId=${{ github.sha }} to the build step (must be on build, not publish — publish runs --no-build and would not pick up a property added there). The .NET SDK appends this to AssemblyInformationalVersionAttribute as "1.0.0+<sha>" automatically.
- Runtime: new BuildInfo helper in Services/ reads the attribute via reflection in its static initializer and exposes ShortSha (first 7 chars) + CommitUrl (full GitHub commit link). Local dev runs without the property leave both null and the footer renders nothing rather than a placeholder.
- UI: one-line addition to MainLayout.razor's existing footer. Anchor opens in a new tab with rel="noopener noreferrer". Universal/passive — same display on desktop and mobile, no responsive work needed beyond inheriting the existing footer.

Test: BuildInfoTests covers the InformationalVersion → SHA parser (the static initializer's load-time path stays untested; depends on build state and adds little value vs. the parser tests).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
