### PR TITLE
feat(covers): user-supplied cover photos for individual editions (PR2)

### DIFF
--- a/BookTracker.Data/Migrations/20260507062841_AddEditionIsUserSupplied.Designer.cs
+++ b/BookTracker.Data/Migrations/20260507062841_AddEditionIsUserSupplied.Designer.cs
@@ -4,6 +4,7 @@ using BookTracker.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BookTracker.Data.Migrations
 {
     [DbContext(typeof(BookTrackerDbContext))]
-    partial class BookTrackerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260507062841_AddEditionIsUserSupplied")]
+    partial class AddEditionIsUserSupplied
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BookTracker.Data/Migrations/20260507062841_AddEditionIsUserSupplied.cs
+++ b/BookTracker.Data/Migrations/20260507062841_AddEditionIsUserSupplied.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BookTracker.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddEditionIsUserSupplied : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsUserSupplied",
+                table: "Editions",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsUserSupplied",
+                table: "Editions");
+        }
+    }
+}

--- a/BookTracker.Data/Models/Edition.cs
+++ b/BookTracker.Data/Models/Edition.cs
@@ -25,6 +25,16 @@ public class Edition
     [MaxLength(500)]
     public string? CoverUrl { get; set; }
 
+    /// <summary>
+    /// True when <see cref="CoverUrl"/> points at a user-uploaded photo
+    /// (typically because no online cover was available for a rare or old
+    /// edition). Mirrored covers from upstream providers stay false. Used
+    /// to (a) flag the cover with a small "your photo" badge in display
+    /// surfaces, and (b) skip user-supplied covers if a future re-mirror
+    /// pass re-fetches upstream URLs en masse.
+    /// </summary>
+    public bool IsUserSupplied { get; set; }
+
     public int? PublisherId { get; set; }
     public Publisher? Publisher { get; set; }
 

--- a/BookTracker.Tests/ViewModels/BookDetailViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/BookDetailViewModelTests.cs
@@ -1,17 +1,26 @@
 using BookTracker.Data.Models;
+using BookTracker.Web.Services.Covers;
 using BookTracker.Web.ViewModels;
+using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
 
 namespace BookTracker.Tests.ViewModels;
 
 [Trait("Category", TestCategories.Integration)]
 public class BookDetailViewModelTests
 {
+    private static BookDetailViewModel CreateVm(TestDbContextFactory factory, IBookCoverStorage? coverStorage = null) =>
+        new(factory,
+            coverStorage ?? Substitute.For<IBookCoverStorage>(),
+            NullLogger<BookDetailViewModel>.Instance);
+
     [Fact]
     public async Task InitializeAsync_MissingId_MarksNotFound()
     {
         var factory = new TestDbContextFactory();
-        var vm = new BookDetailViewModel(factory);
+        var vm = CreateVm(factory);
 
         await vm.InitializeAsync(999);
 
@@ -50,7 +59,7 @@ public class BookDetailViewModelTests
             bookId = book.Id;
         }
 
-        var vm = new BookDetailViewModel(factory);
+        var vm = CreateVm(factory);
         await vm.InitializeAsync(bookId);
 
         Assert.False(vm.NotFound);
@@ -90,7 +99,7 @@ public class BookDetailViewModelTests
             bookId = book.Id;
         }
 
-        var vm = new BookDetailViewModel(factory);
+        var vm = CreateVm(factory);
         await vm.InitializeAsync(bookId);
 
         Assert.False(vm.IsSingleWork);
@@ -138,7 +147,7 @@ public class BookDetailViewModelTests
             bookId = book.Id;
         }
 
-        var vm = new BookDetailViewModel(factory);
+        var vm = CreateVm(factory);
         await vm.InitializeAsync(bookId);
 
         Assert.Equal(2, vm.TotalEditions);
@@ -154,7 +163,7 @@ public class BookDetailViewModelTests
         var factory = new TestDbContextFactory();
         var bookId = await SeedSimpleBookAsync(factory, rating: 2);
 
-        var vm = new BookDetailViewModel(factory);
+        var vm = CreateVm(factory);
         await vm.InitializeAsync(bookId);
         await vm.SetRatingAsync(5);
 
@@ -169,7 +178,7 @@ public class BookDetailViewModelTests
         var factory = new TestDbContextFactory();
         var bookId = await SeedSimpleBookAsync(factory, status: BookStatus.Unread);
 
