### PR TITLE
feat(library): MudBlazor migration for /books

### DIFF
--- a/BookTracker.Web/Components/Pages/Books/List.razor
+++ b/BookTracker.Web/Components/Pages/Books/List.razor
@@ -4,165 +4,196 @@
 
 <PageTitle>Library - BookTracker</PageTitle>
 
-<h1 class="mb-3">Library</h1>
+@* MudBlazor migration. Filter card stays inline-visible on desktop (most-used
+   page; filters are core); on mobile the secondary filters collapse behind a
+   toggle while search stays exposed. Flat list and grouped accordion both
+   render through one shared book-row template — desktop MudTable, mobile
+   custom card row. ViewModel is unchanged; this is presentation only. *@
 
-<div class="card mb-4">
-    <div class="card-body">
-        <div class="row g-3 align-items-end">
-            <div class="col-12 col-md-3">
-                <label class="form-label small text-muted">Search</label>
-                <input type="text" class="form-control" placeholder="Title or author..." @bind="VM.SearchTerm" @bind:event="oninput" @onkeyup="HandleSearchKeyUp" />
-            </div>
-            <div class="col-6 col-md-1 d-md-none">
-                <button type="button" class="btn btn-outline-secondary w-100" @onclick="() => showFilters = !showFilters">
-                    Filters @(showFilters ? "▲" : "▼")
-                </button>
-            </div>
-            <div class="col-6 col-md-1 d-md-none">
-                <button type="button" class="btn btn-outline-secondary w-100" @onclick="VM.ClearFiltersAsync" title="Clear filters">
+<MudContainer MaxWidth="MaxWidth.Large" Class="py-3">
+
+    <MudText Typo="Typo.h4" Class="mb-3">Library</MudText>
+
+    @* Filter card *@
+    <MudPaper Elevation="1" Class="pa-3 mb-3">
+        <MudGrid Spacing="2">
+            <MudItem xs="12" md="3">
+                <MudTextField T="string"
+                              Value="@VM.SearchTerm"
+                              ValueChanged="@OnSearchTermChanged"
+                              Variant="Variant.Outlined"
+                              Margin="Margin.Dense"
+                              Label="Search"
+                              Placeholder="Title or author..."
+                              Adornment="Adornment.Start"
+                              AdornmentIcon="@Icons.Material.Filled.Search"
+                              Immediate="true"
+                              OnKeyUp="HandleSearchKeyUp" />
+            </MudItem>
+
+            @* Mobile-only filter toggle row *@
+            <MudItem xs="6" Class="d-md-none">
+                <MudButton OnClick="@(() => showFilters = !showFilters)"
+                           Variant="Variant.Outlined"
+                           FullWidth="true"
+                           EndIcon="@(showFilters ? Icons.Material.Filled.ExpandLess : Icons.Material.Filled.ExpandMore)">
+                    Filters
+                </MudButton>
+            </MudItem>
+            <MudItem xs="6" Class="d-md-none">
+                <MudButton OnClick="VM.ClearFiltersAsync"
+                           Variant="Variant.Outlined"
+                           FullWidth="true">
                     Clear
