### PR TITLE
feat(bulk-add): always-visible "Back to home" link at page bottom

### DIFF
--- a/BookTracker.Web/Components/Pages/Books/BulkAdd.razor
+++ b/BookTracker.Web/Components/Pages/Books/BulkAdd.razor
@@ -251,6 +251,13 @@
 
 }
 
+@* Always-visible nav back to Home — Home surfaces the running counts, which is
+   the natural "OK, I'm done capturing" destination after a bulk-add session.
+   Outside the rows-conditional so it's reachable even on a fresh page load. *@
+<div class="mt-3">
+    <a href="/" class="btn btn-outline-secondary">Back to home</a>
+</div>
+
 @code {
     private bool scannerActive;
     private string? scannerError;


### PR DESCRIPTION
Restores the lost-affordance flagged in the previous PR. The hard-remove-on-accept change cleared the bottom "View library" button (which only appeared after the first accept), leaving no visible "I'm done, take me somewhere useful" link after a productive bulk-scan session.

Per Drew's preference: link goes to Home rather than Library — Home surfaces running counts which is more useful as a session-end destination. Always-visible (outside the rows-conditional) so it's reachable on a fresh page load too.

Quiet styling (btn-outline-secondary) since it's nav, not a primary CTA.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