-        var vm = new BookDetailViewModel(factory);
+        var vm = CreateVm(factory);
         await vm.InitializeAsync(bookId);
         await vm.SetStatusAsync(BookStatus.Reading);
 
@@ -184,7 +193,7 @@ public class BookDetailViewModelTests
         var factory = new TestDbContextFactory();
         var bookId = await SeedSimpleBookAsync(factory, notes: "original");
 
-        var vm = new BookDetailViewModel(factory);
+        var vm = CreateVm(factory);
         await vm.InitializeAsync(bookId);
 
         // Not dirty yet — save should be a no-op even if CurrentNotes changed.
@@ -213,7 +222,7 @@ public class BookDetailViewModelTests
         var factory = new TestDbContextFactory();
         var bookId = await SeedSimpleBookAsync(factory, notes: "will be cleared");
 
-        var vm = new BookDetailViewModel(factory);
+        var vm = CreateVm(factory);
         await vm.InitializeAsync(bookId);
         vm.CurrentNotes = "   ";
         vm.MarkNotesDirty();
@@ -229,7 +238,7 @@ public class BookDetailViewModelTests
         var factory = new TestDbContextFactory();
         var bookId = await SeedSimpleBookAsync(factory);
 
-        var vm = new BookDetailViewModel(factory);
+        var vm = CreateVm(factory);
         await vm.InitializeAsync(bookId);
         var added = await vm.AddTagAsync("Signed");
 
@@ -260,7 +269,7 @@ public class BookDetailViewModelTests
             bookId = book.Id;
         }
 
-        var vm = new BookDetailViewModel(factory);
+        var vm = CreateVm(factory);
         await vm.InitializeAsync(bookId);
         await vm.AddTagAsync("FOLLOW-UP");
 
@@ -288,7 +297,7 @@ public class BookDetailViewModelTests
             bookId = book.Id;
         }
 
-        var vm = new BookDetailViewModel(factory);
+        var vm = CreateVm(factory);
         await vm.InitializeAsync(bookId);
         var second = await vm.AddTagAsync("gift");
 
@@ -317,7 +326,7 @@ public class BookDetailViewModelTests
             tagId = tag.Id;
         }
 
-        var vm = new BookDetailViewModel(factory);
+        var vm = CreateVm(factory);
         await vm.InitializeAsync(bookId);
         await vm.RemoveTagAsync(tagId);
 
@@ -359,7 +368,7 @@ public class BookDetailViewModelTests
             copyToDelete = edition.Copies[0].Id;
         }
 
-        var vm = new BookDetailViewModel(factory);
+        var vm = CreateVm(factory);
         await vm.InitializeAsync(bookId);
         await vm.DeleteCopyAsync(copyToDelete);
 
@@ -391,7 +400,7 @@ public class BookDetailViewModelTests
             copyToDelete = edition.Copies[0].Id;
         }
 
-        var vm = new BookDetailViewModel(factory);
+        var vm = CreateVm(factory);
         await vm.InitializeAsync(bookId);
         await vm.DeleteCopyAsync(copyToDelete);
 
@@ -421,7 +430,7 @@ public class BookDetailViewModelTests
             bookId = book.Id;
         }
 
-        var vm = new BookDetailViewModel(factory);
+        var vm = CreateVm(factory);
         await vm.InitializeAsync(bookId);
         var results = (await vm.SearchTagsAsync("", CancellationToken.None)).ToList();
 
@@ -475,10 +484,134 @@ public class BookDetailViewModelTests
             bookId = book.Id;
         }
 
-        var vm = new BookDetailViewModel(factory);
+        var vm = CreateVm(factory);
         await vm.InitializeAsync(bookId);
 
         var names = vm.Book!.Tags.Select(t => t.Name).ToList();
         Assert.Equal(new[] { "follow-up", "gift", "signed" }, names);