-                </button>
-            </div>
-            <div class="@FilterPanelCss">
-                <div class="row g-3 align-items-end">
-                    <div class="col-6 col-md">
-                        <label class="form-label small text-muted">Group by</label>
-                        <select class="form-select" @bind="GroupBySelected" @bind:after="ChangeGroupingAsync">
-                            <option value="@LibraryGroupBy.Author">Author</option>
-                            <option value="@LibraryGroupBy.Genre">Genre</option>
-                            <option value="@LibraryGroupBy.Collection">Series / Collection</option>
-                            <option value="@LibraryGroupBy.None">None (flat list)</option>
-                        </select>
-                    </div>
-                    <div class="col-6 col-md">
-                        <label class="form-label small text-muted">Category</label>
-                        <select class="form-select" @bind="VM.SelectedCategory" @bind:after="() => VM.ApplyFiltersAsync()">
-                            <option value="">All</option>
-                            <option value="Fiction">Fiction</option>
-                            <option value="NonFiction">Non-Fiction</option>
-                        </select>
-                    </div>
-                    <div class="col-6 col-md">
-                        <label class="form-label small text-muted">Genre</label>
-                        <select class="form-select" @bind="VM.SelectedGenreId" @bind:after="() => VM.ApplyFiltersAsync()">
-                            <option value="0">All</option>
+                </MudButton>
+            </MudItem>
+
+            @* Secondary filters — always visible on desktop, collapsible on mobile *@
+            <MudItem xs="12" md="9" Class="@(showFilters ? "" : "d-none d-md-block")">
+                <MudGrid Spacing="2">
+                    <MudItem xs="6" md="2">
+                        <MudSelect T="LibraryGroupBy"
+                                   Value="@GroupBySelected"
+                                   ValueChanged="@OnGroupByChanged"
+                                   Label="Group by"
+                                   Variant="Variant.Outlined"
+                                   Margin="Margin.Dense"
+                                   Dense="true">
+                            <MudSelectItem Value="@LibraryGroupBy.Author">Author</MudSelectItem>
+                            <MudSelectItem Value="@LibraryGroupBy.Genre">Genre</MudSelectItem>
+                            <MudSelectItem Value="@LibraryGroupBy.Collection">Series / Collection</MudSelectItem>
+                            <MudSelectItem Value="@LibraryGroupBy.None">None (flat list)</MudSelectItem>
+                        </MudSelect>
+                    </MudItem>
+                    <MudItem xs="6" md="2">
+                        <MudSelect T="string"
+                                   Value="@VM.SelectedCategory"
+                                   ValueChanged="@OnCategoryChanged"
+                                   Label="Category"
+                                   Variant="Variant.Outlined"
+                                   Margin="Margin.Dense"
+                                   Dense="true">
+                            <MudSelectItem Value="@("")">All</MudSelectItem>
+                            <MudSelectItem Value="@("Fiction")">Fiction</MudSelectItem>
+                            <MudSelectItem Value="@("NonFiction")">Non-Fiction</MudSelectItem>
+                        </MudSelect>
+                    </MudItem>
+                    <MudItem xs="6" md="2">
+                        <MudSelect T="int"
+                                   Value="@VM.SelectedGenreId"
+                                   ValueChanged="@OnGenreChanged"
+                                   Label="Genre"
+                                   Variant="Variant.Outlined"
+                                   Margin="Margin.Dense"
+                                   Dense="true">
+                            <MudSelectItem Value="0">All</MudSelectItem>
                             @foreach (var g in VM.AllGenres)
                             {
-                                var prefix = g.ParentGenreId.HasValue ? "\u00A0\u00A0\u00A0\u00A0" : "";
-                                <option value="@g.Id">@prefix@g.Name</option>
+                                @* NBSPs preserve the parent/child indent inside the dropdown. *@
+                                var prefix = g.ParentGenreId.HasValue ? "    " : "";
+                                <MudSelectItem Value="@g.Id">@($"{prefix}{g.Name}")</MudSelectItem>
                             }
-                        </select>
-                    </div>
-                    <div class="col-6 col-md">
-                        <label class="form-label small text-muted">Tag</label>
-                        <select class="form-select" @bind="VM.SelectedTagId" @bind:after="() => VM.ApplyFiltersAsync()">
-                            <option value="0">All</option>
+                        </MudSelect>
+                    </MudItem>
+                    <MudItem xs="6" md="2">
+                        <MudSelect T="int"
+                                   Value="@VM.SelectedTagId"
+                                   ValueChanged="@OnTagChanged"
+                                   Label="Tag"
+                                   Variant="Variant.Outlined"
+                                   Margin="Margin.Dense"
+                                   Dense="true">
+                            <MudSelectItem Value="0">All</MudSelectItem>
                             @foreach (var t in VM.AllTags)
                             {
-                                <option value="@t.Id">@t.Name</option>
+                                <MudSelectItem Value="@t.Id">@t.Name</MudSelectItem>
                             }
