### PR TITLE
feat(bulk-add): clear accepted rows from grid + footer wrap fix

### DIFF
--- a/BookTracker.Tests/ViewModels/BulkAddViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/BulkAddViewModelTests.cs
@@ -179,7 +179,7 @@ public class BulkAddViewModelTests
     }
 
     [Fact]
-    public async Task AcceptRowAsync_CreatesBookAndCopy()
+    public async Task AcceptRowAsync_CreatesBookAndCopy_AndRemovesRowFromGrid()
     {
         var vm = CreateVm();
         var row = new BulkAddViewModel.DiscoveryRow
@@ -189,10 +189,11 @@ public class BulkAddViewModelTests
             Author = "J.R.R. Tolkien",
             Status = BulkAddViewModel.RowStatus.Found
         };
+        vm.Rows.Add(row);
 
         await vm.AcceptRowAsync(row);
 
-        Assert.Equal(BulkAddViewModel.RowAction.Accepted, row.Action);
+        Assert.Empty(vm.Rows); // row cleared post-accept so the discovery list stays manageable
 
         using var db = _factory.CreateDbContext();
         var book = db.Books.Include(b => b.Works).ThenInclude(w => w.WorkAuthors).ThenInclude(wa => wa.Author).FirstOrDefault(b => b.Title == "The Hobbit");
@@ -225,7 +226,7 @@ public class BulkAddViewModelTests
     }
 
     [Fact]
-    public async Task FollowUpRowAsync_CreatesBookWithFollowUpTag()
+    public async Task FollowUpRowAsync_CreatesBookWithFollowUpTag_AndRemovesRowFromGrid()
     {
         // Seed the follow-up tag (like the real migration does)
         using (var db = _factory.CreateDbContext())
@@ -242,10 +243,11 @@ public class BulkAddViewModelTests
             Author = "J.R.R. Tolkien",
             Status = BulkAddViewModel.RowStatus.Found
         };
+        vm.Rows.Add(row);
 
         await vm.FollowUpRowAsync(row);
 
-        Assert.Equal(BulkAddViewModel.RowAction.FollowUp, row.Action);
+        Assert.Empty(vm.Rows);
 
         using var db2 = _factory.CreateDbContext();
         var book = db2.Books.FirstOrDefault(b => b.Title == "The Hobbit");
@@ -253,7 +255,7 @@ public class BulkAddViewModelTests
     }
 
     [Fact]
-    public async Task FollowUpNotFoundAsync_UsesDefaultTitle()
+    public async Task FollowUpNotFoundAsync_UsesDefaultTitle_AndRemovesRowFromGrid()
     {
         using (var db = _factory.CreateDbContext())
         {
@@ -267,11 +269,12 @@ public class BulkAddViewModelTests
             Isbn = "1234567890",
             Status = BulkAddViewModel.RowStatus.NotFound
         };
+        vm.Rows.Add(row);
 
         await vm.FollowUpNotFoundAsync(row);
 
-        Assert.Equal(BulkAddViewModel.RowAction.FollowUp, row.Action);
-        Assert.StartsWith("Unknown book", row.Title);
+        Assert.Empty(vm.Rows);
+        Assert.StartsWith("Unknown book", row.Title); // title filled defensively before save
     }
 
     [Fact]
@@ -286,9 +289,9 @@ public class BulkAddViewModelTests
 
         await vm.AcceptAllFoundAsync();
 
-        Assert.Equal(BulkAddViewModel.RowAction.Accepted, found.Action);
-        Assert.Equal(BulkAddViewModel.RowAction.Pending, duplicate.Action); // skipped
-        Assert.Equal(BulkAddViewModel.RowAction.Pending, notFound.Action); // skipped
+        Assert.DoesNotContain(found, vm.Rows);   // accepted, removed from grid
+        Assert.Contains(duplicate, vm.Rows);     // skipped — duplicates need user review
+        Assert.Contains(notFound, vm.Rows);      // skipped — needs follow-up decision
     }
 
     [Theory]

--- a/BookTracker.Web/Components/Layout/MainLayout.razor
+++ b/BookTracker.Web/Components/Layout/MainLayout.razor
@@ -69,10 +69,15 @@
 
 <footer class="border-top footer text-muted">
     <div class="container">