+    }
+
+    [Fact]
+    public async Task UploadEditionCoverAsync_HappyPath_UpdatesUrlAndFlagsUserSupplied()
+    {
+        var factory = new TestDbContextFactory();
+        int bookId, editionId;
+        using (var db = factory.CreateDbContext())
+        {
+            var author = new Author { Name = "A" };
+            var book = new Book
+            {
+                Title = "B",
+                Works = [new Work { Title = "B", WorkAuthors = [new WorkAuthor { Author = author, Order = 0 }] }],
+                Editions = [new Edition { Isbn = "1", Format = BookFormat.TradePaperback, Copies = [new Copy { Condition = BookCondition.Good }] }],
+            };
+            db.Books.Add(book);
+            await db.SaveChangesAsync();
+            bookId = book.Id;
+            editionId = book.Editions[0].Id;
+        }
+
+        var storage = Substitute.For<IBookCoverStorage>();
+        storage.IsEnabled.Returns(true);
+        storage.UploadAsync(Arg.Any<byte[]>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns("https://test/book-covers/editions/" + editionId + ".jpg?v=42");
+
+        var fileBytes = new byte[] { 0xFF, 0xD8, 0x01, 0x02, 0x03 }; // JPEG-ish header bytes
+        var file = Substitute.For<IBrowserFile>();
+        file.Size.Returns((long)fileBytes.Length);
+        file.Name.Returns("test.jpg");
+        file.ContentType.Returns("image/jpeg");
+        file.OpenReadStream(Arg.Any<long>(), Arg.Any<CancellationToken>()).Returns(new MemoryStream(fileBytes));
+
+        var vm = CreateVm(factory, storage);
+        await vm.InitializeAsync(bookId);
+
+        var result = await vm.UploadEditionCoverAsync(editionId, file, CancellationToken.None);
+
+        Assert.True(result.Success);
+        Assert.Equal("https://test/book-covers/editions/" + editionId + ".jpg?v=42", result.NewUrl);
+
+        using var verifyDb = factory.CreateDbContext();
+        var saved = verifyDb.Editions.Single(e => e.Id == editionId);
+        Assert.Equal("https://test/book-covers/editions/" + editionId + ".jpg?v=42", saved.CoverUrl);
+        Assert.True(saved.IsUserSupplied);
+
+        // The VM snapshot should reflect the new URL after the post-upload refresh.
+        var refreshedEdition = vm.Book!.Editions.Single(e => e.Id == editionId);
+        Assert.Equal(saved.CoverUrl, refreshedEdition.CoverUrl);
+        Assert.True(refreshedEdition.IsUserSupplied);
+    }
+
+    [Fact]
+    public async Task UploadEditionCoverAsync_FileTooLarge_ReturnsFailure_AndDoesNotUpload()
+    {
+        var factory = new TestDbContextFactory();
+        int bookId, editionId;
+        using (var db = factory.CreateDbContext())
+        {
+            var author = new Author { Name = "A" };
+            var book = new Book
+            {
+                Title = "B",
+                Works = [new Work { Title = "B", WorkAuthors = [new WorkAuthor { Author = author, Order = 0 }] }],
+                Editions = [new Edition { Format = BookFormat.TradePaperback, Copies = [new Copy { Condition = BookCondition.Good }] }],
+            };
+            db.Books.Add(book);
+            await db.SaveChangesAsync();
+            bookId = book.Id;
+            editionId = book.Editions[0].Id;
+        }
+
+        var storage = Substitute.For<IBookCoverStorage>();
+        storage.IsEnabled.Returns(true);
+
+        var file = Substitute.For<IBrowserFile>();
+        file.Size.Returns(BookDetailViewModel.MaxUploadBytes + 1);
+        file.Name.Returns("huge.jpg");
+        file.ContentType.Returns("image/jpeg");
+
+        var vm = CreateVm(factory, storage);
+        await vm.InitializeAsync(bookId);
+
+        var result = await vm.UploadEditionCoverAsync(editionId, file, CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Contains("too large", result.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+        await storage.DidNotReceive().UploadAsync(Arg.Any<byte[]>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task UploadEditionCoverAsync_StorageDisabled_ReturnsFailure()
+    {
+        var factory = new TestDbContextFactory();
+        int bookId, editionId;
+        using (var db = factory.CreateDbContext())
+        {
+            var author = new Author { Name = "A" };
+            var book = new Book
+            {
+                Title = "B",
+                Works = [new Work { Title = "B", WorkAuthors = [new WorkAuthor { Author = author, Order = 0 }] }],
+                Editions = [new Edition { Format = BookFormat.TradePaperback, Copies = [new Copy { Condition = BookCondition.Good }] }],
+            };
+            db.Books.Add(book);
+            await db.SaveChangesAsync();
+            bookId = book.Id;
+            editionId = book.Editions[0].Id;
+        }
+
+        var storage = Substitute.For<IBookCoverStorage>();
+        storage.IsEnabled.Returns(false); // configuration missing — service idle
+
+        var file = Substitute.For<IBrowserFile>();
+        file.Size.Returns(100L);
+
+        var vm = CreateVm(factory, storage);
+        await vm.InitializeAsync(bookId);
+
+        var result = await vm.UploadEditionCoverAsync(editionId, file, CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Contains("not configured", result.ErrorMessage, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/BookTracker.Web/Components/Pages/Books/Detail.razor
+++ b/BookTracker.Web/Components/Pages/Books/Detail.razor
@@ -312,6 +312,20 @@
                                             <FieldRow Label="Printed" Value="@edition.DatePrintedDisplay" />
                                         }
 
+                                        @* Cover preview row — shown when the edition has a cover so the user can
+                                           see what's currently on file before replacing. The "your photo" badge
+                                           surfaces when the cover came from a user upload rather than upstream. *@
+                                        @if (!string.IsNullOrEmpty(edition.CoverUrl))
+                                        {
+                                            <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
+                                                <MudImage Src="@edition.CoverUrl" Alt="" Width="48" Height="68" ObjectFit="ObjectFit.Cover" Style="border-radius: 4px;" />
+                                                @if (edition.IsUserSupplied)
+                                                {
+                                                    <MudChip T="string" Size="Size.Small" Color="Color.Info" Variant="Variant.Text">your photo</MudChip>
+                                                }
+                                            </MudStack>
+                                        }
+
                                         <MudStack Row="true" Spacing="1" Wrap="Wrap.Wrap">
                                             <MudButton OnClick="@(() => OpenEditEditionDialog(edition.Id))"
                                                        Disabled="@dialogOpening"
@@ -326,6 +340,13 @@
                                                        Size="Size.Small"
                                                        StartIcon="@Icons.Material.Filled.Add">
                                                 Add copy
+                                            </MudButton>
+                                            <MudButton OnClick="@(() => OpenUploadCoverDialog(edition.Id))"
+                                                       Disabled="@dialogOpening"
+                                                       Variant="Variant.Outlined"
+                                                       Size="Size.Small"
+                                                       StartIcon="@Icons.Material.Filled.PhotoCamera">
+                                                @(string.IsNullOrEmpty(edition.CoverUrl) ? "Upload photo" : "Replace photo")
                                             </MudButton>
                                         </MudStack>
 
@@ -695,6 +716,21 @@
             Snackbar.Add("Copy added", Severity.Success);
             await VM.InitializeAsync(BookId);
         }
+    });
+
+    private Task OpenUploadCoverDialog(int editionId) => OpenDialogGuardedAsync(async () =>
+    {
+        var parameters = new DialogParameters<EditionCoverUploadDialog>
+        {
+            { x => x.EditionId, editionId },
+            { x => x.ViewModel, VM },
+        };
+        var options = new DialogOptions { MaxWidth = MaxWidth.Small, FullWidth = true, CloseButton = true };
+        var dialog = await DialogService.ShowAsync<EditionCoverUploadDialog>("Upload cover photo", parameters, options);
+        // The dialog itself runs the upload through VM.UploadEditionCoverAsync,
+        // which calls InitializeAsync on success — so the page already has fresh
+        // data by the time we get back here. No extra refresh needed.
+        await dialog.Result;
     });
 
     private Task OpenEditCopyDialog(int copyId) => OpenDialogGuardedAsync(async () =>

--- a/BookTracker.Web/Components/Shared/EditionCoverUploadDialog.razor
+++ b/BookTracker.Web/Components/Shared/EditionCoverUploadDialog.razor
@@ -1,0 +1,118 @@
+@* Modal dialog for uploading a user-supplied cover photo for a specific
+   Edition. Used for rare / old editions where no online cover exists. The
+   dialog routes the upload through the page's BookDetailViewModel (passed
+   in as a parameter) so post-upload state refresh is centralised — the
+   VM persists Edition.CoverUrl + IsUserSupplied and re-loads the page's
+   snapshot in one step. *@
+
+@inject ISnackbar Snackbar
+@using Microsoft.AspNetCore.Components.Forms
+
+<MudDialog>
+    <DialogContent>
+        <MudStack Spacing="2" Style="min-width: 280px;">
+            <MudText Typo="Typo.body2" Color="Color.Secondary">
+                Upload a photo of this edition's cover. Mobile users get the rear camera by default. Max @(BookDetailViewModel.MaxUploadBytes / 1024 / 1024) MB.
+            </MudText>
+
+            <MudFileUpload T="IBrowserFile"
+                           FilesChanged="OnFileChanged"
+                           Accept="image/*"
+                           MaximumFileCount="1">
+                <ActivatorContent>
+                    <MudButton Variant="Variant.Outlined"
+                               StartIcon="@Icons.Material.Filled.CameraAlt"
+                               Color="Color.Primary"
+                               FullWidth="true"
+                               Disabled="@uploading">
+                        @(picked is null ? "Choose photo" : "Choose different photo")
+                    </MudButton>
+                </ActivatorContent>
+            </MudFileUpload>
+
+            @if (picked is not null)
+            {
+                <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
+                    <MudIcon Icon="@Icons.Material.Filled.Image" Color="Color.Primary" />
+                    <MudStack Spacing="0" Class="flex-grow-1" Style="min-width: 0;">
+                        <MudText Typo="Typo.body2" Style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">@picked.Name</MudText>
+                        <MudText Typo="Typo.caption" Color="Color.Secondary">
+                            @FormatSize(picked.Size) — @picked.ContentType
+                        </MudText>
+                    </MudStack>
+                </MudStack>
+                @if (picked.Size > BookDetailViewModel.MaxUploadBytes)
+                {
+                    <MudAlert Severity="Severity.Error" Dense="true">
+                        File too large. Max is @(BookDetailViewModel.MaxUploadBytes / 1024 / 1024) MB.
+                    </MudAlert>
+                }
+            }
+        </MudStack>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Cancel" Disabled="@uploading">Cancel</MudButton>
+        <MudButton Color="Color.Primary"
+                   Variant="Variant.Filled"
+                   OnClick="UploadAsync"
+                   Disabled="@(picked is null || picked.Size > BookDetailViewModel.MaxUploadBytes || uploading)">
+            @if (uploading)
+            {
+                <MudProgressCircular Indeterminate="true" Size="Size.Small" Class="mr-2" />
+                <span>Uploading...</span>
+            }
+            else
+            {
+                <span>Upload</span>
+            }
+        </MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] private IMudDialogInstance MudDialog { get; set; } = default!;
+    [Parameter, EditorRequired] public int EditionId { get; set; }
+    [Parameter, EditorRequired] public BookDetailViewModel ViewModel { get; set; } = default!;
+
+    private IBrowserFile? picked;
+    private bool uploading;
+
+    private void OnFileChanged(IBrowserFile? file)
+    {
+        picked = file;
+    }
+
+    private async Task UploadAsync()
+    {
+        if (picked is null) return;
+        uploading = true;
+        try
+        {
+            var result = await ViewModel.UploadEditionCoverAsync(EditionId, picked, CancellationToken.None);
+            if (result.Success)
+            {
+                Snackbar.Add("Cover photo uploaded.", Severity.Success);
+                MudDialog.Close(DialogResult.Ok(true));
+                return;
+            }
+            Snackbar.Add(result.ErrorMessage ?? "Upload failed.", Severity.Error);
+        }
+        catch (Exception)
+        {
+            Snackbar.Add("Upload failed unexpectedly.", Severity.Error);
+        }
+        finally
+        {
+            uploading = false;
+        }
+    }
+
+    private void Cancel() => MudDialog.Cancel();
+
+    private static string FormatSize(long bytes)
+    {
+        if (bytes < 1024) return $"{bytes} B";
+        if (bytes < 1024 * 1024) return $"{bytes / 1024} KB";
+        return $"{bytes / 1024.0 / 1024.0:F1} MB";
+    }
+}

--- a/BookTracker.Web/Services/Covers/BlobBookCoverStorage.cs
+++ b/BookTracker.Web/Services/Covers/BlobBookCoverStorage.cs
@@ -102,7 +102,14 @@ public class BlobBookCoverStorage : IBookCoverStorage
             },
         }, ct);
 