-                        </select>
-                    </div>
-                    <div class="col-6 col-md">
-                        <label class="form-label small text-muted">Author</label>
-                        <input type="text" class="form-control" placeholder="Author..." list="author-filter-options" @bind="VM.SelectedAuthor" @bind:after="() => VM.ApplyFiltersAsync()" />
-                        <datalist id="author-filter-options">
-                            @foreach (var a in VM.AllAuthors)
-                            {
-                                <option value="@a"></option>
-                            }
-                        </datalist>
-                    </div>
-                </div>
-            </div>
-            <div class="col-md-1 d-none d-md-block">
-                <button type="button" class="btn btn-outline-secondary w-100" @onclick="VM.ClearFiltersAsync" title="Clear filters">
-                    <span aria-hidden="true">&times;</span>
-                </button>
-            </div>
-        </div>
-    </div>
-</div>
+                        </MudSelect>
+                    </MudItem>
+                    <MudItem xs="12" md="3">
+                        <MudAutocomplete T="string"
+                                         Value="@VM.SelectedAuthor"
+                                         ValueChanged="@OnAuthorChanged"
+                                         SearchFunc="@SearchAuthors"
+                                         Label="Author"
+                                         Variant="Variant.Outlined"
+                                         Margin="Margin.Dense"
+                                         Dense="true"
+                                         Clearable="true"
+                                         CoerceValue="true" />
+                    </MudItem>
+                    <MudItem xs="12" md="1" Class="d-none d-md-flex">
+                        <MudIconButton OnClick="VM.ClearFiltersAsync"
+                                       Icon="@Icons.Material.Filled.Clear"
+                                       title="Clear filters"
+                                       Color="Color.Default"
+                                       Variant="Variant.Outlined" />
+                    </MudItem>
+                </MudGrid>
+            </MudItem>
+        </MudGrid>
+    </MudPaper>
 