-        &copy; 2026 - BookTracker - <a href="privacy">Privacy</a>
+        @* Each segment is d-inline-block so the browser can wrap between segments
+           on a narrow viewport without breaking mid-text (e.g. "Version:" and the
+           SHA staying together). The inter-segment whitespace is the natural
+           wrap point. *@
+        <span class="d-inline-block">&copy; 2026 - BookTracker</span>
+        <span class="d-inline-block">- <a href="privacy">Privacy</a></span>
         @if (BuildInfo.ShortSha is { } sha)
         {
-            <span class="ms-2">- Version: <a href="@BuildInfo.CommitUrl" target="_blank" rel="noopener noreferrer" class="text-muted">@sha</a></span>
+            <span class="d-inline-block">- Version: <a href="@BuildInfo.CommitUrl" target="_blank" rel="noopener noreferrer" class="text-muted">@sha</a></span>
         }
     </div>
 </footer>

--- a/BookTracker.Web/Components/Pages/Books/BulkAdd.razor
+++ b/BookTracker.Web/Components/Pages/Books/BulkAdd.razor
@@ -125,18 +125,11 @@
         <div class="card-header bg-white d-flex justify-content-between align-items-center">
             <h2 class="h5 mb-0">Discovered (@VM.Rows.Count)</h2>
             <div class="d-flex gap-2 align-items-center">
-                @if (VM.Rows.Any(r => r.Status == BulkAddViewModel.RowStatus.Found && r.Action == BulkAddViewModel.RowAction.Pending))
+                @if (VM.Rows.Any(r => r.Status == BulkAddViewModel.RowStatus.Found && !r.IsDuplicate))
                 {
                     <button type="button" class="btn btn-success btn-sm" @onclick="VM.AcceptAllFoundAsync">
                         Accept all
                     </button>
-                }
-                @if (VM.Rows.Any(r => r.Action == BulkAddViewModel.RowAction.Accepted || r.Action == BulkAddViewModel.RowAction.FollowUp))
-                {
-                    <span class="text-muted small d-none d-md-inline">
-                        @VM.Rows.Count(r => r.Action == BulkAddViewModel.RowAction.Accepted) accepted,
-                        @VM.Rows.Count(r => r.Action == BulkAddViewModel.RowAction.FollowUp) follow-up
-                    </span>
                 }
             </div>
         </div>
@@ -165,7 +158,7 @@
                                 </td>
                                 <td class="font-monospace small">@row.Isbn</td>
                                 <td>