-        return BuildPublicUrl(blobName);
+        // Cache-bust the year-long Cache-Control header by appending a unix
+        // timestamp. Re-uploads to the same blob key produce a new URL each
+        // time, forcing browsers to refetch — without this the stale image
+        // can hang around in cache for up to a year. Mirror-from-upstream
+        // doesn't need this (URL is stable per blob), so the unstamped
+        // BuildPublicUrl is still used there.
+        var stamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+        return $"{BuildPublicUrl(blobName)}?v={stamp}";
     }
 
     private async Task<BlobContainerClient?> InitContainerAsync()

--- a/BookTracker.Web/ViewModels/BookDetailViewModel.cs
+++ b/BookTracker.Web/ViewModels/BookDetailViewModel.cs
@@ -1,6 +1,8 @@
 using BookTracker.Data;
 using BookTracker.Data.Models;
 using BookTracker.Web.Services;
+using BookTracker.Web.Services.Covers;
+using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.EntityFrameworkCore;
 
 namespace BookTracker.Web.ViewModels;
@@ -11,8 +13,16 @@ namespace BookTracker.Web.ViewModels;
 // notes, tags) mutate the Current* properties + persist in the same call,
 // keeping the page focused on one value at a time. Larger structural
 // edits (Work, Edition, Copy) happen in modal dialogs in a later PR.
