### PR TITLE
feat(authors): rebuild as compact searchable list + per-author detail page

### DIFF
--- a/BookTracker.Tests/ViewModels/AuthorDetailViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/AuthorDetailViewModelTests.cs
@@ -1,0 +1,231 @@
+using BookTracker.Data.Models;
+using BookTracker.Web.ViewModels;
+
+namespace BookTracker.Tests.ViewModels;
+
+[Trait("Category", TestCategories.Integration)]
+public class AuthorDetailViewModelTests
+{
+    [Fact]
+    public async Task LoadAsync_NonExistentId_SetsNotFound()
+    {
+        var factory = new TestDbContextFactory();
+        var vm = new AuthorDetailViewModel(factory);
+
+        await vm.LoadAsync(99999);
+
+        Assert.True(vm.NotFound);
+        Assert.Null(vm.Header);
+    }
+
+    [Fact]
+    public async Task LoadAsync_CanonicalRollsUpAliasWorks()
+    {
+        var factory = new TestDbContextFactory();
+        int kingId;
+        using (var db = factory.CreateDbContext())
+        {
+            var king = new Author { Name = "Stephen King" };
+            var bachman = new Author { Name = "Richard Bachman", CanonicalAuthor = king };
+            db.Authors.AddRange(king, bachman);
+            db.Books.Add(new Book { Title = "Carrie", Works = [new Work { Title = "Carrie", WorkAuthors = [new WorkAuthor { Author = king, Order = 0 }] }] });
+            db.Books.Add(new Book { Title = "Thinner", Works = [new Work { Title = "Thinner", WorkAuthors = [new WorkAuthor { Author = bachman, Order = 0 }] }] });
+            await db.SaveChangesAsync();
+            kingId = king.Id;
+        }
+
+        var vm = new AuthorDetailViewModel(factory);
+        await vm.LoadAsync(kingId);
+
+        Assert.NotNull(vm.Header);
+        Assert.Equal("Stephen King", vm.Header.Name);
+        Assert.Equal(2, vm.Detail.Works.Count);
+        Assert.Contains(vm.Detail.Works, w => w.Title == "Carrie");
+        Assert.Contains(vm.Detail.Works, w => w.Title == "Thinner");
+        Assert.Contains("Richard Bachman", vm.Detail.AliasNames);
+
+        // Bachman work flagged with WrittenAs; King work isn't.
+        Assert.Equal("Richard Bachman", vm.Detail.Works.Single(w => w.Title == "Thinner").WrittenAs);
+        Assert.Null(vm.Detail.Works.Single(w => w.Title == "Carrie").WrittenAs);
+    }
+
+    [Fact]
+    public async Task LoadAsync_AliasShowsOwnWorksOnly()
+    {
+        var factory = new TestDbContextFactory();
+        int bachmanId;
+        using (var db = factory.CreateDbContext())
+        {
+            var king = new Author { Name = "Stephen King" };
+            var bachman = new Author { Name = "Richard Bachman", CanonicalAuthor = king };
+            db.Authors.AddRange(king, bachman);
+            db.Books.Add(new Book { Title = "Carrie", Works = [new Work { Title = "Carrie", WorkAuthors = [new WorkAuthor { Author = king, Order = 0 }] }] });
+            db.Books.Add(new Book { Title = "Thinner", Works = [new Work { Title = "Thinner", WorkAuthors = [new WorkAuthor { Author = bachman, Order = 0 }] }] });
+            await db.SaveChangesAsync();
+            bachmanId = bachman.Id;
+        }
+
+        var vm = new AuthorDetailViewModel(factory);
+        await vm.LoadAsync(bachmanId);
+
+        Assert.Single(vm.Detail.Works);
+        Assert.Equal("Thinner", vm.Detail.Works[0].Title);
+        Assert.Empty(vm.Detail.AliasNames);
+        Assert.Null(vm.Detail.Works[0].WrittenAs);
+    }
+
+    [Fact]
+    public async Task LoadAsync_OrdersWorksByInSeriesThenSeriesOrderThenTitle()
+    {
+        // Same fixture as the previous AuthorListViewModelTests Pratchett case;
+        // Discworld 1, 2, 3, ... clusters before Bromeliad alphabetically, then
+        // standalones tail at the end.
+        var factory = new TestDbContextFactory();
+        int authorId;
+        using (var db = factory.CreateDbContext())
+        {
+            var pratchett = new Author { Name = "Terry Pratchett" };
+            db.Authors.Add(pratchett);
+            var discworld = new Series { Name = "Discworld", Type = SeriesType.Collection };
+            var bromeliad = new Series { Name = "Bromeliad", Type = SeriesType.Series };
+            db.Series.AddRange(discworld, bromeliad);
+
+            db.Books.AddRange(
+                new Book { Title = "Good Omens", Works = [new Work { Title = "Good Omens", WorkAuthors = [new WorkAuthor { Author = pratchett, Order = 0 }] }] },
+                new Book { Title = "Nation", Works = [new Work { Title = "Nation", WorkAuthors = [new WorkAuthor { Author = pratchett, Order = 0 }] }] },
+                new Book { Title = "Mort", Works = [new Work { Title = "Mort", WorkAuthors = [new WorkAuthor { Author = pratchett, Order = 0 }], Series = discworld, SeriesOrder = 4 }] },
+                new Book { Title = "The Colour of Magic", Works = [new Work { Title = "The Colour of Magic", WorkAuthors = [new WorkAuthor { Author = pratchett, Order = 0 }], Series = discworld, SeriesOrder = 1 }] },
+                new Book { Title = "Equal Rites", Works = [new Work { Title = "Equal Rites", WorkAuthors = [new WorkAuthor { Author = pratchett, Order = 0 }], Series = discworld, SeriesOrder = 3 }] },
+                new Book { Title = "Truckers", Works = [new Work { Title = "Truckers", WorkAuthors = [new WorkAuthor { Author = pratchett, Order = 0 }], Series = bromeliad, SeriesOrder = 1 }] });
+            await db.SaveChangesAsync();
+            authorId = pratchett.Id;
+        }
+
+        var vm = new AuthorDetailViewModel(factory);
+        await vm.LoadAsync(authorId);
+
+        var titles = vm.Detail.Works.Select(w => w.Title).ToList();
+        Assert.Equal(
+            ["Truckers", "The Colour of Magic", "Equal Rites", "Mort", "Good Omens", "Nation"],
+            titles);
+    }
+
+    [Fact]
+    public async Task RenameAsync_UpdatesNameAndReloads()
+    {
+        var factory = new TestDbContextFactory();
+        int authorId;
+        using (var db = factory.CreateDbContext())
+        {
+            var a = new Author { Name = "Old Name" };
+            db.Authors.Add(a);
+            await db.SaveChangesAsync();
+            authorId = a.Id;
+        }
+
+        var vm = new AuthorDetailViewModel(factory);
+        await vm.LoadAsync(authorId);
+        await vm.RenameAsync("New Name");
+
+        Assert.NotNull(vm.Header);
+        Assert.Equal("New Name", vm.Header.Name);
+        Assert.NotNull(vm.SuccessMessage);
+    }
+
+    [Fact]
+    public async Task RenameAsync_RejectsNameClash()
+    {
+        var factory = new TestDbContextFactory();
+        int aliceId;
+        using (var db = factory.CreateDbContext())
+        {
+            db.Authors.AddRange(new Author { Name = "Alice" }, new Author { Name = "Bob" });
+            await db.SaveChangesAsync();
+            aliceId = db.Authors.Single(a => a.Name == "Alice").Id;
+        }
+
+        var vm = new AuthorDetailViewModel(factory);
+        await vm.LoadAsync(aliceId);
+        await vm.RenameAsync("Bob");
+
+        Assert.NotNull(vm.Header);
+        Assert.Equal("Alice", vm.Header.Name); // unchanged
+        Assert.NotNull(vm.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task MarkAsAliasOfAsync_LinksToCanonicalAndRefreshesHeader()
+    {
+        var factory = new TestDbContextFactory();
+        int kingId;
+        int bachmanId;
+        using (var db = factory.CreateDbContext())
+        {
+            var king = new Author { Name = "Stephen King" };
+            var bachman = new Author { Name = "Richard Bachman" };
+            db.Authors.AddRange(king, bachman);
+            await db.SaveChangesAsync();
+            kingId = king.Id;
+            bachmanId = bachman.Id;
+        }
+
+        var vm = new AuthorDetailViewModel(factory);
+        await vm.LoadAsync(bachmanId);
+        await vm.MarkAsAliasOfAsync(kingId);
+
+        Assert.NotNull(vm.Header);
+        Assert.Equal(kingId, vm.Header.CanonicalAuthorId);
+        Assert.Equal("Stephen King", vm.Header.CanonicalName);
+    }
+
+    [Fact]
+    public async Task MarkAsAliasOfAsync_ChainedTarget_ReRootsToTopCanonical()
+    {
+        // If A is an alias of B, and we mark C as alias-of-A, C should
+        // actually point at B (no two-hop chains).
+        var factory = new TestDbContextFactory();
+        int aId;
+        int bId;
+        int cId;
+        using (var db = factory.CreateDbContext())
+        {
+            var b = new Author { Name = "B" };
+            var a = new Author { Name = "A", CanonicalAuthor = b };
+            var c = new Author { Name = "C" };
+            db.Authors.AddRange(b, a, c);
+            await db.SaveChangesAsync();
+            aId = a.Id;
+            bId = b.Id;
+            cId = c.Id;
+        }
+
+        var vm = new AuthorDetailViewModel(factory);
+        await vm.LoadAsync(cId);
+        await vm.MarkAsAliasOfAsync(aId);
+
+        Assert.NotNull(vm.Header);
+        Assert.Equal(bId, vm.Header.CanonicalAuthorId);
+    }
+
+    [Fact]
+    public async Task PromoteToCanonicalAsync_DropsCanonicalLink()
+    {
+        var factory = new TestDbContextFactory();
+        int bachmanId;
+        using (var db = factory.CreateDbContext())
+        {
+            var king = new Author { Name = "Stephen King" };
+            var bachman = new Author { Name = "Richard Bachman", CanonicalAuthor = king };
+            db.Authors.AddRange(king, bachman);
+            await db.SaveChangesAsync();
+            bachmanId = bachman.Id;
+        }
+
+        var vm = new AuthorDetailViewModel(factory);
+        await vm.LoadAsync(bachmanId);
+        await vm.PromoteToCanonicalAsync();
+
+        Assert.NotNull(vm.Header);
+        Assert.Null(vm.Header.CanonicalAuthorId);
+    }
+}

--- a/BookTracker.Tests/ViewModels/AuthorListViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/AuthorListViewModelTests.cs
@@ -7,7 +7,7 @@ namespace BookTracker.Tests.ViewModels;
 public class AuthorListViewModelTests
 {
     [Fact]
-    public async Task LoadAsync_PopulatesAuthorRows()
+    public async Task LoadAsync_PopulatesAuthorRows_WithCanonicalAndAliasShape()
     {
         var factory = new TestDbContextFactory();
         using (var db = factory.CreateDbContext())
@@ -26,115 +26,49 @@ public class AuthorListViewModelTests
         Assert.Equal(2, vm.Authors.Count);
         var kingRow = vm.Authors.Single(a => a.Name == "Stephen King");
         Assert.Null(kingRow.CanonicalAuthorId);
+        Assert.Contains("Richard Bachman", kingRow.AliasNames);
+
         var bachmanRow = vm.Authors.Single(a => a.Name == "Richard Bachman");
         Assert.Equal(kingRow.Id, bachmanRow.CanonicalAuthorId);
     }
 
     [Fact]
-    public async Task ToggleExpandAsync_CanonicalRollsUpAliasWorks()
+    public async Task LoadAsync_CanonicalCountsRollUpAliasWorks_AliasCountsAreOwnOnly()
     {
+        // King has Carrie + IT (own); Bachman is an alias contributing Thinner.
+        // King's row should report 3 works / 3 books / 0 series. Bachman's row
+        // should report just its own — 1 / 1 / 0.
         var factory = new TestDbContextFactory();
-        int kingId;
         using (var db = factory.CreateDbContext())
         {
             var king = new Author { Name = "Stephen King" };
             var bachman = new Author { Name = "Richard Bachman", CanonicalAuthor = king };
             db.Authors.AddRange(king, bachman);
             db.Books.Add(new Book { Title = "Carrie", Works = [new Work { Title = "Carrie", WorkAuthors = [new WorkAuthor { Author = king, Order = 0 }] }] });
+            db.Books.Add(new Book { Title = "It", Works = [new Work { Title = "It", WorkAuthors = [new WorkAuthor { Author = king, Order = 0 }] }] });
             db.Books.Add(new Book { Title = "Thinner", Works = [new Work { Title = "Thinner", WorkAuthors = [new WorkAuthor { Author = bachman, Order = 0 }] }] });
             await db.SaveChangesAsync();
-            kingId = king.Id;
         }
 
         var vm = new AuthorListViewModel(factory);
         await vm.LoadAsync();
-        await vm.ToggleExpandAsync(kingId);
 
-        Assert.Contains(kingId, vm.ExpandedAuthorIds);
-        var detail = vm.DetailByAuthorId[kingId];
-        Assert.Equal(2, detail.Works.Count);
-        Assert.Contains(detail.Works, w => w.Title == "Carrie");
-        Assert.Contains(detail.Works, w => w.Title == "Thinner");
-        Assert.Contains("Richard Bachman", detail.AliasNames);
+        var kingRow = vm.Authors.Single(a => a.Name == "Stephen King");
+        Assert.Equal(3, kingRow.WorkCount);
+        Assert.Equal(3, kingRow.BookCount);
+        Assert.Equal(0, kingRow.SeriesCount);
 
-        // The Bachman work should be flagged with WrittenAs, the King one shouldn't.
-        Assert.Equal("Richard Bachman", detail.Works.Single(w => w.Title == "Thinner").WrittenAs);
-        Assert.Null(detail.Works.Single(w => w.Title == "Carrie").WrittenAs);
+        var bachmanRow = vm.Authors.Single(a => a.Name == "Richard Bachman");
+        Assert.Equal(1, bachmanRow.WorkCount);
+        Assert.Equal(1, bachmanRow.BookCount);
+        Assert.Equal(0, bachmanRow.SeriesCount);
     }
 
     [Fact]
-    public async Task ToggleExpandAsync_AliasRowShowsOnlyOwnWorks()
+    public async Task LoadAsync_SeriesCount_DistinctSeriesAcrossWorks()
     {
+        // Pratchett: Discworld + Bromeliad + a standalone. Series count = 2.
         var factory = new TestDbContextFactory();
-        int bachmanId;
-        using (var db = factory.CreateDbContext())
-        {
-            var king = new Author { Name = "Stephen King" };
-            var bachman = new Author { Name = "Richard Bachman", CanonicalAuthor = king };
-            db.Authors.AddRange(king, bachman);
-            db.Books.Add(new Book { Title = "Carrie", Works = [new Work { Title = "Carrie", WorkAuthors = [new WorkAuthor { Author = king, Order = 0 }] }] });
-            db.Books.Add(new Book { Title = "Thinner", Works = [new Work { Title = "Thinner", WorkAuthors = [new WorkAuthor { Author = bachman, Order = 0 }] }] });
-            await db.SaveChangesAsync();
-            bachmanId = bachman.Id;
-        }
-
-        var vm = new AuthorListViewModel(factory);
-        await vm.LoadAsync();
-        await vm.ToggleExpandAsync(bachmanId);
-
-        var detail = vm.DetailByAuthorId[bachmanId];
-        Assert.Single(detail.Works);
-        Assert.Equal("Thinner", detail.Works[0].Title);
-        Assert.Empty(detail.AliasNames); // alias rows don't roll anything up
-        Assert.Null(detail.Works[0].WrittenAs); // no "as X" label on alias-own rows
-    }
-
-    [Fact]
-    public async Task ToggleExpandAsync_SecondCallCollapsesWithoutReload()
-    {
-        var factory = new TestDbContextFactory();
-        int authorId;
-        using (var db = factory.CreateDbContext())
-        {
-            var author = new Author { Name = "A" };
-            db.Authors.Add(author);
-            db.Books.Add(new Book { Title = "B", Works = [new Work { Title = "W", WorkAuthors = [new WorkAuthor { Author = author, Order = 0 }] }] });
-            await db.SaveChangesAsync();
-            authorId = author.Id;
-        }
-
-        var vm = new AuthorListViewModel(factory);
-        await vm.LoadAsync();
-        await vm.ToggleExpandAsync(authorId);
-        Assert.Contains(authorId, vm.ExpandedAuthorIds);
-        Assert.True(vm.DetailByAuthorId.ContainsKey(authorId));
-
-        await vm.ToggleExpandAsync(authorId);
-        Assert.DoesNotContain(authorId, vm.ExpandedAuthorIds);
-        // Detail cache survives the collapse — a later re-expand reuses it.
-        Assert.True(vm.DetailByAuthorId.ContainsKey(authorId));
-    }
-
-    [Fact]
-    public async Task GetViewMode_DefaultsToWorks_SetViewMode_Sticks()
-    {
-        var factory = new TestDbContextFactory();
-        var vm = new AuthorListViewModel(factory);
-
-        Assert.Equal(AuthorListViewModel.AuthorViewMode.Works, vm.GetViewMode(42));
-        vm.SetViewMode(42, AuthorListViewModel.AuthorViewMode.Books);
-        Assert.Equal(AuthorListViewModel.AuthorViewMode.Books, vm.GetViewMode(42));
-    }
-
-    [Fact]
-    public async Task ToggleExpandAsync_OrdersWorksByInSeries_ThenSeriesOrder_ThenTitle()
-    {
-        // Drew set up Discworld manually with SeriesOrder 1..N and expects
-        // the /authors expand to read Discworld 1, 2, 3, ..., then standalone
-        // works alphabetical — not pure title-alphabetical (which buried the
-        // numbered series order entirely). This test fixes that ordering.
-        var factory = new TestDbContextFactory();
-        int authorId;
         using (var db = factory.CreateDbContext())
         {
             var pratchett = new Author { Name = "Terry Pratchett" };
@@ -144,58 +78,90 @@ public class AuthorListViewModelTests
             db.Series.AddRange(discworld, bromeliad);
 
             db.Books.AddRange(
-                // Standalone (no series) — expect at the END despite alpha-early titles.
-                new Book { Title = "Good Omens", Works = [new Work { Title = "Good Omens", WorkAuthors = [new WorkAuthor { Author = pratchett, Order = 0 }] }] },
-                new Book { Title = "Nation", Works = [new Work { Title = "Nation", WorkAuthors = [new WorkAuthor { Author = pratchett, Order = 0 }] }] },
-                // Discworld — out-of-order titles to prove SeriesOrder wins over Title.
                 new Book { Title = "Mort", Works = [new Work { Title = "Mort", WorkAuthors = [new WorkAuthor { Author = pratchett, Order = 0 }], Series = discworld, SeriesOrder = 4 }] },
                 new Book { Title = "The Colour of Magic", Works = [new Work { Title = "The Colour of Magic", WorkAuthors = [new WorkAuthor { Author = pratchett, Order = 0 }], Series = discworld, SeriesOrder = 1 }] },
-                new Book { Title = "Equal Rites", Works = [new Work { Title = "Equal Rites", WorkAuthors = [new WorkAuthor { Author = pratchett, Order = 0 }], Series = discworld, SeriesOrder = 3 }] },
-                // Bromeliad — single work; cluster comes BEFORE Discworld alphabetically.
-                new Book { Title = "Truckers", Works = [new Work { Title = "Truckers", WorkAuthors = [new WorkAuthor { Author = pratchett, Order = 0 }], Series = bromeliad, SeriesOrder = 1 }] });
+                new Book { Title = "Truckers", Works = [new Work { Title = "Truckers", WorkAuthors = [new WorkAuthor { Author = pratchett, Order = 0 }], Series = bromeliad, SeriesOrder = 1 }] },
+                new Book { Title = "Good Omens", Works = [new Work { Title = "Good Omens", WorkAuthors = [new WorkAuthor { Author = pratchett, Order = 0 }] }] });
             await db.SaveChangesAsync();
-            authorId = pratchett.Id;
         }
 
         var vm = new AuthorListViewModel(factory);
         await vm.LoadAsync();
-        await vm.ToggleExpandAsync(authorId);
 
-        var titles = vm.DetailByAuthorId[authorId].Works.Select(w => w.Title).ToList();
-        Assert.Equal(
-            ["Truckers", "The Colour of Magic", "Equal Rites", "Mort", "Good Omens", "Nation"],
-            titles);
+        var p = vm.Authors.Single(a => a.Name == "Terry Pratchett");
+        Assert.Equal(4, p.WorkCount);
+        Assert.Equal(4, p.BookCount);
+        Assert.Equal(2, p.SeriesCount);
     }
 
     [Fact]
-    public async Task MarkAsAliasAsync_InvalidatesDetailCache()
+    public async Task FilteredAuthors_HidesAliases_WhenShowAliasesIsFalse()
     {
-        // Structural change (mark X as alias of Y) should drop any cached
-        // detail for X and Y so the next expand picks up the new roll-up.
         var factory = new TestDbContextFactory();
-        int kingId;
-        int bachmanId;
         using (var db = factory.CreateDbContext())
         {
             var king = new Author { Name = "Stephen King" };
-            var bachman = new Author { Name = "Richard Bachman" }; // NOT an alias yet
+            var bachman = new Author { Name = "Richard Bachman", CanonicalAuthor = king };
             db.Authors.AddRange(king, bachman);
-            db.Books.Add(new Book { Title = "Carrie", Works = [new Work { Title = "Carrie", WorkAuthors = [new WorkAuthor { Author = king, Order = 0 }] }] });
-            db.Books.Add(new Book { Title = "Thinner", Works = [new Work { Title = "Thinner", WorkAuthors = [new WorkAuthor { Author = bachman, Order = 0 }] }] });
             await db.SaveChangesAsync();
-            kingId = king.Id;
-            bachmanId = bachman.Id;
         }
 
         var vm = new AuthorListViewModel(factory);
         await vm.LoadAsync();
-        await vm.ToggleExpandAsync(kingId);
-        Assert.Single(vm.DetailByAuthorId[kingId].Works); // Carrie only
+        Assert.Equal(2, vm.FilteredAuthors.Count());
 
-        await vm.MarkAsAliasAsync(bachmanId, kingId);
+        vm.ShowAliases = false;
+        var only = Assert.Single(vm.FilteredAuthors);
+        Assert.Equal("Stephen King", only.Name);
+    }
 
-        Assert.False(vm.DetailByAuthorId.ContainsKey(kingId));
-        await vm.ExpandAsync(kingId);
-        Assert.Equal(2, vm.DetailByAuthorId[kingId].Works.Count); // now includes Thinner
+    [Fact]
+    public async Task FilteredAuthors_SearchIsAliasAware_AndCaseInsensitive()
+    {
+        // Typing "bachman" should surface King's row even with show-aliases off,
+        // because the alias name contains the term.
+        var factory = new TestDbContextFactory();
+        using (var db = factory.CreateDbContext())
+        {
+            var king = new Author { Name = "Stephen King" };
+            var bachman = new Author { Name = "Richard Bachman", CanonicalAuthor = king };
+            var atwood = new Author { Name = "Margaret Atwood" };
+            db.Authors.AddRange(king, bachman, atwood);
+            await db.SaveChangesAsync();
+        }
+
+        var vm = new AuthorListViewModel(factory);
+        await vm.LoadAsync();
+
+        vm.SearchTerm = "bachman";
+        var matches = vm.FilteredAuthors.Select(a => a.Name).ToList();
+        Assert.Contains("Stephen King", matches);   // matched by alias rollup
+        Assert.Contains("Richard Bachman", matches); // matched by literal name
+        Assert.DoesNotContain("Margaret Atwood", matches);
+
+        // Show-aliases=false + alias-name search still surfaces the canonical.
+        vm.ShowAliases = false;
+        var canonicalOnly = vm.FilteredAuthors.Select(a => a.Name).ToList();
+        Assert.Equal(["Stephen King"], canonicalOnly);
+    }
+
+    [Fact]
+    public async Task FilteredAuthors_EmptySearch_ReturnsAllRows()
+    {
+        var factory = new TestDbContextFactory();
+        using (var db = factory.CreateDbContext())
+        {
+            db.Authors.AddRange(
+                new Author { Name = "A" },
+                new Author { Name = "B" });
+            await db.SaveChangesAsync();
+        }
+
+        var vm = new AuthorListViewModel(factory);
+        await vm.LoadAsync();
+
+        Assert.Equal(2, vm.FilteredAuthors.Count());
+        vm.SearchTerm = "   ";
+        Assert.Equal(2, vm.FilteredAuthors.Count()); // whitespace ignored
     }
 }

--- a/BookTracker.Web/Components/Pages/Authors/Detail.razor
+++ b/BookTracker.Web/Components/Pages/Authors/Detail.razor
@@ -1,0 +1,262 @@
+@page "/authors/{Id:int}"
+@inject AuthorDetailViewModel VM
+@inject NavigationManager Nav
+
+<PageTitle>@(VM.Header?.Name ?? "Author") - BookTracker</PageTitle>
+
+@* Per-author detail. Owns rename, alias-management (mark-as-alias / promote-
+   to-canonical), and the works/books drill-down. List page (/authors) lost
+   these inline affordances when it was rebuilt as a compact searchable list —
+   this page is where they now live. *@
+
+<MudContainer MaxWidth="MaxWidth.Large" Class="py-3">
+
+    <MudLink Href="/authors" Underline="Underline.Hover" Class="d-inline-flex align-items-center mb-3">
+        <MudIcon Icon="@Icons.Material.Filled.ArrowBack" Size="Size.Small" Class="mr-1" />
+        Authors
+    </MudLink>
+
+    @if (VM.Loading)
+    {
+        <MudStack AlignItems="AlignItems.Center" Class="py-5">
+            <MudProgressCircular Indeterminate="true" />
+        </MudStack>
+    }
+    else if (VM.NotFound || VM.Header is null)
+    {
+        <MudAlert Severity="Severity.Warning">No author found with id @Id.</MudAlert>
+    }
+    else
+    {
+        var header = VM.Header;
+
+        @if (!string.IsNullOrEmpty(VM.SuccessMessage))
+        {
+            <MudAlert Severity="Severity.Success"
+                      ShowCloseIcon="true"
+                      CloseIconClicked="@(() => { VM.SuccessMessage = null; StateHasChanged(); })"
+                      Class="mb-3">@VM.SuccessMessage</MudAlert>
+        }
+        @if (!string.IsNullOrEmpty(VM.ErrorMessage))
+        {
+            <MudAlert Severity="Severity.Error"
+                      ShowCloseIcon="true"
+                      CloseIconClicked="@(() => { VM.ErrorMessage = null; StateHasChanged(); })"
+                      Class="mb-3">@VM.ErrorMessage</MudAlert>
+        }
+
+        <MudPaper Elevation="1" Class="pa-3 mb-3">
+            <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center" Wrap="Wrap.Wrap" Class="mb-2">
+                <MudText Typo="Typo.h4" Class="flex-grow-1">@header.Name</MudText>
+                @if (header.CanonicalAuthorId.HasValue)
+                {
+                    <MudChip T="string" Size="Size.Small" Color="Color.Info" Variant="Variant.Text">
+                        alias of <MudLink Href="@($"/authors/{header.CanonicalAuthorId}")" Class="ml-1">@header.CanonicalName</MudLink>
+                    </MudChip>
+                }
+                else
+                {
+                    <MudChip T="string" Size="Size.Small" Variant="Variant.Text">canonical</MudChip>
+                }
+            </MudStack>
+
+            @* Rename row *@
+            @if (editingName)
+            {
+                <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center" Wrap="Wrap.Wrap" Class="mb-2">
+                    <MudTextField T="string" @bind-Value="renameInput" Variant="Variant.Outlined" Margin="Margin.Dense" Style="max-width: 320px;" />
+                    <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Primary" OnClick="SaveRenameAsync">Save</MudButton>
+                    <MudButton Size="Size.Small" Variant="Variant.Text" OnClick="@(() => editingName = false)">Cancel</MudButton>
+                </MudStack>
+            }
+            else
+            {
+                <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center" Wrap="Wrap.Wrap" Class="mb-2">
+                    <MudButton Size="Size.Small" Variant="Variant.Outlined" StartIcon="@Icons.Material.Filled.Edit"
+                               OnClick="StartRename">Rename</MudButton>
+
+                    @if (header.CanonicalAuthorId.HasValue)
+                    {
+                        <MudButton Size="Size.Small" Variant="Variant.Outlined" StartIcon="@Icons.Material.Filled.Upgrade"
+                                   OnClick="VM.PromoteToCanonicalAsync">
+                            Promote to canonical
+                        </MudButton>
+                    }
+                    else
+                    {
+                        <MudSelect T="int?"
+                                   Value="null"
+                                   ValueChanged="@(async (int? id) => { if (id is int cid) await VM.MarkAsAliasOfAsync(cid); })"
+                                   Label="Mark as alias of…"
+                                   Variant="Variant.Outlined"
+                                   Margin="Margin.Dense"
+                                   Dense="true"
+                                   Style="max-width: 280px;">
+                            @foreach (var canonical in VM.CanonicalCandidates)
+                            {
+                                <MudSelectItem T="int?" Value="@((int?)canonical.Id)">@canonical.Name</MudSelectItem>
+                            }
+                        </MudSelect>
+                    }
+                </MudStack>
+            }
+
+            @if (VM.Detail.AliasNames.Count > 0)
+            {
+                <MudText Typo="Typo.caption" Color="Color.Secondary">
+                    Including @VM.Detail.AliasNames.Count alias@(VM.Detail.AliasNames.Count == 1 ? "" : "es"):
+                    @string.Join(", ", VM.Detail.AliasNames)
+                </MudText>
+            }
+        </MudPaper>
+
+        @* Works / Books toggle + list *@
+        <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center" Class="mb-2">
+            <MudChip T="AuthorDetailViewModel.AuthorViewMode"
+                     Size="Size.Small"
+                     OnClick="@(() => VM.ViewMode = AuthorDetailViewModel.AuthorViewMode.Works)"
+                     Color="@(VM.ViewMode == AuthorDetailViewModel.AuthorViewMode.Works ? Color.Primary : Color.Default)"
+                     Variant="@(VM.ViewMode == AuthorDetailViewModel.AuthorViewMode.Works ? Variant.Filled : Variant.Outlined)">
+                Works (@VM.Detail.Works.Count)
+            </MudChip>
+            <MudChip T="AuthorDetailViewModel.AuthorViewMode"
+                     Size="Size.Small"
+                     OnClick="@(() => VM.ViewMode = AuthorDetailViewModel.AuthorViewMode.Books)"
+                     Color="@(VM.ViewMode == AuthorDetailViewModel.AuthorViewMode.Books ? Color.Primary : Color.Default)"
+                     Variant="@(VM.ViewMode == AuthorDetailViewModel.AuthorViewMode.Books ? Variant.Filled : Variant.Outlined)">
+                Books (@VM.Detail.Books.Count)
+            </MudChip>
+        </MudStack>
+
+        @if (VM.ViewMode == AuthorDetailViewModel.AuthorViewMode.Works)
+        {
+            @if (VM.Detail.Works.Count == 0)
+            {
+                <MudText Typo="Typo.body2" Color="Color.Secondary">No works recorded for this author.</MudText>
+            }
+            else
+            {
+                <MudPaper Elevation="1">
+                    <MudList T="int" Dense="true" Class="pa-0">
+                        @foreach (var w in VM.Detail.Works)
+                        {
+                            <MudListItem T="int" Class="px-2">
+                                <MudStack Spacing="0">
+                                    <MudStack Row="true" Spacing="2" Wrap="Wrap.Wrap">
+                                        @if (w.SeriesOrder is int so)
+                                        {
+                                            <MudText Typo="Typo.body2" Color="Color.Secondary">#@so</MudText>
+                                        }
+                                        <MudText Typo="Typo.body1" Style="font-weight: 500;">@w.Title</MudText>
+                                        @if (!string.IsNullOrEmpty(w.WrittenAs))
+                                        {
+                                            <MudChip T="string" Size="Size.Small" Variant="Variant.Text" Color="Color.Info">as @w.WrittenAs</MudChip>
+                                        }
+                                    </MudStack>
+                                    @if (!string.IsNullOrEmpty(w.Subtitle))
+                                    {
+                                        <MudText Typo="Typo.caption" Color="Color.Secondary" Style="font-style: italic;">@w.Subtitle</MudText>
+                                    }
+                                    <MudStack Row="true" Spacing="2" Wrap="Wrap.Wrap">
+                                        @if (!string.IsNullOrEmpty(w.FirstPublishedDisplay))
+                                        {
+                                            <MudText Typo="Typo.caption" Color="Color.Secondary">First published @w.FirstPublishedDisplay</MudText>
+                                        }
+                                        @if (!string.IsNullOrEmpty(w.SeriesName))
+                                        {
+                                            <MudText Typo="Typo.caption" Color="Color.Secondary">
+                                                @(w.SeriesType == BookTracker.Data.Models.SeriesType.Collection ? "Collection" : "Series"): @w.SeriesName
+                                            </MudText>
+                                        }
+                                    </MudStack>
+                                    @if (w.InBooks.Count > 0)
+                                    {
+                                        <MudStack Row="true" Spacing="1" Wrap="Wrap.Wrap" Class="mt-1">
+                                            <MudText Typo="Typo.caption" Color="Color.Secondary" Class="align-self-center">In:</MudText>
+                                            @foreach (var b in w.InBooks)
+                                            {
+                                                <MudLink Href="@($"/books/{b.Id}")" Typo="Typo.caption">@b.Title</MudLink>
+                                            }
+                                        </MudStack>
+                                    }
+                                </MudStack>
+                            </MudListItem>
+                        }
+                    </MudList>
+                </MudPaper>
+            }
+        }
+        else
+        {
+            @if (VM.Detail.Books.Count == 0)
+            {
+                <MudText Typo="Typo.body2" Color="Color.Secondary">No books recorded for this author.</MudText>
+            }
+            else
+            {
+                <MudPaper Elevation="1">
+                    <MudList T="int" Dense="true" Class="pa-0">
+                        @foreach (var b in VM.Detail.Books)
+                        {
+                            <MudListItem T="int" OnClick="@(() => Nav.NavigateTo($"/books/{b.Id}"))" Class="px-2">
+                                <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center" Wrap="Wrap.NoWrap">
+                                    @if (!string.IsNullOrEmpty(b.CoverUrl))
+                                    {
+                                        <MudImage Src="@b.CoverUrl" Alt="@b.Title" Width="36" Height="52" Style="object-fit: cover; border-radius: 2px; flex: 0 0 auto;" />
+                                    }
+                                    else
+                                    {
+                                        <MudIcon Icon="@Icons.Material.Filled.MenuBook" Color="Color.Secondary" />
+                                    }
+                                    <MudStack Spacing="0" Class="flex-grow-1" Style="min-width: 0;">
+                                        <MudText Typo="Typo.body1" Style="word-break: break-word;">@b.Title</MudText>
+                                        <MudText Typo="Typo.caption" Color="Color.Secondary">
+                                            @b.EditionCount edition@(b.EditionCount == 1 ? "" : "s") · @b.CopyCount cop@(b.CopyCount == 1 ? "y" : "ies")
+                                        </MudText>
+                                    </MudStack>
+                                </MudStack>
+                            </MudListItem>
+                        }
+                    </MudList>
+                </MudPaper>
+            }
+        }
+    }
+
+</MudContainer>
+
+@code {
+    [Parameter] public int Id { get; set; }
+
+    private bool editingName;
+    private string renameInput = "";
+
+    protected override async Task OnInitializedAsync()
+    {
+        await VM.LoadAsync(Id);
+    }
+
+    // Re-load on Id change so client-side nav between two author detail pages
+    // (e.g. clicking the canonical link from an alias row) refreshes the data.
+    protected override async Task OnParametersSetAsync()
+    {
+        if (VM.Header is not null && VM.Header.Id != Id)
+        {
+            editingName = false;
+            await VM.LoadAsync(Id);
+        }
+    }
+
+    private void StartRename()
+    {
+        if (VM.Header is null) return;
+        renameInput = VM.Header.Name;
+        editingName = true;
+    }
+
+    private async Task SaveRenameAsync()
+    {
+        await VM.RenameAsync(renameInput);
+        editingName = false;
+    }
+}

--- a/BookTracker.Web/Components/Pages/Authors/Index.razor
+++ b/BookTracker.Web/Components/Pages/Authors/Index.razor
@@ -1,15 +1,15 @@
 @page "/authors"
+@using Microsoft.AspNetCore.Components.Web.Virtualization
 @inject AuthorListViewModel VM
 @inject NavigationManager Nav
-@inject IJSRuntime JS
 
 <PageTitle>Authors - BookTracker</PageTitle>
 
-@* MudBlazor rewrite. Each author row expands to a drill-down showing
-   either the author's Works or the Books containing them (per-row
-   toggle). Canonical rows roll up any aliases — Stephen King's
-   drill-down includes Bachman titles. A deep link from Home
-   (/authors?expand=<id>) pre-opens the matching row. *@
+@* Compact searchable list. Each row: name, alias chip, work/book/series counts.
+   Click navigates to /authors/{id} for full detail (rename, alias-management,
+   works/books drill-down). MudVirtualize keeps 200+ → 1000+ author lists
+   smooth on mobile. Search is alias-aware — typing "Bachman" surfaces King's
+   row even when the alias toggle is off. *@
 
 <MudContainer MaxWidth="MaxWidth.Large" Class="py-3">
 