-@if (VM.Loading)
-{
-    <div class="text-center py-5">
-        <div class="spinner-border" role="status"><span class="visually-hidden">Loading...</span></div>
-    </div>
-}
-else if (VM.SelectedGroupBy == LibraryGroupBy.None)
-{
-    @* Flat list — original behaviour *@
-    @if (VM.Books.Count == 0)
+    @if (VM.Loading)
     {
-        <div class="text-center py-5 text-muted">
-            <p class="mb-2">No books found.</p>
-            <a href="/books/add" class="btn btn-primary btn-sm">Add your first book</a>
-        </div>
+        <MudStack AlignItems="AlignItems.Center" Class="py-5">
+            <MudProgressCircular Indeterminate="true" />
+        </MudStack>
     }
-    else
+    else if (VM.SelectedGroupBy == LibraryGroupBy.None)
     {
-        @RenderBooks(VM.Books)
-
-        @if (VM.TotalPages > 1)
+        @if (VM.Books.Count == 0)
         {
-            <nav aria-label="Book list pagination" class="mt-3">
-                <ul class="pagination pagination-sm justify-content-center">
-                    <li class="page-item @(VM.CurrentPage <= 1 ? "disabled" : "")">
-                        <button class="page-link" @onclick="() => VM.GoToPageAsync(VM.CurrentPage - 1)" disabled="@(VM.CurrentPage <= 1)">Prev</button>
-                    </li>
-                    @for (int p = 1; p <= VM.TotalPages; p++)
-                    {
-                        var pageNum = p;
-                        <li class="page-item @(pageNum == VM.CurrentPage ? "active" : "")">
-                            <button class="page-link" @onclick="() => VM.GoToPageAsync(pageNum)">@(pageNum)</button>
-                        </li>
-                    }
-                    <li class="page-item @(VM.CurrentPage >= VM.TotalPages ? "disabled" : "")">
-                        <button class="page-link" @onclick="() => VM.GoToPageAsync(VM.CurrentPage + 1)" disabled="@(VM.CurrentPage >= VM.TotalPages)">Next</button>
-                    </li>
-                </ul>
-            </nav>
+            @RenderEmptyState
         }
+        else
+        {
+            @RenderBooks(VM.Books)
 
-        <div class="text-center text-muted small mb-3">
-            Showing @((VM.CurrentPage - 1) * BookListViewModel.PageSize + 1)–@Math.Min(VM.CurrentPage * BookListViewModel.PageSize, VM.TotalCount) of @VM.TotalCount books
-        </div>
-    }
-}
-else
-{
-    @* Grouped accordion view *@
-    @if (VM.Groups.Count == 0)
-    {
-        <div class="text-center py-5 text-muted">
-            <p class="mb-2">No books found.</p>
-            <a href="/books/add" class="btn btn-primary btn-sm">Add your first book</a>
-        </div>
+            @if (VM.TotalPages > 1)
+            {
+                <MudStack AlignItems="AlignItems.Center" Class="my-3">
+                    <MudPagination Count="@VM.TotalPages"
+                                   Selected="@VM.CurrentPage"
+                                   SelectedChanged="@OnPageChanged" />
+                </MudStack>
+            }
+
+            <MudText Typo="Typo.body2" Color="Color.Secondary" Align="Align.Center" Class="mb-3">
+                Showing @((VM.CurrentPage - 1) * BookListViewModel.PageSize + 1)–@Math.Min(VM.CurrentPage * BookListViewModel.PageSize, VM.TotalCount) of @VM.TotalCount books
+            </MudText>
+        }
     }
     else
     {
-        <div class="accordion">
-            @foreach (var group in VM.Groups)
-            {
-                var isOpen = VM.ExpandedGroupKeys.Contains(group.Key);
-                var loaded = VM.LoadedGroups.GetValueOrDefault(group.Key);
-                <div class="accordion-item">
-                    <h2 class="accordion-header">
-                        <button class="accordion-button @(isOpen ? "" : "collapsed")" type="button" @onclick="() => VM.ToggleGroupAsync(group.Key)">
-                            <span class="fw-semibold">@group.Label</span>
-                            <span class="badge bg-light text-dark border ms-2">@group.Count book@(group.Count == 1 ? "" : "s")</span>
-                        </button>
-                    </h2>
-                    @if (isOpen)
-                    {
-                        <div class="accordion-collapse collapse show">
-                            <div class="accordion-body p-0">
-                                @if (loaded is null)
+        @if (VM.Groups.Count == 0)
+        {
+            @RenderEmptyState
+        }
+        else
+        {
+            <MudExpansionPanels MultiExpansion="true" Elevation="1">
+                @foreach (var group in VM.Groups)
+                {
+                    var key = group.Key;
+                    var isOpen = VM.ExpandedGroupKeys.Contains(key);
+                    var loaded = VM.LoadedGroups.GetValueOrDefault(key);
+                    <MudExpansionPanel Expanded="@isOpen"
+                                       ExpandedChanged="@(v => OnGroupExpandChanged(v, key))">
+                        <TitleContent>
+                            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+                                <MudText Typo="Typo.body1" Style="font-weight: 500;" Class="flex-grow-1">@group.Label</MudText>
+                                <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined">@($"{group.Count} book{(group.Count == 1 ? "" : "s")}")</MudChip>
+                            </MudStack>
+                        </TitleContent>
+                        <ChildContent>
+                            @if (isOpen)
+                            {
+                                if (loaded is null)
                                 {
-                                    <div class="text-center py-3">
-                                        <div class="spinner-border spinner-border-sm" role="status"><span class="visually-hidden">Loading...</span></div>
-                                    </div>
+                                    <MudStack AlignItems="AlignItems.Center" Class="py-3">
+                                        <MudProgressCircular Indeterminate="true" Size="Size.Small" />
+                                    </MudStack>
                                 }
                                 else
                                 {
@@ -170,40 +201,39 @@ else
 
                                     @if (loaded.TotalPages > 1)
                                     {
-                                        <nav class="d-flex justify-content-center py-2 border-top">
-                                            <ul class="pagination pagination-sm mb-0">
-                                                <li class="page-item @(loaded.Page <= 1 ? "disabled" : "")">
-                                                    <button class="page-link" @onclick="() => VM.LoadGroupBooksAsync(group.Key, loaded.Page - 1)" disabled="@(loaded.Page <= 1)">Prev</button>
-                                                </li>
-                                                <li class="page-item disabled"><span class="page-link">@loaded.Page / @loaded.TotalPages</span></li>
-                                                <li class="page-item @(loaded.Page >= loaded.TotalPages ? "disabled" : "")">
-                                                    <button class="page-link" @onclick="() => VM.LoadGroupBooksAsync(group.Key, loaded.Page + 1)" disabled="@(loaded.Page >= loaded.TotalPages)">Next</button>
-                                                </li>
-                                            </ul>
-                                        </nav>
+                                        <MudStack AlignItems="AlignItems.Center" Class="py-2">
+                                            <MudPagination Count="@loaded.TotalPages"
+                                                           Selected="@loaded.Page"
+                                                           SelectedChanged="@(p => VM.LoadGroupBooksAsync(key, p))" />
+                                        </MudStack>
                                     }
                                 }
-                            </div>
-                        </div>
-                    }
-                </div>
-            }
-        </div>
+                            }
+                        </ChildContent>
+                    </MudExpansionPanel>
+                }
+            </MudExpansionPanels>
+        }
     }
-}
+
+</MudContainer>
 
 @code {
     private bool showFilters;
     private LibraryGroupBy GroupBySelected { get; set; } = LibraryGroupBy.Author;
 
-    private string FilterPanelCss => showFilters
-        ? "col-12 mt-2 d-md-contents"
-        : "col-12 mt-2 d-none d-md-contents";
-
     protected override async Task OnInitializedAsync()
     {
         await VM.InitializeAsync();
         GroupBySelected = VM.SelectedGroupBy;
+    }
+
+    private async Task OnSearchTermChanged(string value)
+    {
+        // Match the legacy "type updates state, Enter triggers query" UX —
+        // we update SearchTerm on each keystroke (Immediate="true") but
+        // ApplyFiltersAsync is only called from HandleSearchKeyUp on Enter.
+        VM.SearchTerm = value ?? "";
     }
 
     private async Task HandleSearchKeyUp(KeyboardEventArgs e)
@@ -212,79 +242,132 @@ else
             await VM.ApplyFiltersAsync();
     }
 