-public class BookDetailViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory)
+public class BookDetailViewModel(
+    IDbContextFactory<BookTrackerDbContext> dbFactory,
+    IBookCoverStorage coverStorage,
+    ILogger<BookDetailViewModel> logger)
 {
+    /// <summary>Server-side cap on user-uploaded cover photos. 10 MB is generous
+    /// enough to accept a 12MP phone-camera JPEG without rejection while
+    /// bounding the worst-case payload through Blazor Server's SignalR pipe
+    /// and the resize step in CoverImageProcessor.</summary>
+    public const long MaxUploadBytes = 10 * 1024 * 1024;
     public bool NotFound { get; private set; }
     public BookDetail? Book { get; private set; }
 
@@ -193,6 +203,71 @@ public class BookDetailViewModel(IDbContextFactory<BookTrackerDbContext> dbFacto
         await db.SaveChangesAsync();
     }
 
+    /// <summary>
+    /// Uploads a user-supplied photo as the cover for a specific Edition,
+    /// replacing any existing cover. Used for rare / old editions where no
+    /// online cover is available. Returns a <see cref="UploadCoverResult"/>
+    /// with success/error shape so the page can render the right snackbar.
+    /// </summary>
+    public async Task<UploadCoverResult> UploadEditionCoverAsync(int editionId, IBrowserFile file, CancellationToken ct)
+    {
+        if (Book is null) return UploadCoverResult.Failure("Book not loaded.");
+
+        if (file.Size > MaxUploadBytes)
+        {
+            return UploadCoverResult.Failure($"File too large ({file.Size / 1024 / 1024} MB). Max is {MaxUploadBytes / 1024 / 1024} MB.");
+        }
+
+        if (!coverStorage.IsEnabled)
+        {
+            return UploadCoverResult.Failure("Cover storage is not configured.");
+        }
+
+        byte[] bytes;
+        try
+        {
+            using var stream = file.OpenReadStream(MaxUploadBytes, ct);
+            using var ms = new MemoryStream();
+            await stream.CopyToAsync(ms, ct);
+            bytes = ms.ToArray();
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to read uploaded cover stream for Edition {EditionId}.", editionId);
+            return UploadCoverResult.Failure("Couldn't read the uploaded file.");
+        }
+
+        string newUrl;
+        try
+        {
+            newUrl = await coverStorage.UploadAsync(bytes, file.ContentType, $"editions/{editionId}", ct);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Cover upload failed for Edition {EditionId}.", editionId);
+            return UploadCoverResult.Failure("Upload failed. Try again or check the file.");
+        }
+
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var edition = await db.Editions.FirstOrDefaultAsync(e => e.Id == editionId, ct);
+        if (edition is null) return UploadCoverResult.Failure("Edition not found.");
+
+        edition.CoverUrl = newUrl;
+        edition.IsUserSupplied = true;
+        await db.SaveChangesAsync(ct);
+
+        // Refresh the in-memory snapshot so the page re-renders against the new URL.
+        await InitializeAsync(Book.Id);
+
+        return UploadCoverResult.Ok(newUrl);
+    }
+
+    public record UploadCoverResult(bool Success, string? ErrorMessage, string? NewUrl)
+    {
+        public static UploadCoverResult Ok(string url) => new(true, null, url);
+        public static UploadCoverResult Failure(string error) => new(false, error, null);
+    }
+
     public async Task RemoveTagAsync(int tagId)
     {
         if (Book is null) return;
@@ -250,6 +325,7 @@ public class BookDetailViewModel(IDbContextFactory<BookTrackerDbContext> dbFacto
         e.Publisher?.Name,
         PartialDateParser.Format(e.DatePrinted, e.DatePrintedPrecision),
         e.CoverUrl,
+        e.IsUserSupplied,
         e.Copies
             .OrderBy(c => c.DateAcquired ?? DateTime.MaxValue)
             .ThenBy(c => c.Id)
@@ -291,6 +367,7 @@ public class BookDetailViewModel(IDbContextFactory<BookTrackerDbContext> dbFacto
         string? Publisher,
         string DatePrintedDisplay,
         string? CoverUrl,
+        bool IsUserSupplied,
         IReadOnlyList<CopyDetail> Copies);
 
     public record CopyDetail(int Id, BookCondition Condition, DateTime? DateAcquired, string? Notes);


### PR DESCRIPTION
Closes the #5 use case from the original cover-storage plan: rare /
old editions where no online cover exists. Per-edition button on the
Book detail page opens a dialog with a file picker (camera by default
on mobile via accept="image/*"). User picks → confirms → bytes flow
up via Blazor Server's IBrowserFile pipe → IBookCoverStorage.UploadAsync
→ blob lands at editions/{id}.{ext} → Edition.CoverUrl + IsUserSupplied
update → page snapshot refreshes.

Re-uses everything PR1 already built: the UploadAsync method on the
interface, CoverImageProcessor's JPEG normalise + 1200px resize,
per-Edition blob keying, the storage account + container split per
slot. No new infra.

Schema:
- New `Edition.IsUserSupplied` bool (default false). Migration
  `20260507062841_AddEditionIsUserSupplied`. Additive only — existing
  rows keep their upstream-mirrored covers and read as IsUserSupplied
  = false. Safe deploy: migrate-on-startup will add the column on
  first run after this lands.

ViewModel:
- BookDetailViewModel constructor now takes IBookCoverStorage +
  ILogger. Adds UploadEditionCoverAsync(editionId, IBrowserFile, ct):
    * Server-side cap of 10 MB (MaxUploadBytes) — generous enough for
      a 12MP phone-camera JPEG, bounded against runaway payloads on
      the SignalR pipe.
    * Reads stream into memory, calls coverStorage.UploadAsync.
    * Persists Edition.CoverUrl + IsUserSupplied=true on success.
    * Re-runs InitializeAsync so the page's snapshot reflects the new
      URL without a full nav.
  Returns UploadCoverResult { Success, ErrorMessage, NewUrl } so the
  dialog can show the right snackbar shape.
- EditionDetail record gains IsUserSupplied for the "your photo" badge.

UI:
- New EditionCoverUploadDialog (Shared) — MudFileUpload + filename /
  size / content-type readout + Upload/Cancel. Uploading state shows
  a spinner; size-cap violation surfaces an inline alert before
  enabling the upload button. Routes through the page's VM (passed
  in as a parameter) so post-upload refresh is one path.
- Detail.razor's Edition expansion panel gains a small cover preview
  thumbnail (when present), a "your photo" chip when IsUserSupplied,
  and an "Upload photo" / "Replace photo" button alongside Edit /
  Add copy. OpenUploadCoverDialog handler matches the existing
  OpenDialogGuardedAsync / DialogParameters pattern.

Cache-busting:
- BlobBookCoverStorage.UploadAsync now appends ?v={unix-timestamp}
  to the returned URL. Without this, replacing a user's photo over
  an existing blob (same blob key, same URL) would leave the year-long
  Cache-Control max-age in place and browsers would show the stale
  image for up to a year. Mirror-from-upstream is unaffected — its
  blobs are write-once-per-URL, no cache-bust needed; that path
  still uses the unstamped BuildPublicUrl.
- IsManagedUrl still works correctly with stamped URLs because the
  startswith check sees the same publicBase prefix.

Tests:
- 3 new BookDetailViewModel tests for the upload path:
  HappyPath_UpdatesUrlAndFlagsUserSupplied (assert DB row, VM
  refresh, returned NewUrl), FileTooLarge_ReturnsFailure_AndDoes
  NotUpload (assert IBookCoverStorage.UploadAsync was never called),
  StorageDisabled_ReturnsFailure (when IsEnabled=false).
- Existing 16 tests updated: CreateVm helper provides an NSubstitute
  IBookCoverStorage and a NullLogger so test sites stay terse.

All 380 non-E2E tests pass.

Local deploy step: `dotnet ef database update --project .\BookTracker.Data --startup-project .\BookTracker.Web` to apply the migration (or just restart the app — migrate-on-startup picks it up).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