@@ -18,17 +18,36 @@
         <MudText Typo="Typo.body2" Color="Color.Secondary" Class="mb-3">
             Each author has its own row. Pen names are linked back to a canonical author so aggregations
             (top-authors stats, author filter) roll the totals together. Stephen King's tally includes
-            his Bachman titles when you mark Bachman as an alias of King.
+            his Bachman titles when you mark Bachman as an alias of King. Click any row to open the
+            detail view where you can rename, link or unlink aliases, and browse the author's works
+            or books.
         </MudText>
     </CollapsibleSubtitle>
 
-    @if (!string.IsNullOrEmpty(VM.SuccessMessage))
-    {
-        <MudAlert Severity="Severity.Success"
-                  ShowCloseIcon="true"
-                  CloseIconClicked="@(() => { VM.SuccessMessage = null; StateHasChanged(); })"
-                  Class="mb-3">@VM.SuccessMessage</MudAlert>
-    }
+    <MudPaper Elevation="1" Class="pa-3 mb-3">
+        <MudGrid Spacing="2">
+            <MudItem xs="12" md="6">
+                <MudTextField T="string"
+                              Value="@VM.SearchTerm"
+                              ValueChanged="@OnSearchChanged"
+                              Variant="Variant.Outlined"
+                              Margin="Margin.Dense"
+                              Label="Search"
+                              Placeholder="Author name or pen name..."
+                              Adornment="Adornment.Start"
+                              AdornmentIcon="@Icons.Material.Filled.Search"
+                              Immediate="true"
+                              Clearable="true" />
+            </MudItem>
+            <MudItem xs="12" md="6" Class="d-flex align-items-center">
+                <MudSwitch T="bool"
+                           Value="@VM.ShowAliases"
+                           ValueChanged="@OnShowAliasesChanged"
+                           Color="Color.Primary"
+                           Label="Show alias rows" />
+            </MudItem>
+        </MudGrid>
+    </MudPaper>
 
     @if (VM.Loading)
     {
@@ -42,264 +61,73 @@
     }
     else
     {
-        <MudPaper Elevation="1">
-            @foreach (var author in VM.Authors)
-            {
-                var expanded = VM.ExpandedAuthorIds.Contains(author.Id);
-                <div class="author-row" id="@($"author-row-{author.Id}")">
-                    <MudStack Row="true"
-                              Spacing="2"
-                              AlignItems="AlignItems.Center"
-                              Wrap="Wrap.Wrap"
-                              Class="pa-3"
-                              Style="cursor: pointer;"
-                              @onclick="@(() => OnToggleExpandAsync(author.Id))">
-                        <MudIcon Icon="@(expanded ? Icons.Material.Filled.ExpandLess : Icons.Material.Filled.ExpandMore)" Size="Size.Small" />
-                        <MudText Typo="Typo.body1" Class="flex-grow-1" Style="font-weight: 500;">@author.Name</MudText>
-                        @if (author.CanonicalAuthorId.HasValue)
-                        {
-                            <MudChip T="string" Size="Size.Small" Color="Color.Info" Variant="Variant.Text">
-                                alias of @author.CanonicalName
-                            </MudChip>
-                        }
-                        else
-                        {
-                            <MudChip T="string" Size="Size.Small" Variant="Variant.Text">canonical</MudChip>
-                        }
-                        <MudText Typo="Typo.body2" Color="Color.Secondary" Style="min-width: 60px; text-align: right;">
-                            @author.WorkCount work@(author.WorkCount == 1 ? "" : "s")
-                        </MudText>
-                    </MudStack>
+        @* Snapshot the filtered list so MudVirtualize and the empty-result text
+           share one view of the data per render. *@
+        var filtered = VM.FilteredAuthors.ToList();
 
-                    @* Action row — rename + alias-management. stopPropagation keeps
-                       clicks here from re-toggling the row. *@
-                    <div @onclick:stopPropagation="true" class="px-3 pb-3">
-                        @if (editingId == author.Id)
-                        {
-                            <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center">
-                                <MudTextField T="string" @bind-Value="editingName" Variant="Variant.Outlined" Margin="Margin.Dense" Style="max-width: 320px;" />
-                                <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Primary" OnClick="@(() => SaveRenameAsync(author.Id))">Save</MudButton>
-                                <MudButton Size="Size.Small" Variant="Variant.Text" OnClick="@(() => editingId = null)">Cancel</MudButton>
-                            </MudStack>
-                        }
-                        else
-                        {
-                            <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center" Wrap="Wrap.Wrap">
-                                <MudButton Size="Size.Small" Variant="Variant.Outlined" StartIcon="@Icons.Material.Filled.Edit"
-                                           OnClick="@(() => StartRename(author))">Rename</MudButton>
-                                @if (author.CanonicalAuthorId.HasValue)
-                                {
-                                    <MudButton Size="Size.Small" Variant="Variant.Outlined" StartIcon="@Icons.Material.Filled.Upgrade"
-                                               OnClick="@(() => VM.PromoteToCanonicalAsync(author.Id))">
-                                        Promote to canonical
-                                    </MudButton>
-                                }
-                                else
-                                {
-                                    <MudSelect T="int?"
-                                               Value="null"
-                                               ValueChanged="@(async (int? id) => { if (id is int cid) await VM.MarkAsAliasAsync(author.Id, cid); })"
-                                               Label="Mark as alias of…"
-                                               Variant="Variant.Outlined"
-                                               Margin="Margin.Dense"
-                                               Dense="true"
-                                               Style="max-width: 260px;">
-                                        @foreach (var canonical in VM.CanonicalAuthors.Where(c => c.Id != author.Id))
-                                        {
-                                            <MudSelectItem T="int?" Value="@((int?)canonical.Id)">@canonical.Name</MudSelectItem>
-                                        }
-                                    </MudSelect>
-                                }
-                            </MudStack>
-                        }
-                    </div>
+        @if (filtered.Count == 0)
+        {
+            <MudText Color="Color.Secondary">No authors match the current filter.</MudText>
+        }
+        else
+        {
+            <MudPaper Elevation="1">
+                <Virtualize Items="filtered" Context="author" ItemSize="64">
+                    <ItemContent>
+                        <MudStack Row="true"
+                                  Spacing="2"
+                                  AlignItems="AlignItems.Center"
+                                  Wrap="Wrap.NoWrap"
+                                  Class="pa-3"
+                                  Style="cursor: pointer; border-bottom: 1px solid var(--mud-palette-divider);"
+                                  @onclick="@(() => Nav.NavigateTo($"/authors/{author.Id}"))">
+                            <MudText Typo="Typo.body1" Class="flex-grow-1" Style="font-weight: 500; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">@author.Name</MudText>
 
-                    @if (expanded)
-                    {
-                        <div @onclick:stopPropagation="true" class="px-3 pb-3">
-                            @if (!VM.DetailByAuthorId.TryGetValue(author.Id, out var detail))
+                            @if (author.CanonicalAuthorId.HasValue)
                             {
-                                <MudStack AlignItems="AlignItems.Center" Class="py-3">
-                                    <MudProgressCircular Indeterminate="true" Size="Size.Small" />
-                                </MudStack>
+                                <MudChip T="string" Size="Size.Small" Color="Color.Info" Variant="Variant.Text" Class="d-none d-md-inline-flex">
+                                    alias of @author.CanonicalName
+                                </MudChip>
                             }
                             else
                             {
-                                var view = VM.GetViewMode(author.Id);
-
-                                @if (detail.AliasNames.Count > 0)
-                                {
-                                    <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mb-2">
-                                        Including @detail.AliasNames.Count alias@(detail.AliasNames.Count == 1 ? "" : "es"):
-                                        @string.Join(", ", detail.AliasNames)
-                                    </MudText>
-                                }
-
-                                <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center" Class="mb-2">
-                                    <MudChip T="AuthorListViewModel.AuthorViewMode"
-                                             Size="Size.Small"
-                                             OnClick="@(() => SetView(author.Id, AuthorListViewModel.AuthorViewMode.Works))"
-                                             Color="@(view == AuthorListViewModel.AuthorViewMode.Works ? Color.Primary : Color.Default)"
-                                             Variant="@(view == AuthorListViewModel.AuthorViewMode.Works ? Variant.Filled : Variant.Outlined)">
-                                        Works (@detail.Works.Count)
-                                    </MudChip>
-                                    <MudChip T="AuthorListViewModel.AuthorViewMode"
-                                             Size="Size.Small"
-                                             OnClick="@(() => SetView(author.Id, AuthorListViewModel.AuthorViewMode.Books))"
-                                             Color="@(view == AuthorListViewModel.AuthorViewMode.Books ? Color.Primary : Color.Default)"
-                                             Variant="@(view == AuthorListViewModel.AuthorViewMode.Books ? Variant.Filled : Variant.Outlined)">
-                                        Books (@detail.Books.Count)
-                                    </MudChip>
-                                </MudStack>
-
-                                @if (view == AuthorListViewModel.AuthorViewMode.Works)
-                                {
-                                    @if (detail.Works.Count == 0)
-                                    {
-                                        <MudText Typo="Typo.body2" Color="Color.Secondary">No works recorded for this author.</MudText>
-                                    }
-                                    else
-                                    {
-                                        <MudList T="int" Dense="true" Class="pa-0">
-                                            @foreach (var w in detail.Works)
-                                            {
-                                                <MudListItem T="int" Class="px-2">
-                                                    <MudStack Spacing="0">
-                                                        <MudStack Row="true" Spacing="2" Wrap="Wrap.Wrap">
-                                                            @if (w.SeriesOrder is int so)
-                                                            {
-                                                                <MudText Typo="Typo.body2" Color="Color.Secondary">#@so</MudText>
-                                                            }
-                                                            <MudText Typo="Typo.body1" Style="font-weight: 500;">@w.Title</MudText>
-                                                            @if (!string.IsNullOrEmpty(w.WrittenAs))
-                                                            {
-                                                                <MudChip T="string" Size="Size.Small" Variant="Variant.Text" Color="Color.Info">as @w.WrittenAs</MudChip>
-                                                            }
-                                                        </MudStack>
-                                                        @if (!string.IsNullOrEmpty(w.Subtitle))
-                                                        {
-                                                            <MudText Typo="Typo.caption" Color="Color.Secondary" Style="font-style: italic;">@w.Subtitle</MudText>
-                                                        }
-                                                        <MudStack Row="true" Spacing="2" Wrap="Wrap.Wrap">
-                                                            @if (!string.IsNullOrEmpty(w.FirstPublishedDisplay))
-                                                            {
-                                                                <MudText Typo="Typo.caption" Color="Color.Secondary">First published @w.FirstPublishedDisplay</MudText>
-                                                            }
-                                                            @if (!string.IsNullOrEmpty(w.SeriesName))
-                                                            {
-                                                                <MudText Typo="Typo.caption" Color="Color.Secondary">
-                                                                    @(w.SeriesType == BookTracker.Data.Models.SeriesType.Collection ? "Collection" : "Series"): @w.SeriesName
-                                                                </MudText>
-                                                            }
-                                                        </MudStack>
-                                                        @if (w.InBooks.Count > 0)
-                                                        {
-                                                            <MudStack Row="true" Spacing="1" Wrap="Wrap.Wrap" Class="mt-1">
-                                                                <MudText Typo="Typo.caption" Color="Color.Secondary" Class="align-self-center">In:</MudText>
-                                                                @foreach (var b in w.InBooks)
-                                                                {
-                                                                    <MudLink Href="@($"/books/{b.Id}")"
-                                                                             Typo="Typo.caption">@b.Title</MudLink>
-                                                                }
-                                                            </MudStack>
-                                                        }
-                                                    </MudStack>
-                                                </MudListItem>
-                                            }
-                                        </MudList>
-                                    }
-                                }
-                                else
-                                {
-                                    @if (detail.Books.Count == 0)
-                                    {
-                                        <MudText Typo="Typo.body2" Color="Color.Secondary">No books recorded for this author.</MudText>
-                                    }
-                                    else
-                                    {
-                                        <MudList T="int" Dense="true" Class="pa-0">
-                                            @foreach (var b in detail.Books)
-                                            {
-                                                <MudListItem T="int" OnClick="@(() => Nav.NavigateTo($"/books/{b.Id}"))" Class="px-2">
-                                                    <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center" Wrap="Wrap.NoWrap">
-                                                        @if (!string.IsNullOrEmpty(b.CoverUrl))
-                                                        {
-                                                            <MudImage Src="@b.CoverUrl" Alt="@b.Title" Width="36" Height="52" Style="object-fit: cover; border-radius: 2px; flex: 0 0 auto;" />
-                                                        }
-                                                        else
-                                                        {
-                                                            <MudIcon Icon="@Icons.Material.Filled.MenuBook" Color="Color.Secondary" />
-                                                        }
-                                                        <MudStack Spacing="0" Class="flex-grow-1" Style="min-width: 0;">
-                                                            <MudText Typo="Typo.body1" Style="word-break: break-word;">@b.Title</MudText>
-                                                            <MudText Typo="Typo.caption" Color="Color.Secondary">
-                                                                @b.EditionCount edition@(b.EditionCount == 1 ? "" : "s") · @b.CopyCount cop@(b.CopyCount == 1 ? "y" : "ies")
-                                                            </MudText>
-                                                        </MudStack>
-                                                    </MudStack>
-                                                </MudListItem>
-                                            }
-                                        </MudList>
-                                    }
-                                }
+                                <MudChip T="string" Size="Size.Small" Variant="Variant.Text" Class="d-none d-md-inline-flex">canonical</MudChip>
                             }
-                        </div>
-                    }
-                </div>
-                <MudDivider />
-            }
-        </MudPaper>
+
+                            <MudText Typo="Typo.body2" Color="Color.Secondary" Style="min-width: 56px; text-align: right;" Class="d-none d-sm-inline-flex">
+                                @author.WorkCount work@(author.WorkCount == 1 ? "" : "s")
+                            </MudText>
+                            <MudText Typo="Typo.body2" Color="Color.Secondary" Style="min-width: 56px; text-align: right;" Class="d-none d-md-inline-flex">
+                                @author.BookCount book@(author.BookCount == 1 ? "" : "s")
+                            </MudText>
+                            <MudText Typo="Typo.body2" Color="Color.Secondary" Style="min-width: 56px; text-align: right;" Class="d-none d-md-inline-flex">
+                                @author.SeriesCount series
+                            </MudText>
+
+                            <MudIcon Icon="@Icons.Material.Filled.ChevronRight" Size="Size.Small" Color="Color.Secondary" />
+                        </MudStack>
+                    </ItemContent>
+                </Virtualize>
+            </MudPaper>
+        }
     }
 
 </MudContainer>
 
 @code {
-    [SupplyParameterFromQuery(Name = "expand")] public int? ExpandId { get; set; }
-
-    private int? editingId;
-    private string editingName = "";
-    private bool scrolledToExpanded;
-
     protected override async Task OnInitializedAsync()
     {
         await VM.LoadAsync();
-        if (ExpandId is int id && VM.Authors.Any(a => a.Id == id))
-        {
-            await VM.ExpandAsync(id);
-        }
     }
 
-    // Scroll the pre-expanded row into view once the initial render has placed
-    // it in the DOM. Only fires once per navigation (scrolledToExpanded guard)
-    // so manual expand/collapse later doesn't yank the viewport.
-    protected override async Task OnAfterRenderAsync(bool firstRender)
+    private void OnSearchChanged(string value)
     {
-        if (firstRender && !scrolledToExpanded && ExpandId is int id && VM.Authors.Any(a => a.Id == id))
-        {
-            scrolledToExpanded = true;
-            try { await JS.InvokeVoidAsync("ScrollTo.element", $"author-row-{id}"); }
-            catch (JSDisconnectedException) { /* circuit tearing down */ }
-            catch (TaskCanceledException) { /* ditto */ }
-        }
+        // Filter is computed in-memory via FilteredAuthors; just nudge state.
+        VM.SearchTerm = value ?? "";
     }
 
-    private async Task OnToggleExpandAsync(int authorId)
+    private void OnShowAliasesChanged(bool value)
     {
-        await VM.ToggleExpandAsync(authorId);
-    }
-
-    private void SetView(int authorId, AuthorListViewModel.AuthorViewMode mode) =>
-        VM.SetViewMode(authorId, mode);
-
-    private void StartRename(AuthorListViewModel.AuthorRow author)
-    {
-        editingId = author.Id;
-        editingName = author.Name;
-    }
-
-    private async Task SaveRenameAsync(int authorId)
-    {
-        await VM.RenameAsync(authorId, editingName);
-        editingId = null;
+        VM.ShowAliases = value;
     }
 }