-    private async Task ChangeGroupingAsync()
+    private async Task OnGroupByChanged(LibraryGroupBy value)
     {
-        await VM.ChangeGroupingAsync(GroupBySelected);
+        GroupBySelected = value;
+        await VM.ChangeGroupingAsync(value);
+    }
+
+    private async Task OnCategoryChanged(string value)
+    {
+        VM.SelectedCategory = value ?? "";
+        await VM.ApplyFiltersAsync();
+    }
+
+    private async Task OnGenreChanged(int value)
+    {
+        VM.SelectedGenreId = value;
+        await VM.ApplyFiltersAsync();
+    }
+
+    private async Task OnTagChanged(int value)
+    {
+        VM.SelectedTagId = value;
+        await VM.ApplyFiltersAsync();
+    }
+
+    private async Task OnAuthorChanged(string value)
+    {
+        VM.SelectedAuthor = value ?? "";
+        await VM.ApplyFiltersAsync();
+    }
+
+    private Task<IEnumerable<string>> SearchAuthors(string value, CancellationToken token)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return Task.FromResult<IEnumerable<string>>(VM.AllAuthors.Take(20));
+
+        return Task.FromResult<IEnumerable<string>>(
+            VM.AllAuthors
+                .Where(a => a.Contains(value, StringComparison.OrdinalIgnoreCase))
+                .Take(20));
+    }
+
+    private async Task OnPageChanged(int page)
+    {
+        await VM.GoToPageAsync(page);
+    }
+
+    private async Task OnGroupExpandChanged(bool isExpanded, string key)
+    {
+        var alreadyExpanded = VM.ExpandedGroupKeys.Contains(key);
+        if (isExpanded != alreadyExpanded)
+        {
+            await VM.ToggleGroupAsync(key);
+        }
     }
 
     private void NavigateToBook(int bookId) => Nav.NavigateTo($"/books/{bookId}");
 