-                                    @if (row.Status == BulkAddViewModel.RowStatus.NotFound && row.Action != BulkAddViewModel.RowAction.FollowUp)
+                                    @if (row.Status == BulkAddViewModel.RowStatus.NotFound)
                                     {
                                         <input type="text" class="form-control form-control-sm" placeholder="Book title..."
                                                @bind="row.Title" />
@@ -217,7 +210,7 @@
                         <div class="flex-grow-1 min-width-0">
                             <div class="d-flex justify-content-between align-items-start">
                                 <div class="min-width-0">
-                                    @if (row.Status == BulkAddViewModel.RowStatus.NotFound && row.Action != BulkAddViewModel.RowAction.FollowUp)
+                                    @if (row.Status == BulkAddViewModel.RowStatus.NotFound)
                                     {
                                         <input type="text" class="form-control form-control-sm mb-1" placeholder="Book title..."
                                                @bind="row.Title" />
@@ -256,12 +249,6 @@
         </div>
     </div>
 
-    @if (VM.Rows.Any(r => r.Action == BulkAddViewModel.RowAction.Accepted || r.Action == BulkAddViewModel.RowAction.FollowUp))
-    {
-        <div class="d-flex gap-2">
-            <a href="/books" class="btn btn-primary">View library</a>
-        </div>
-    }
 }
 
 @code {
@@ -462,38 +449,30 @@
 
     private RenderFragment RenderStatusBadge(BulkAddViewModel.DiscoveryRow row) => __builder =>
     {
-        switch (row.Action)
+        // Accepted / FollowUp rows are removed from the grid on action, so only
+        // Pending and Duplicate-skip states are reachable here.
+        if (row.Action == BulkAddViewModel.RowAction.Duplicate)
         {
-            case BulkAddViewModel.RowAction.Accepted:
-                <span class="badge bg-success">Accepted</span>
-                break;
-            case BulkAddViewModel.RowAction.FollowUp:
-                <span class="badge bg-warning text-dark">Follow-up</span>
-                break;
-            case BulkAddViewModel.RowAction.Duplicate:
-                <span class="badge bg-secondary">Duplicate</span>
-                break;
-            default:
-                if (row.IsDuplicate)
-                {
-                    <span class="badge bg-warning text-dark">In library</span>
-                }
-                else
-                {
-                    switch (row.Status)
-                    {
-                        case BulkAddViewModel.RowStatus.Found:
-                            <span class="badge bg-info text-dark">Found</span>
-                            break;
-                        case BulkAddViewModel.RowStatus.NotFound:
-                            <span class="badge bg-danger">Not found</span>
-                            break;
-                        case BulkAddViewModel.RowStatus.Searching:
-                            <span class="badge bg-light text-dark">Searching...</span>
-                            break;
-                    }
-                }
-                break;
+            <span class="badge bg-secondary">Duplicate</span>
+        }
+        else if (row.IsDuplicate)
+        {
+            <span class="badge bg-warning text-dark">In library</span>
+        }
+        else
+        {
+            switch (row.Status)
+            {
+                case BulkAddViewModel.RowStatus.Found:
+                    <span class="badge bg-info text-dark">Found</span>
+                    break;
+                case BulkAddViewModel.RowStatus.NotFound:
+                    <span class="badge bg-danger">Not found</span>
+                    break;
+                case BulkAddViewModel.RowStatus.Searching:
+                    <span class="badge bg-light text-dark">Searching...</span>
+                    break;
+            }
         }
     };
 

--- a/BookTracker.Web/ViewModels/BulkAddViewModel.cs
+++ b/BookTracker.Web/ViewModels/BulkAddViewModel.cs
@@ -126,13 +126,13 @@ public class BulkAddViewModel(
     public async Task AcceptRowAsync(DiscoveryRow row)
     {
         await SaveBookAsync(row, followUp: false);
-        row.Action = RowAction.Accepted;
+        Rows.Remove(row);
     }
 
     public async Task FollowUpRowAsync(DiscoveryRow row)
     {
         await SaveBookAsync(row, followUp: true);
-        row.Action = RowAction.FollowUp;
+        Rows.Remove(row);
     }
 
     public async Task FollowUpNotFoundAsync(DiscoveryRow row)
@@ -142,7 +142,7 @@ public class BulkAddViewModel(
             row.Title = $"Unknown book — {row.Isbn}";
         }
         await SaveBookAsync(row, followUp: true);
-        row.Action = RowAction.FollowUp;
+        Rows.Remove(row);
     }
 
     public async Task AcceptAllFoundAsync()


### PR DESCRIPTION
Two small UI/usability tweaks bundled in one PR.

Bulk Add — auto-clear on accept (TODO list item from session). After Accept / Follow-up / Add-as-follow-up, the row now disappears from the discovery grid rather than staying with "Accepted" / "Follow-up" styling. Keeps the list manageable during a long bulk-scan session.

Three accept methods (AcceptRowAsync, FollowUpRowAsync, FollowUpNotFoundAsync) now call Rows.Remove(row) instead of setting row.Action. The Skip-duplicate affordance still sets Action=Duplicate to mark the row as ignored without removing it (intentional — duplicates need to remain visible so the user can revisit).

Markup cleanup: dead UI branches that depended on Accepted/FollowUp rows staying in Rows are removed:
- "N accepted, N follow-up" session counter — never rendered after auto-clear.
- Bottom "View library" button — same. Note: this loses a "go view your new books" affordance after a productive session. If that bites, follow-up is a separate session counter on the VM (kept outside Rows). Per Drew's "just hard remove on accept" instruction, not adding the counter pre-emptively.
- RenderStatusBadge: Accepted/FollowUp cases unreachable; simplified to handle only Duplicate / Pending paths.
- Status==NotFound condition no longer needs && Action!=FollowUp (FollowUp removes the row).

Tests: 4 affected tests updated to assert row removed from vm.Rows after accept/follow-up rather than asserting row.Action set.

Footer wrap on small screens. The newly-added Version SHA line could wrap awkwardly mid-text on narrow viewports. Each footer segment now wraps in a d-inline-block span so the browser breaks between segments rather than mid-section. Inter-segment whitespace is the natural wrap point. Visual stays identical on desktop where the line fits.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