--- a/BookTracker.Web/Components/Pages/Home.razor
+++ b/BookTracker.Web/Components/Pages/Home.razor
@@ -133,7 +133,7 @@
                             @foreach (var a in VM.TopAuthors)
                             {
                                 var pct = VM.MaxAuthor == 0 ? 0 : (double)a.Count * 100.0 / VM.MaxAuthor;
-                                <MudLink Href="@($"/authors?expand={a.CanonicalAuthorId}")" Underline="Underline.None" Color="Color.Inherit">
+                                <MudLink Href="@($"/authors/{a.CanonicalAuthorId}")" Underline="Underline.None" Color="Color.Inherit">
                                     <div>
                                         <MudStack Row Justify="Justify.SpaceBetween" Class="mb-1">
                                             <MudText Typo="Typo.body2" Style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">@a.Author</MudText>

--- a/BookTracker.Web/ProgramSetup.cs
+++ b/BookTracker.Web/ProgramSetup.cs
@@ -135,6 +135,7 @@ public static class ProgramSetup
         builder.Services.AddTransient<SeriesListViewModel>();
         builder.Services.AddTransient<SeriesEditViewModel>();
         builder.Services.AddTransient<AuthorListViewModel>();
+        builder.Services.AddTransient<AuthorDetailViewModel>();
         builder.Services.AddTransient<PublisherListViewModel>();
         builder.Services.AddTransient<ShoppingViewModel>();
         builder.Services.AddTransient<DuplicatesViewModel>();

--- a/BookTracker.Web/ViewModels/AuthorDetailViewModel.cs
+++ b/BookTracker.Web/ViewModels/AuthorDetailViewModel.cs
@@ -1,0 +1,224 @@
+using BookTracker.Data;
+using BookTracker.Data.Models;
+using BookTracker.Web.Services;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookTracker.Web.ViewModels;
+
+// Backs /authors/{id}. Owns rename + alias-management ops and the
+// per-author drill-down (Works / Books) that previously lived inside
+// AuthorListViewModel's inline expand. Each detail VM is bound to a
+// single author id loaded via LoadAsync(authorId).
+public class AuthorDetailViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory)
+{
+    public bool Loading { get; private set; } = true;
+    public bool NotFound { get; private set; }
+    public AuthorHeader? Header { get; private set; }
+    public AuthorDetail Detail { get; private set; } = AuthorDetail.Empty;
+    public AuthorViewMode ViewMode { get; set; } = AuthorViewMode.Works;
+
+    /// <summary>List of canonical authors used by the "mark as alias of…" dropdown.</summary>
+    public List<CanonicalCandidate> CanonicalCandidates { get; private set; } = [];
+
+    public string? SuccessMessage { get; set; }
+    public string? ErrorMessage { get; set; }
+
+    public async Task LoadAsync(int authorId)
+    {
+        Loading = true;
+        NotFound = false;
+        Header = null;
+        Detail = AuthorDetail.Empty;
+
+        await using var db = await dbFactory.CreateDbContextAsync();
+
+        var author = await db.Authors
+            .Include(a => a.CanonicalAuthor)
+            .Include(a => a.Aliases)
+            .FirstOrDefaultAsync(a => a.Id == authorId);
+
+        if (author is null)
+        {
+            NotFound = true;
+            Loading = false;
+            return;
+        }
+
+        Header = new AuthorHeader(
+            author.Id,
+            author.Name,
+            author.CanonicalAuthorId,
+            author.CanonicalAuthor?.Name);
+
+        Detail = await LoadDetailAsync(db, author);
+
+        // Canonical-candidate list for the "mark as alias of" dropdown — every
+        // canonical author except this one. Avoid alias-of-alias chains (the
+        // existing rule on save also re-roots, but this trims the dropdown).
+        CanonicalCandidates = await db.Authors
+            .Where(a => a.CanonicalAuthorId == null && a.Id != authorId)
+            .OrderBy(a => a.Name)
+            .Select(a => new CanonicalCandidate(a.Id, a.Name))
+            .ToListAsync();
+
+        Loading = false;
+    }
+
+    private async Task<AuthorDetail> LoadDetailAsync(BookTrackerDbContext db, Author author)
+    {
+        bool isCanonical = author.CanonicalAuthorId is null;
+
+        var ids = new List<int> { author.Id };
+        if (isCanonical)
+        {
+            ids.AddRange(author.Aliases.Select(a => a.Id));
+        }
+
+        var works = await db.Works
+            .Include(w => w.WorkAuthors).ThenInclude(wa => wa.Author)
+            .Include(w => w.Books)
+            .Include(w => w.Series)
+            .Where(w => w.WorkAuthors.Any(wa => ids.Contains(wa.AuthorId)))
+            .OrderBy(w => w.SeriesId == null)
+            .ThenBy(w => w.Series!.Name)
+            .ThenBy(w => w.SeriesOrder ?? int.MaxValue)
+            .ThenBy(w => w.Title)
+            .ToListAsync();
+
+        var workRows = works.Select(w => new WorkRow(
+            w.Id,
+            w.Title,
+            w.Subtitle,
+            // "Written as" tag only on canonical drill-downs; alias rows always
+            // are themselves so the label would be redundant.
+            isCanonical
+                ? w.WorkAuthors.OrderBy(wa => wa.Order).Select(wa => wa.Author).FirstOrDefault() is { } leadAuthor && leadAuthor.Id != author.Id
+                    ? leadAuthor.Name
+                    : null
+                : null,
+            PartialDateParser.Format(w.FirstPublishedDate, w.FirstPublishedDatePrecision),
+            w.Series?.Name,
+            w.Series?.Type,
+            w.SeriesOrder,
+            w.Books.Select(b => new BookRef(b.Id, b.Title)).ToList()
+        )).ToList();
+
+        var bookIds = works.SelectMany(w => w.Books).Select(b => b.Id).Distinct().ToList();
+        var books = await db.Books
+            .Where(b => bookIds.Contains(b.Id))
+            .Include(b => b.Editions).ThenInclude(e => e.Copies)
+            .OrderBy(b => b.Title)
+            .ToListAsync();
+
+        var bookRows = books.Select(b => new BookSummaryRow(
+            b.Id,
+            b.Title,
+            b.DefaultCoverArtUrl,
+            b.Editions.Count,
+            b.Editions.Sum(e => e.Copies.Count)
+        )).ToList();
+
+        var aliasNames = isCanonical
+            ? author.Aliases.Select(a => a.Name).OrderBy(n => n).ToList()
+            : new List<string>();
+
+        return new AuthorDetail(workRows, bookRows, aliasNames);
+    }
+
+    public async Task RenameAsync(string newName)
+    {
+        if (Header is null) return;
+        var trimmed = newName.Trim();
+        if (string.IsNullOrEmpty(trimmed)) return;
+
+        await using var db = await dbFactory.CreateDbContextAsync();
+        var author = await db.Authors.FirstOrDefaultAsync(a => a.Id == Header.Id);
+        if (author is null) return;
+
+        var clash = await db.Authors.AnyAsync(a => a.Id != Header.Id && a.Name == trimmed);
+        if (clash)
+        {
+            ErrorMessage = $"An author named \"{trimmed}\" already exists. Use the alias dropdown to merge.";
+            return;
+        }
+
+        author.Name = trimmed;
+        await db.SaveChangesAsync();
+        SuccessMessage = $"Renamed to \"{trimmed}\".";
+        await LoadAsync(Header.Id);
+    }
+
+    public async Task MarkAsAliasOfAsync(int canonicalId)
+    {
+        if (Header is null || Header.Id == canonicalId) return;
+
+        await using var db = await dbFactory.CreateDbContextAsync();
+        var alias = await db.Authors.FirstOrDefaultAsync(a => a.Id == Header.Id);
+        var canonical = await db.Authors.FirstOrDefaultAsync(a => a.Id == canonicalId);
+        if (alias is null || canonical is null) return;
+
+        // Re-root if the chosen "canonical" is itself an alias — avoids alias-of-alias chains.
+        var rootCanonicalId = canonical.CanonicalAuthorId ?? canonical.Id;
+
+        alias.CanonicalAuthorId = rootCanonicalId;
+
+        // Re-point any prior aliases that targeted this row at the new root.
+        var prior = await db.Authors.Where(a => a.CanonicalAuthorId == Header.Id).ToListAsync();
+        foreach (var p in prior)
+        {
+            p.CanonicalAuthorId = rootCanonicalId;
+        }
+
+        await db.SaveChangesAsync();
+        SuccessMessage = $"\"{alias.Name}\" is now an alias of \"{canonical.Name}\".";
+        await LoadAsync(Header.Id);
+    }
+
+    public async Task PromoteToCanonicalAsync()
+    {
+        if (Header is null || Header.CanonicalAuthorId is null) return;
+
+        await using var db = await dbFactory.CreateDbContextAsync();
+        var alias = await db.Authors.FirstOrDefaultAsync(a => a.Id == Header.Id);
+        if (alias is null || alias.CanonicalAuthorId is null) return;
+
+        alias.CanonicalAuthorId = null;
+        await db.SaveChangesAsync();
+        SuccessMessage = $"\"{alias.Name}\" is now its own canonical author.";
+        await LoadAsync(Header.Id);
+    }
+
+    public record AuthorHeader(int Id, string Name, int? CanonicalAuthorId, string? CanonicalName);
+
+    public record AuthorDetail(
+        IReadOnlyList<WorkRow> Works,
+        IReadOnlyList<BookSummaryRow> Books,
+        IReadOnlyList<string> AliasNames)
+    {
+        public static AuthorDetail Empty => new([], [], []);
+    }
+
+    public record WorkRow(
+        int Id,
+        string Title,
+        string? Subtitle,
+        string? WrittenAs,
+        string FirstPublishedDisplay,
+        string? SeriesName,
+        SeriesType? SeriesType,
+        int? SeriesOrder,
+        IReadOnlyList<BookRef> InBooks);
+
+    public record BookSummaryRow(
+        int Id,
+        string Title,
+        string? CoverUrl,
+        int EditionCount,
+        int CopyCount);
+
+    public record BookRef(int Id, string Title);
+
+    public record CanonicalCandidate(int Id, string Name);
+
+    public enum AuthorViewMode { Works, Books }
+}