+    private RenderFragment RenderEmptyState =>
+    @<text>
+        <MudStack AlignItems="AlignItems.Center" Class="py-5">
+            <MudText Color="Color.Secondary" Class="mb-2">No books found.</MudText>
+            <MudButton Href="/books/add" Variant="Variant.Filled" Color="Color.Primary" Size="Size.Small">
+                Add your first book
+            </MudButton>
+        </MudStack>
+    </text>;
+
     private RenderFragment RenderBooks(IReadOnlyList<BookListViewModel.BookListItem> books) =>
     @<text>
         @* Desktop table — hidden on mobile *@
-        <div class="d-none d-md-block table-responsive">
-            <table class="table table-hover align-middle mb-0">
-                <thead class="table-light">
-                    <tr>
-                        <th style="width: 60px;"></th>
-                        <th>Title</th>
-                        <th>Author</th>
-                        <th>Genres</th>
-                        <th>Tags</th>
-                        <th>Status</th>
-                        <th style="width: 110px;">Rating</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    @foreach (var book in books)
-                    {
-                        <tr role="button" @onclick="() => NavigateToBook(book.Id)" style="cursor: pointer;">
-                            <td>
-                                @if (!string.IsNullOrWhiteSpace(book.CoverUrl))
-                                {
-                                    <img src="@book.CoverUrl" alt="" class="rounded" style="width: 40px; height: 56px; object-fit: cover;" />
-                                }
-                                else
-                                {
-                                    <div class="rounded bg-light d-flex align-items-center justify-content-center" style="width: 40px; height: 56px;">
-                                        <span class="text-muted small">--</span>
-                                    </div>
-                                }
-                            </td>
-                            <td>
-                                <div class="fw-semibold">@book.Title</div>
-                                @if (!string.IsNullOrWhiteSpace(book.Subtitle))
-                                {
-                                    <div class="text-muted small">@book.Subtitle</div>
-                                }
-                            </td>
-                            <td>@book.Author</td>
-                            <td>
-                                @foreach (var genre in book.Genres)
-                                {
-                                    <span class="badge bg-light text-dark border me-1 mb-1">@genre</span>
-                                }
-                            </td>
-                            <td>
-                                @foreach (var tag in book.Tags)
-                                {
-                                    <span class="badge bg-info text-dark me-1 mb-1">@tag</span>
-                                }
-                            </td>
-                            <td>
-                                <span class="badge @BookListViewModel.StatusBadgeClass(book.Status)">@book.Status</span>
-                            </td>
-                            <td>
-                                @for (int i = 1; i <= 5; i++)
-                                {
-                                    var filled = i <= book.Rating;
-                                    <span class="@(filled ? "text-warning" : "text-muted")" style="font-size: 0.85rem;">&#9733;</span>
-                                }
-                            </td>
-                        </tr>
-                    }
-                </tbody>
-            </table>
+        <div class="d-none d-md-block">
+            <MudTable Items="@books"
+                      Hover="true"
+                      Elevation="0"
+                      OnRowClick="@((TableRowClickEventArgs<BookListViewModel.BookListItem> e) => NavigateToBook(e.Item!.Id))"
+                      RowStyle="cursor: pointer;">
+                <HeaderContent>
+                    <MudTh Style="width: 60px;"></MudTh>
+                    <MudTh>Title</MudTh>
+                    <MudTh>Author</MudTh>
+                    <MudTh>Genres</MudTh>
+                    <MudTh>Tags</MudTh>
+                    <MudTh>Status</MudTh>
+                    <MudTh Style="width: 130px;">Rating</MudTh>
+                </HeaderContent>
+                <RowTemplate>
+                    <MudTd>
+                        @if (!string.IsNullOrWhiteSpace(context.CoverUrl))
+                        {
+                            <img src="@context.CoverUrl" alt="" class="rounded" style="width: 40px; height: 56px; object-fit: cover;" />
+                        }
+                        else
+                        {
+                            <div class="rounded d-flex align-items-center justify-content-center" style="width: 40px; height: 56px; background: rgba(0,0,0,0.05);">
+                                <MudText Typo="Typo.caption" Color="Color.Secondary">--</MudText>
+                            </div>
+                        }
+                    </MudTd>
+                    <MudTd>
+                        <MudText Style="font-weight: 500;">@context.Title</MudText>
+                        @if (!string.IsNullOrWhiteSpace(context.Subtitle))
+                        {
+                            <MudText Typo="Typo.body2" Color="Color.Secondary">@context.Subtitle</MudText>
+                        }
+                    </MudTd>
+                    <MudTd>@context.Author</MudTd>
+                    <MudTd>
+                        @foreach (var genre in context.Genres)
+                        {
+                            <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined" Class="mr-1 mb-1">@genre</MudChip>
+                        }
+                    </MudTd>
+                    <MudTd>
+                        @foreach (var tag in context.Tags)
+                        {
+                            <MudChip T="string" Size="Size.Small" Color="Color.Info" Variant="Variant.Filled" Class="mr-1 mb-1">@tag</MudChip>
+                        }
+                    </MudTd>
+                    <MudTd>
+                        <MudChip T="string" Size="Size.Small" Color="@StatusColor(context.Status)">@context.Status.ToString()</MudChip>
+                    </MudTd>
+                    <MudTd>
+                        <MudRating ReadOnly="true" SelectedValue="@context.Rating" MaxValue="5" Size="Size.Small" />
+                    </MudTd>
+                </RowTemplate>
+            </MudTable>
         </div>
 
         @* Mobile card layout — hidden on desktop *@
