### PR TITLE
fix(covers): isolate prod and staging into separate containers

### DIFF
--- a/infra/modules/app-config.bicep
+++ b/infra/modules/app-config.bicep
@@ -23,10 +23,14 @@ param aiAzureOpenAIEndpoint string = ''
 param aiAzureOpenAIDeployment string = ''
 param aiDefaultProvider string = 'Anthropic'
 
-// Cover storage. Connection string is resolved from KV; container URL is
-// non-secret (it's the public read URL embedded in <img src> tags).
-param coverStoragePublicBaseUrl string = ''
-param coverStorageContainerName string = 'book-covers'
+// Cover storage. Connection string is resolved from KV (shared by both
+// slots — same storage account). Container name + public URL differ per
+// slot so prod and staging writes can't collide on independent Edition IDs;
+// both are slot-sticky (see slotConfigNames below).
+param coverStorageProdContainerName string = 'book-covers'
+param coverStorageStagingContainerName string = 'book-covers-staging'
+param coverStorageProdPublicBaseUrl string = ''
+param coverStorageStagingPublicBaseUrl string = ''
 
 // Key Vault reference helpers. App Service resolves these via its managed
 // identity (which has Key Vault Secrets User role) and caches the resolved
@@ -53,7 +57,10 @@ var coverStorageConnRef = '@Microsoft.KeyVault(SecretUri=${kvBase}/CoverStorageC
 // Same shape for prod + staging; slotConfigNames below marks the secret-ish
 // entries as slot-sticky so swaps don't move them if the two slots' values
 // ever diverge.
-var appSettingsValues = {
+// Shared values across both slots — connection string is one because both
+// slots use the same storage account; the container name + public URL differ
+// per slot below.
+var commonAppSettings = {
   ASPNETCORE_ENVIRONMENT: 'Production'
   APPLICATIONINSIGHTS_CONNECTION_STRING: appInsightsConnectionString
   MICROSOFT_PROVIDER_AUTHENTICATION_SECRET: authClientSecretRef
@@ -64,9 +71,17 @@ var appSettingsValues = {
   AI__Anthropic__ApiKey: anthropicKeyRef
   Trove__ApiKey: troveKeyRef
   CoverStorage__ConnectionString: coverStorageConnRef
-  CoverStorage__ContainerName: coverStorageContainerName
-  CoverStorage__PublicBaseUrl: coverStoragePublicBaseUrl
 }
+
+var prodAppSettingsValues = union(commonAppSettings, {
+  CoverStorage__ContainerName: coverStorageProdContainerName
+  CoverStorage__PublicBaseUrl: coverStorageProdPublicBaseUrl
+})
+
+var stagingAppSettingsValues = union(commonAppSettings, {
+  CoverStorage__ContainerName: coverStorageStagingContainerName
+  CoverStorage__PublicBaseUrl: coverStorageStagingPublicBaseUrl
+})
 
 // Settings that must stay pinned to their slot during a swap. Keys and
 // environment-flavoured values should never hop between prod and staging,
@@ -83,6 +98,12 @@ var slotStickyAppSettingNames = [
   'AI__DefaultProvider'
   'Trove__ApiKey'
   'CoverStorage__ConnectionString'
+  // ContainerName + PublicBaseUrl MUST be slot-sticky — they differ per slot
+  // (`book-covers` vs `book-covers-staging`) so writes don't collide on
+  // independent Edition IDs. A swap moving them with the bits would break
+  // the just-promoted slot's cover URLs.
+  'CoverStorage__ContainerName'
+  'CoverStorage__PublicBaseUrl'
 ]
 
 // Paths served publicly (without Easy Auth). Limited to the PWA assets
@@ -115,7 +136,7 @@ resource stagingSlot 'Microsoft.Web/sites/slots@2023-12-01' existing = {
 resource appSettings 'Microsoft.Web/sites/config@2023-12-01' = {
   parent: app
   name: 'appsettings'
-  properties: appSettingsValues
+  properties: prodAppSettingsValues
 }
 
 // Slot-sticky setting names. Attached to the production site (not the slot)
@@ -196,7 +217,7 @@ resource authConfig 'Microsoft.Web/sites/config@2023-12-01' = {
 resource stagingAppSettings 'Microsoft.Web/sites/slots/config@2023-12-01' = {
   parent: stagingSlot
   name: 'appsettings'
-  properties: appSettingsValues
+  properties: stagingAppSettingsValues
 }
 
 resource stagingConnStrings 'Microsoft.Web/sites/slots/config@2023-12-01' = {

--- a/infra/modules/cover-storage.bicep
+++ b/infra/modules/cover-storage.bicep
@@ -13,7 +13,13 @@ param location string
 param tags object
 param storageAccountName string
 param keyVaultName string
-param containerName string = 'book-covers'
+
+// Two containers — one per slot — share a single storage account. Mirrors
+// the slot-isolation pattern used for SQL (one server, two databases). Keys
+// like `editions/{id}.jpg` would collide across slots if both wrote to the
+// same container, since prod and staging DBs assign IDs independently.
+param prodContainerName string = 'book-covers'
+param stagingContainerName string = 'book-covers-staging'
 
 resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' = {
   name: storageAccountName
@@ -50,11 +56,19 @@ resource blobService 'Microsoft.Storage/storageAccounts/blobServices@2023-05-01'
   }
 }
 
-resource container 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-05-01' = {
+resource prodContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-05-01' = {
   parent: blobService
-  name: containerName
+  name: prodContainerName
   properties: {
     // Blob-level public read — anyone with the URL can GET, no listing.
+    publicAccess: 'Blob'
+  }
+}
+
+resource stagingContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-05-01' = {
+  parent: blobService
+  name: stagingContainerName
+  properties: {
     publicAccess: 'Blob'
   }
 }
@@ -78,6 +92,8 @@ resource secretConnectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' =
 }
 
 output storageAccountName string = storageAccount.name