--- a/BookTracker.Web/ViewModels/AuthorListViewModel.cs
+++ b/BookTracker.Web/ViewModels/AuthorListViewModel.cs
@@ -1,269 +1,136 @@
 using BookTracker.Data;
-using BookTracker.Data.Models;
-using BookTracker.Web.Services;
 using Microsoft.EntityFrameworkCore;
 
 namespace BookTracker.Web.ViewModels;
 
-// Backs the /authors page. Lists all Author entities with their work
-// counts and supports the basic alias operations:
-// - Mark a canonical Author as an alias of another canonical (Bachman → King)
-// - Promote an alias back to canonical
-// - Rename
-// Author merging (combining two canonicals) is tracked in TODO.md.
+// Backs /authors as a compact searchable list. Per-row counts (works,
+// books, series) are rolled up onto canonical rows — Stephen King's
+// counts include Bachman titles when Bachman is marked as an alias.
+// Alias rows show their own counts only.
 //
-// Each row can be expanded to show a drill-down with the author's Works
-// or Books (per-row toggle). For canonical authors the drill-down rolls
-// up any aliases — so Stephen King's expanded view includes Bachman
-// titles, and a note surfaces which aliases contributed. Works/books
-// load lazily on first expand; view-mode and expand state are kept on
-// the VM so flipping back and forth doesn't re-hit the DB.
+// Detail / rename / alias-management lives at /authors/{id} via
+// AuthorDetailViewModel — this VM only renders the listing.
 public class AuthorListViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory)
 {
     public bool Loading { get; private set; } = true;
     public List<AuthorRow> Authors { get; private set; } = [];
-    public string? SuccessMessage { get; set; }
 
-    public HashSet<int> ExpandedAuthorIds { get; private set; } = [];
-    public Dictionary<int, AuthorDetail> DetailByAuthorId { get; private set; } = [];
-    public Dictionary<int, AuthorViewMode> ViewModeByAuthorId { get; private set; } = [];
+    /// <summary>Free-text filter; matches the row name OR any of its alias names so that
+    /// typing a pen name surfaces the canonical row even when the alias row is hidden.</summary>
+    public string SearchTerm { get; set; } = "";
+
+    /// <summary>When false, only canonical authors render. Defaults to true (show every row).</summary>
+    public bool ShowAliases { get; set; } = true;
+
+    /// <summary>Filter applied to <see cref="Authors"/> using <see cref="SearchTerm"/> and <see cref="ShowAliases"/>.</summary>
+    public IEnumerable<AuthorRow> FilteredAuthors
+    {
+        get
+        {
+            IEnumerable<AuthorRow> q = Authors;
+
+            if (!ShowAliases)
+            {
+                q = q.Where(a => a.CanonicalAuthorId is null);
+            }
+
+            if (!string.IsNullOrWhiteSpace(SearchTerm))
+            {
+                var term = SearchTerm.Trim();
+                q = q.Where(a =>
+                    a.Name.Contains(term, StringComparison.OrdinalIgnoreCase) ||
+                    a.AliasNames.Any(n => n.Contains(term, StringComparison.OrdinalIgnoreCase)));
+            }
+
+            return q;
+        }
+    }
 
     public async Task LoadAsync()
     {
         Loading = true;
         await using var db = await dbFactory.CreateDbContextAsync();
 
-        var raw = await db.Authors
+        // Pull author + alias structure once. Counts are computed in-app from
+        // bulk-loaded join data — keeps the SQL simple (avoids the EF Core 10.x
+        // record-projection pitfalls) and the post-processing trivial at the
+        // 3000+ books target.
+        var authorsRaw = await db.Authors
             .Include(a => a.CanonicalAuthor)
-            .Select(a => new
-            {
-                a.Id,
-                a.Name,
-                a.CanonicalAuthorId,
-                CanonicalName = a.CanonicalAuthor != null ? a.CanonicalAuthor.Name : null,
-                WorkCount = a.Works.Count
-            })
+            .Include(a => a.Aliases)
             .OrderBy(a => a.Name)
             .ToListAsync();
 
-        Authors = raw
-            .Select(a => new AuthorRow(a.Id, a.Name, a.CanonicalAuthorId, a.CanonicalName, a.WorkCount))
-            .ToList();
+        var workAuthors = await db.WorkAuthors
+            .Select(wa => new { wa.AuthorId, wa.WorkId })
+            .ToListAsync();
 
+        var workSeries = await db.Works
+            .Where(w => w.SeriesId != null)
+            .Select(w => new { WorkId = w.Id, SeriesId = w.SeriesId!.Value })
+            .ToListAsync();
+
+        var bookWorkPairs = await db.Books
+            .SelectMany(b => b.Works.Select(w => new { BookId = b.Id, WorkId = w.Id }))
+            .ToListAsync();
+
+        var worksByAuthor = workAuthors
+            .GroupBy(wa => wa.AuthorId)
+            .ToDictionary(g => g.Key, g => g.Select(x => x.WorkId).ToHashSet());
+
+        var seriesByWork = workSeries
+            .GroupBy(w => w.WorkId)
+            .ToDictionary(g => g.Key, g => g.First().SeriesId);
+
+        var booksByWork = bookWorkPairs
+            .GroupBy(x => x.WorkId)
+            .ToDictionary(g => g.Key, g => g.Select(x => x.BookId).ToHashSet());
+
+        var rows = new List<AuthorRow>(authorsRaw.Count);
+        foreach (var a in authorsRaw)
+        {
+            // Canonical rollup: own author id PLUS every alias id pointing at it.
+            // Alias rows just count their own works/books/series — they exist
+            // mainly so the user can promote / rename / remove the alias link.
+            var rollupAuthorIds = a.CanonicalAuthorId is null
+                ? new[] { a.Id }.Concat(a.Aliases.Select(al => al.Id)).ToHashSet()
+                : new HashSet<int> { a.Id };
+
+            var workIds = rollupAuthorIds
+                .SelectMany(id => worksByAuthor.GetValueOrDefault(id, []))
+                .ToHashSet();
+
+            var bookIds = workIds
+                .SelectMany(wId => booksByWork.GetValueOrDefault(wId, []))
+                .ToHashSet();
+
+            var seriesIds = workIds
+                .Where(wId => seriesByWork.ContainsKey(wId))
+                .Select(wId => seriesByWork[wId])
+                .ToHashSet();
+
+            rows.Add(new AuthorRow(
+                a.Id,
+                a.Name,
+                a.CanonicalAuthorId,
+                a.CanonicalAuthor?.Name,
+                a.Aliases.Select(al => al.Name).OrderBy(n => n).ToList(),
+                workIds.Count,
+                bookIds.Count,
+                seriesIds.Count));
+        }
+
+        Authors = rows;
         Loading = false;
     }
 
-    public IEnumerable<AuthorRow> CanonicalAuthors => Authors.Where(a => a.CanonicalAuthorId is null);
-
-    public async Task ToggleExpandAsync(int authorId)
-    {
-        if (ExpandedAuthorIds.Remove(authorId)) return;
-        ExpandedAuthorIds.Add(authorId);
-        if (!DetailByAuthorId.ContainsKey(authorId))
-        {
-            DetailByAuthorId[authorId] = await LoadDetailAsync(authorId);
-        }
-    }
-
-    /// <summary>Pre-expand (idempotent) — used when /authors?expand=<id> is followed.</summary>
-    public async Task ExpandAsync(int authorId)
-    {
-        ExpandedAuthorIds.Add(authorId);
-        if (!DetailByAuthorId.ContainsKey(authorId))
-        {
-            DetailByAuthorId[authorId] = await LoadDetailAsync(authorId);
-        }
-    }
-
-    public AuthorViewMode GetViewMode(int authorId) =>
-        ViewModeByAuthorId.TryGetValue(authorId, out var m) ? m : AuthorViewMode.Works;
-
-    public void SetViewMode(int authorId, AuthorViewMode mode) =>
-        ViewModeByAuthorId[authorId] = mode;
-
-    private async Task<AuthorDetail> LoadDetailAsync(int authorId)
-    {
-        await using var db = await dbFactory.CreateDbContextAsync();
-
-        var author = await db.Authors
-            .Include(a => a.Aliases)
-            .FirstOrDefaultAsync(a => a.Id == authorId);
-        if (author is null) return AuthorDetail.Empty;
-
-        bool isCanonical = author.CanonicalAuthorId is null;
-
-        // Collect every author id that rolls up into this view — the
-        // author itself plus (for canonicals) every alias that points at it.
-        var ids = new List<int> { authorId };
-        if (isCanonical)
-        {
-            ids.AddRange(author.Aliases.Select(a => a.Id));
-        }
-
-        // Series-clustered Works first (in series-name then SeriesOrder
-        // order); standalone Works tail out alphabetically. So a Pratchett
-        // expand reads Discworld 1, 2, 3, ..., then Good Omens / Nation /
-        // etc. SeriesOrder-null Works inside a series sink to the bottom of
-        // their series via int.MaxValue.
-        var works = await db.Works
-            .Include(w => w.WorkAuthors).ThenInclude(wa => wa.Author)
-            .Include(w => w.Books)
-            .Include(w => w.Series)
-            .Where(w => w.WorkAuthors.Any(wa => ids.Contains(wa.AuthorId)))
-            .OrderBy(w => w.SeriesId == null)
-            .ThenBy(w => w.Series!.Name)
-            .ThenBy(w => w.SeriesOrder ?? int.MaxValue)
-            .ThenBy(w => w.Title)
-            .ToListAsync();
-
-        var workRows = works.Select(w => new WorkRow(
-            w.Id,
-            w.Title,
-            w.Subtitle,
-            // Flag which alias a work was written as, but only on canonical
-            // rows (on an alias row the author is always itself). For single-
-            // identity canonicals this is always null. Picks the *lead*
-            // author for the alias label — co-authored works under a canonical
-            // get labelled by their lead's pen name, which is how booksellers
-            // typically attribute them.
-            isCanonical
-                ? w.WorkAuthors.OrderBy(wa => wa.Order).Select(wa => wa.Author).FirstOrDefault() is { } leadAuthor && leadAuthor.Id != authorId
-                    ? leadAuthor.Name
-                    : null
-                : null,
-            PartialDateParser.Format(w.FirstPublishedDate, w.FirstPublishedDatePrecision),
-            w.Series?.Name,
-            w.Series?.Type,
-            w.SeriesOrder,
-            w.Books.Select(b => new BookRef(b.Id, b.Title)).ToList()
-        )).ToList();
-
-        var bookIds = works.SelectMany(w => w.Books).Select(b => b.Id).Distinct().ToList();
-        var books = await db.Books
-            .Where(b => bookIds.Contains(b.Id))
-            .Include(b => b.Editions).ThenInclude(e => e.Copies)
-            .OrderBy(b => b.Title)
-            .ToListAsync();
-
-        var bookRows = books.Select(b => new BookSummaryRow(
-            b.Id,
-            b.Title,
-            b.DefaultCoverArtUrl,
-            b.Editions.Count,
-            b.Editions.Sum(e => e.Copies.Count)
-        )).ToList();
-
-        var aliasNames = isCanonical
-            ? author.Aliases.Select(a => a.Name).OrderBy(n => n).ToList()
-            : new List<string>();
-
-        return new AuthorDetail(workRows, bookRows, aliasNames);
-    }
-
-    public async Task MarkAsAliasAsync(int aliasId, int canonicalId)
-    {
-        if (aliasId == canonicalId) return; // can't alias to self
-
-        await using var db = await dbFactory.CreateDbContextAsync();
-        var alias = await db.Authors.FirstOrDefaultAsync(a => a.Id == aliasId);
-        var canonical = await db.Authors.FirstOrDefaultAsync(a => a.Id == canonicalId);
-        if (alias is null || canonical is null) return;
-
-        // Don't chain aliases — point at the *root* canonical so two-hop
-        // alias graphs don't form.
-        var rootCanonicalId = canonical.CanonicalAuthorId ?? canonical.Id;
-
-        alias.CanonicalAuthorId = rootCanonicalId;
-
-        // Any author that previously aliased to this one should now alias to
-        // the new root, otherwise we'd leave dangling chained aliases.
-        var prior = await db.Authors.Where(a => a.CanonicalAuthorId == aliasId).ToListAsync();
-        foreach (var p in prior)
-        {
-            p.CanonicalAuthorId = rootCanonicalId;
-        }
-
-        await db.SaveChangesAsync();
-        SuccessMessage = $"\"{alias.Name}\" is now an alias of \"{canonical.Name}\".";
-        InvalidateDetailsFor(aliasId, canonicalId, rootCanonicalId);
-        await LoadAsync();
-    }
-
-    public async Task PromoteToCanonicalAsync(int aliasId)
-    {
-        await using var db = await dbFactory.CreateDbContextAsync();
-        var alias = await db.Authors.FirstOrDefaultAsync(a => a.Id == aliasId);
-        if (alias is null || alias.CanonicalAuthorId is null) return;
-
-        var priorCanonicalId = alias.CanonicalAuthorId.Value;
-        alias.CanonicalAuthorId = null;
-        await db.SaveChangesAsync();
-        SuccessMessage = $"\"{alias.Name}\" is now its own canonical author.";
-        InvalidateDetailsFor(aliasId, priorCanonicalId);
-        await LoadAsync();
-    }
-
-    public async Task RenameAsync(int authorId, string newName)
-    {
-        var trimmed = newName.Trim();
-        if (string.IsNullOrEmpty(trimmed)) return;
-
-        await using var db = await dbFactory.CreateDbContextAsync();
-        var author = await db.Authors.FirstOrDefaultAsync(a => a.Id == authorId);
-        if (author is null) return;
-
-        // Prevent rename collision with another existing Author.
-        var clash = await db.Authors.AnyAsync(a => a.Id != authorId && a.Name == trimmed);
-        if (clash)
-        {
-            SuccessMessage = $"An author named \"{trimmed}\" already exists. Use the alias dropdown to merge.";
-            return;
-        }
-
-        author.Name = trimmed;
-        await db.SaveChangesAsync();
-        SuccessMessage = $"Renamed to \"{trimmed}\".";
-        InvalidateDetailsFor(authorId);
-        await LoadAsync();
-    }
-
-    // Any structural change (alias / promote / rename) potentially invalidates
-    // the cached drill-down detail for the affected authors — drop them so
-    // the next expand reloads fresh from the DB.
-    private void InvalidateDetailsFor(params int[] authorIds)
-    {
-        foreach (var id in authorIds) DetailByAuthorId.Remove(id);
-    }
-
-    public record AuthorRow(int Id, string Name, int? CanonicalAuthorId, string? CanonicalName, int WorkCount);
-
-    public record AuthorDetail(
-        IReadOnlyList<WorkRow> Works,
-        IReadOnlyList<BookSummaryRow> Books,
-        IReadOnlyList<string> AliasNames)
-    {
-        public static AuthorDetail Empty => new([], [], []);
-    }
-
-    public record WorkRow(
+    public record AuthorRow(
         int Id,
-        string Title,
-        string? Subtitle,
-        string? WrittenAs,
-        string FirstPublishedDisplay,
-        string? SeriesName,
-        SeriesType? SeriesType,
-        int? SeriesOrder,
-        IReadOnlyList<BookRef> InBooks);
-
-    public record BookSummaryRow(
-        int Id,
-        string Title,
-        string? CoverUrl,
-        int EditionCount,
-        int CopyCount);
-
-    public record BookRef(int Id, string Title);
-
-    public enum AuthorViewMode { Works, Books }
+        string Name,
+        int? CanonicalAuthorId,
+        string? CanonicalName,
+        IReadOnlyList<string> AliasNames,
+        int WorkCount,
+        int BookCount,
+        int SeriesCount);
 }