@@ -298,24 +381,28 @@ else
                     }
                     else
                     {
-                        <div class="rounded bg-light d-flex align-items-center justify-content-center flex-shrink-0" style="width: 48px; height: 68px;">
-                            <span class="text-muted small">--</span>
+                        <div class="rounded d-flex align-items-center justify-content-center flex-shrink-0" style="width: 48px; height: 68px; background: rgba(0,0,0,0.05);">
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">--</MudText>
                         </div>
                     }
                     <div class="flex-grow-1 min-width-0">
-                        <div class="fw-semibold text-truncate">@book.Title</div>
-                        <div class="text-muted small">@book.Author</div>
-                        <div class="mt-1 d-flex flex-wrap gap-1 align-items-center">
-                            <span class="badge @BookListViewModel.StatusBadgeClass(book.Status)">@book.Status</span>
-                            @for (int i = 1; i <= 5; i++)
-                            {
-                                var filled = i <= book.Rating;
-                                <span class="@(filled ? "text-warning" : "text-muted")" style="font-size: 0.75rem;">&#9733;</span>
-                            }
-                        </div>
+                        <MudText Style="font-weight: 500; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">@book.Title</MudText>
+                        <MudText Typo="Typo.body2" Color="Color.Secondary">@book.Author</MudText>
+                        <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center" Class="mt-1" Wrap="Wrap.Wrap">
+                            <MudChip T="string" Size="Size.Small" Color="@StatusColor(book.Status)">@book.Status.ToString()</MudChip>
+                            <MudRating ReadOnly="true" SelectedValue="@book.Rating" MaxValue="5" Size="Size.Small" />
+                        </MudStack>
                     </div>
                 </div>
             }
         </div>
     </text>;
