### PR TITLE
feat/collapsible mobile subtitles

### DIFF
--- a/BookTracker.Web/Components/Layout/MainLayout.razor
+++ b/BookTracker.Web/Components/Layout/MainLayout.razor
@@ -14,14 +14,18 @@
 <MudSnackbarProvider />
 
 <header>
-    <nav class="navbar navbar-expand-sm navbar-toggleable-sm navbar-light bg-white border-bottom box-shadow mb-3">
+    @* navbar-expand-lg: 11 nav items overflow horizontally well before the
+       sm breakpoint (576px) was kicking in the hamburger. lg flips to the
+       collapsed menu below 992px, which is roughly where the items stop
+       fitting alongside the BookTracker brand on a Bootstrap container. *@
+    <nav class="navbar navbar-expand-lg navbar-toggleable-lg navbar-light bg-white border-bottom box-shadow mb-3">
         <div class="container">
             <a class="navbar-brand" href="/">BookTracker</a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target=".navbar-collapse" aria-controls="navbarSupportedContent"
                     aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>
-            <div class="navbar-collapse collapse d-sm-inline-flex justify-content-between">
+            <div class="navbar-collapse collapse d-lg-inline-flex justify-content-between">
                 <ul class="navbar-nav flex-grow-1">
                     <li class="nav-item">
                         <NavLink class="nav-link text-dark" href="" Match="NavLinkMatch.All">Home</NavLink>

--- a/BookTracker.Web/Components/Pages/Authors/Index.razor
+++ b/BookTracker.Web/Components/Pages/Authors/Index.razor
@@ -14,11 +14,13 @@
 <MudContainer MaxWidth="MaxWidth.Large" Class="py-3">
 
     <MudText Typo="Typo.h4" Class="mb-2">Authors</MudText>