### PR DESCRIPTION
Closes the "Authors page unusable at 200+ rows" item. The previous
expand-in-row UX was workable at small scale but fell apart on
mobile when the page got long enough that a single expanded row
made the rest unscrollable.

New shape:
- /authors becomes a compact list. Per-row: name, alias-or-canonical
  chip, work count, book count, series count, click-anywhere row to
  navigate. Counts roll up onto canonical rows (King's row counts
  King + Bachman titles); alias rows show their own counts only.
  Search input filters by name OR alias name (typing "Bachman"
  surfaces King's row even when alias-rows are hidden). Toggle
  switch hides alias rows entirely (defaults to showing them, matches
  current behaviour). MudVirtualize keeps scroll smooth as the list
  grows past 200 → 1000+ authors.
- /authors/{id:int} is a new detail page. Hosts rename + alias
  management (mark-as-alias-of, promote-to-canonical) which moved
  off the list. Same Works / Books drill-down as before, with the
  same "as Bachman" labels on canonical roll-up rows. Back link to
  /authors.

ViewModel split:
- AuthorListViewModel: slim down to listing + filter. Counts pulled
  via bulk-loaded join data + in-memory aggregation (avoids EF Core
  10.x's record-projection translation pitfalls; one query each for
  authors, WorkAuthors, work-series, book-work pairs).
- AuthorDetailViewModel: NEW. Owns the rename / alias / promote ops
  and the per-author Works/Books/Aliases load. Bound per page
  instance via LoadAsync(authorId). OnParametersSetAsync handles
  client-side nav between two author detail pages (e.g. clicking
  the canonical link from an alias header).

Home page deep-link updated: /authors?expand=<id> → /authors/<id>
direct. The query-param shape was only used from Home so the swap
is cleanly contained.

Tests:
- AuthorListViewModelTests: trimmed expand/rename/alias coverage,
  added 5 fresh tests for counts (rollup vs own), filter (alias
  toggle, alias-aware search, whitespace).
- AuthorDetailViewModelTests: NEW. 9 tests covering NotFound shape,
  canonical roll-up, alias-only-shows-own, series-clustered ordering,
  rename happy-path + clash, mark-as-alias linking + chain re-root,
  promote-to-canonical.

All 358 non-E2E tests pass. ViewModel-level tests cover the new
behaviour; the Razor markup needs hands-on testing locally —
particularly the search/filter behaviour, the virtualised scroll on
mobile (200+ author seed), the click-to-detail navigation, and the
detail-page rename/alias/promote flows.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