+
+    private static Color StatusColor(BookStatus status) => status switch
+    {
+        BookStatus.Reading => Color.Primary,
+        BookStatus.Read => Color.Success,
+        BookStatus.Unread => Color.Default,
+        _ => Color.Default
+    };
 }


### PR DESCRIPTION
Library page rewritten in MudBlazor to match the warm leather/brass palette
already in use on Home, Authors, Publishers, BookDetail. Most-used page,
so the rewrite is markup-only — ViewModel is untouched, all 7
BookListViewModelTests stay green, behaviour is preserved.

Surface-by-surface mapping:
- Page wrapper: <MudContainer MaxWidth="Large">.
- Title: <MudText Typo="h4">.
- Filter card: <MudPaper> with <MudGrid>. Always-visible on desktop;
  on mobile, the secondary filters collapse behind a toggle button
  (showFilters bool) while search stays exposed. Mobile-toggle and
  mobile-clear buttons are mobile-only via d-md-none.
- Search: <MudTextField> with Variant.Outlined, search icon adornment,
  Immediate=true so each keystroke updates SearchTerm without firing
  a query — Enter is still the trigger, matching the legacy UX.
- Group by / Category / Genre / Tag: <MudSelect> with Variant.Outlined.
  Genre keeps the parent/child indent via 4×NBSP prefix on child items.
- Author: <MudAutocomplete> with SearchFunc — replaces the legacy
  <datalist> for a much better mobile experience. Coerces typed
  values, clearable.
- Clear-all: <MudIconButton> with Clear icon on desktop, full-width
  <MudButton> on mobile (matches legacy mobile shape).
- Loading: <MudProgressCircular> centered in <MudStack>.
- Empty state: <MudStack> centered with link to /books/add.
- Flat list desktop: <MudTable> with click-row navigation. RowStyle
  cursor:pointer, Hover=true. Cover thumbnail + title/subtitle +
  author + genre/tag chips + status chip + <MudRating> read-only.
- Flat list mobile: kept the existing custom card layout (lighter
  than rebuilding each row in a Mud component); just the inner
  pieces (chip, rating) swap to MudBlazor for theme consistency.
  .book-card-mobile CSS class still applies (border-bottom +
  padding) so the visual rhythm is preserved.
- Flat-list pagination: <MudPagination> — replaces the custom <ul>
  with full page-number list. MudPagination truncates intelligently
  (1, 2, 3, …, 50) which matters as the library scales toward the
  3000+ copies target.
- "Showing X–Y of N" caption: <MudText Color="Secondary"> centered.
- Grouped view: <MudExpansionPanels MultiExpansion=true>. Each
  group's expand toggles ToggleGroupAsync via ExpandedChanged with
  a guard to avoid double-toggle when MudBlazor's internal state
  agrees with VM state. Lazy-load preserved — books are fetched on
  first expand. Per-group pagination via <MudPagination>.
- Status badge: <MudChip> with Color mapped from BookStatus
  (Reading→Primary, Read→Success, Unread→Default).
- Star rating: <MudRating ReadOnly Size="Small">.

Out of scope per the planning round:
- No sort UX added (deferred to TODO #9 Shelf-order view).
- No search debouncing change — kept the type-doesn't-query, Enter-
  queries pattern from the legacy page.

Risk profile: this is the kind of rewrite where bUnit would earn
its keep but the chassis only covers MudAuthorPicker today. Test
locally — particularly the flat ↔ grouped switch, the mobile filter
collapse toggle, search-on-Enter, the Author autocomplete, and the
expand-and-paginate behaviour inside the grouped accordion.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