-output containerName string = containerName
 output blobEndpoint string = storageAccount.properties.primaryEndpoints.blob
-output publicContainerUrl string = '${storageAccount.properties.primaryEndpoints.blob}${containerName}'
+output prodContainerName string = prodContainerName
+output stagingContainerName string = stagingContainerName
+output prodPublicContainerUrl string = '${storageAccount.properties.primaryEndpoints.blob}${prodContainerName}'
+output stagingPublicContainerUrl string = '${storageAccount.properties.primaryEndpoints.blob}${stagingContainerName}'

--- a/infra/modules/resources.bicep
+++ b/infra/modules/resources.bicep
@@ -226,7 +226,10 @@ module appConfig './app-config.bicep' = {
     keyVaultName: keyVaultName
     aiAzureOpenAIEndpoint: ai.outputs.openAIEndpoint
     aiAzureOpenAIDeployment: ai.outputs.openAIDeploymentName
-    coverStoragePublicBaseUrl: coverStorage.outputs.publicContainerUrl
+    coverStorageProdContainerName: coverStorage.outputs.prodContainerName
+    coverStorageStagingContainerName: coverStorage.outputs.stagingContainerName
+    coverStorageProdPublicBaseUrl: coverStorage.outputs.prodPublicContainerUrl
+    coverStorageStagingPublicBaseUrl: coverStorage.outputs.stagingPublicContainerUrl
   }
   // Wait for KV (so KV refs resolve). Storage is implicit via the
   // `coverStoragePublicBaseUrl` output reference above.


### PR DESCRIPTION
PR1 left both slots pointed at the same `book-covers` container, with
the connection string + container name + public URL all identical
across slots. Since prod and staging databases assign IDs
independently, both slots writing `editions/{editionId}.jpg` would
overwrite each other on the next swap — staging Edition 42 (e.g. The
Hobbit) and prod Edition 42 (a different book entirely) sharing one
blob.

Fix mirrors the existing slot-isolation pattern used for SQL: one
storage account, two containers — `book-covers` (prod) and
`book-covers-staging` (staging) — with the container name + public
URL slot-sticky. The connection string stays shared (one storage
account, one auth) and stays slot-sticky as before.

cover-storage.bicep:
- Renames `containerName` parameter to `prodContainerName`, adds
  `stagingContainerName` (defaults `book-covers-staging`).
- Two container resources, both with publicAccess=Blob.
- Outputs `prodContainerName` / `stagingContainerName` /
  `prodPublicContainerUrl` / `stagingPublicContainerUrl`.

resources.bicep: passes both URL outputs through to appConfig.

app-config.bicep:
- Splits `appSettingsValues` into a shared `commonAppSettings` plus
  per-slot `prodAppSettingsValues` and `stagingAppSettingsValues`
  that override only the container-name + public-URL pair.
- Adds `CoverStorage__ContainerName` and `CoverStorage__PublicBaseUrl`
  to the slot-sticky list — they MUST stay pinned to their slot
  through swaps, otherwise a swap promotes prod code with staging
  config (or vice versa), which would either re-mirror everything
  on the wrong side or break IsManagedUrl checks on the just-
  promoted slot.

Self-migration on next deploy:
- Staging slot's settings change → staging restarts → mirror service
  walks Editions, sees existing URLs at `.../book-covers/...` (which
  no longer match the new staging PublicBaseUrl `.../book-covers-staging`),
  treats them as un-mirrored, re-fetches from the old URL (still
  served), uploads to the new container, updates the DB. Old blobs
  become orphans in `book-covers` — harmless; can be cleaned up
  manually later if desired.
- Prod stays unchanged (still pointed at `book-covers`). After swap
  to PR1 code, prod's mirror service backfills as normal. If a prod
  Edition ID happens to collide with an old orphan staging blob in
  `book-covers`, the prod write correctly overwrites it.

No app code change — BlobBookCoverStorage already reads ContainerName
and PublicBaseUrl from CoverStorageOptions, so different per-slot
values just route writes to different containers automatically.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