-    <MudText Typo="Typo.body2" Color="Color.Secondary" Class="mb-3">
-        Each author has its own row. Pen names are linked back to a canonical author so aggregations
-        (top-authors stats, author filter) roll the totals together. Stephen King's tally includes
-        his Bachman titles when you mark Bachman as an alias of King.
-    </MudText>
+    <CollapsibleSubtitle>
+        <MudText Typo="Typo.body2" Color="Color.Secondary" Class="mb-3">
+            Each author has its own row. Pen names are linked back to a canonical author so aggregations
+            (top-authors stats, author filter) roll the totals together. Stephen King's tally includes
+            his Bachman titles when you mark Bachman as an alias of King.
+        </MudText>
+    </CollapsibleSubtitle>
 
     @if (!string.IsNullOrEmpty(VM.SuccessMessage))
     {

--- a/BookTracker.Web/Components/Pages/Duplicates/Index.razor
+++ b/BookTracker.Web/Components/Pages/Duplicates/Index.razor
@@ -6,15 +6,17 @@
 <PageTitle>Duplicates - BookTracker</PageTitle>
 
 <h1 class="mb-3">Duplicates</h1>
-<p class="text-muted">
-    Candidate duplicate pairs detected across Authors, Works, Books, and Editions.
-    Authors match either on normalised full name or on shared surname + first-name
-    initial (so "Doug Preston" / "Douglas Preston" / "D Preston" surface together).
-    Works, Books, and Editions need an exact match after normalisation — edit a
-    name or title to line them up if one you expect is missing. Merge actions
-    arrive in the next release; for now you can dismiss false positives (and
-    un-ignore them later).
-</p>
+<CollapsibleSubtitle>
+    <p class="text-muted">
+        Candidate duplicate pairs detected across Authors, Works, Books, and Editions.
+        Authors match either on normalised full name or on shared surname + first-name
+        initial (so "Doug Preston" / "Douglas Preston" / "D Preston" surface together).
+        Works, Books, and Editions need an exact match after normalisation — edit a
+        name or title to line them up if one you expect is missing. Merge actions
+        arrive in the next release; for now you can dismiss false positives (and
+        un-ignore them later).
+    </p>
+</CollapsibleSubtitle>
 
 @if (!string.IsNullOrEmpty(VM.SuccessMessage))
 {

--- a/BookTracker.Web/Components/Pages/Publishers/Index.razor
+++ b/BookTracker.Web/Components/Pages/Publishers/Index.razor
@@ -14,11 +14,13 @@
 <MudContainer MaxWidth="MaxWidth.Large" Class="py-3">
 
     <MudText Typo="Typo.h4" Class="mb-2">Publishers</MudText>
-    <MudText Typo="Typo.body2" Color="Color.Secondary" Class="mb-3">
-        Every publisher that currently attaches to an edition. Rename in place to fix typos, delete when
-        nothing references a publisher, or merge "Tor" into "Tor Books" (or vice-versa) to collapse
-        duplicates — the target absorbs all editions and the source is deleted.
-    </MudText>
+    <CollapsibleSubtitle>
+        <MudText Typo="Typo.body2" Color="Color.Secondary" Class="mb-3">
+            Every publisher that currently attaches to an edition. Rename in place to fix typos, delete when
+            nothing references a publisher, or merge "Tor" into "Tor Books" (or vice-versa) to collapse
+            duplicates — the target absorbs all editions and the source is deleted.
+        </MudText>
+    </CollapsibleSubtitle>
 
     @if (!string.IsNullOrEmpty(VM.SuccessMessage))
     {

--- a/BookTracker.Web/Components/Shared/CollapsibleSubtitle.razor
+++ b/BookTracker.Web/Components/Shared/CollapsibleSubtitle.razor
@@ -7,25 +7,24 @@
    (MudText, <p class="text-muted">, etc.) as ChildContent. The component
    just owns the show/hide mechanism.
 
-   Per-instance state — collapse resets on navigation. Intentional: subtitle
-   text is reference, not stateful, so the cost of re-tapping on a fresh
-   page-load is small relative to the cost of a stuck-open subtitle eating
-   viewport for a user who's already read it once. *@
+   Single-element shape with a custom CSS class (defined in site.css) instead
+   of Bootstrap's `d-md-block` / `d-md-none` paired siblings. Earlier shape
+   produced a dead-zone at certain widths where neither sibling was visible —
+   custom class pins the breakpoint to one rule we own and removes the
+   cascade-ordering dependency.
 
-<div class="d-none d-md-block">
+   Per-instance state — collapse resets on navigation. Subtitle text is
+   reference, not stateful, so re-tapping on a fresh page-load is a small
+   cost relative to a stuck-open subtitle eating viewport for someone who's
+   already read it. *@
+
+<button type="button"
+        class="collapsible-subtitle__toggle btn btn-link btn-sm p-0 text-muted text-decoration-none mb-2"
+        @onclick="Toggle">
+    @(expanded ? "▾" : "▸") @Label
+</button>
+<div class="collapsible-subtitle__content @(expanded ? "is-expanded" : "")">
     @ChildContent
-</div>
-
-<div class="d-md-none mb-3">
-    <button type="button" class="btn btn-link btn-sm p-0 text-muted text-decoration-none" @onclick="Toggle">
-        @(expanded ? "▾" : "▸") @Label
-    </button>
-    @if (expanded)
-    {
-        <div class="mt-2">
-            @ChildContent
-        </div>
-    }
 </div>
 
 @code {

--- a/BookTracker.Web/Components/Shared/CollapsibleSubtitle.razor
+++ b/BookTracker.Web/Components/Shared/CollapsibleSubtitle.razor
@@ -1,0 +1,43 @@
+@* Hides descriptive page subtitles behind a toggle button on mobile (collapsed
+   by default) while keeping them always-visible on desktop. Pages now lean on
+   long subtitle paragraphs for context — useful on a wide screen, but they
+   eat the top of a phone viewport before the actual content shows.
+
+   Content-agnostic: the caller passes whatever markup fits their styling
+   (MudText, <p class="text-muted">, etc.) as ChildContent. The component
+   just owns the show/hide mechanism.
+
+   Per-instance state — collapse resets on navigation. Intentional: subtitle
+   text is reference, not stateful, so the cost of re-tapping on a fresh
+   page-load is small relative to the cost of a stuck-open subtitle eating
+   viewport for a user who's already read it once. *@
+
+<div class="d-none d-md-block">
+    @ChildContent
+</div>
+
+<div class="d-md-none mb-3">
+    <button type="button" class="btn btn-link btn-sm p-0 text-muted text-decoration-none" @onclick="Toggle">
+        @(expanded ? "▾" : "▸") @Label
+    </button>
+    @if (expanded)
+    {
+        <div class="mt-2">
+            @ChildContent
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter, EditorRequired] public RenderFragment ChildContent { get; set; } = default!;
+
+    /// <summary>
+    /// Toggle-button label. Defaults to "About this page" — generic enough to fit
+    /// any descriptive subtitle. Override for pages where a more specific label
+    /// reads better.
+    /// </summary>
+    [Parameter] public string Label { get; set; } = "About this page";
+
+    private bool expanded;
+    private void Toggle() => expanded = !expanded;
+}

--- a/BookTracker.Web/wwwroot/css/site.css
+++ b/BookTracker.Web/wwwroot/css/site.css
@@ -132,3 +132,20 @@ body {
   transform: translateY(-2px);
 }
 }
+
+/* CollapsibleSubtitle component — descriptive page subtitles that collapse
+   behind a toggle button below 768px and stay always-visible above it.
+   The breakpoint is pinned in one place we own (rather than relying on
+   Bootstrap's d-md-* utility ordering in the cascade) to avoid a dead-zone
+   at intermediate widths where neither paired sibling was visible. */
+.collapsible-subtitle__toggle {
+  display: none;
+}
+@media (max-width: 767.98px) {
+  .collapsible-subtitle__toggle {
+    display: inline-block;
+  }
+  .collapsible-subtitle__content:not(.is-expanded) {
+    display: none;
+  }
+}


### PR DESCRIPTION
- **feat(ui): collapsible page subtitles on mobile**
- **fix(ui): pin CollapsibleSubtitle breakpoint to single owned CSS rule**
- **fix(ui): expand navbar to lg breakpoint to avoid horizontal overflow**
