### PR TITLE
feat(books): multi-work collections — N works per Book, no "primary" Work

### DIFF
--- a/BookTracker.Tests/ViewModels/BookAddViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/BookAddViewModelTests.cs
@@ -373,6 +373,104 @@ public class BookAddViewModelTests
     }
 
     [Fact]
+    public async Task SaveAsync_CollectionMode_CreatesBookWithMultipleWorks()
+    {
+        var vm = CreateVm();
+        vm.IsCollection = true;
+        vm.BookInput.Title = "The Bachman Books";
+        vm.EditionInput.Isbn = "9780451178121";
+        vm.CollectionWorks =
+        [
+            new() { Title = "Rage", Authors = ["Richard Bachman"] },
+            new() { Title = "The Long Walk", Authors = ["Richard Bachman"] },
+            new() { Title = "Roadwork", Authors = ["Richard Bachman"], FirstPublishedDate = "1981" },
+        ];
+
+        var ok = await vm.SaveAsync(new List<int>());
+
+        Assert.NotNull(ok);
+        using var db = _factory.CreateDbContext();
+        var book = db.Books
+            .Include(b => b.Works).ThenInclude(w => w.WorkAuthors).ThenInclude(wa => wa.Author)
+            .Single();
+        Assert.Equal("The Bachman Books", book.Title);
+        Assert.Equal(3, book.Works.Count);
+        // Each row's authors land in WorkAuthors. No designated "primary" Work.
+        var rage = book.Works.Single(w => w.Title == "Rage");
+        Assert.Equal("Richard Bachman", rage.WorkAuthors.Single().Author.Name);
+        var roadwork = book.Works.Single(w => w.Title == "Roadwork");
+        Assert.Equal(new DateOnly(1981, 1, 1), roadwork.FirstPublishedDate);
+        Assert.Equal(DatePrecision.Year, roadwork.FirstPublishedDatePrecision);
+    }
+
+    [Fact]
+    public async Task SaveAsync_CollectionMode_SkipsEmptyRows()
+    {
+        // The Add page seeds two empty rows by default; users may add more
+        // and never fill them. Empty rows (no title or no authors) should be
+        // dropped silently rather than throwing.
+        var vm = CreateVm();
+        vm.IsCollection = true;
+        vm.BookInput.Title = "Two Stories";
+        vm.CollectionWorks =
+        [
+            new() { Title = "First Story", Authors = ["Author A"] },
+            new() { Title = "", Authors = ["Author B"] },
+            new() { Title = "Second Story", Authors = ["Author B"] },
+            new() { Title = "Third Story", Authors = [] },
+        ];
+
+        await vm.SaveAsync(new List<int>());
+
+        using var db = _factory.CreateDbContext();
+        var book = db.Books.Include(b => b.Works).Single();
+        Assert.Equal(2, book.Works.Count);
+        Assert.Contains(book.Works, w => w.Title == "First Story");
+        Assert.Contains(book.Works, w => w.Title == "Second Story");
+    }
+
+    [Fact]
+    public async Task SaveAsync_CollectionMode_AllRowsEmpty_Throws()
+    {
+        var vm = CreateVm();
+        vm.IsCollection = true;
+        vm.BookInput.Title = "Empty Collection";
+        vm.CollectionWorks = [new(), new()];
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => vm.SaveAsync(new List<int>()));
+    }
+
+    [Fact]
+    public async Task LookupAsync_CollectionMode_FillsBookOnlyAndSkipsWorkFields()
+    {
+        _lookup.LookupByIsbnAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new BookLookupResult(
+                Isbn: "9780451178121", Title: "The Bachman Books", Subtitle: "Four Early Novels",
+                Author: "Richard Bachman", Publisher: "NAL",
+                GenreCandidates: ["Horror"], DatePrinted: null, CoverUrl: "https://example.invalid/cover.jpg",
+                Source: "Open Library",
+                Series: null, SeriesNumber: null, SeriesNumberRaw: null));
+
+        var vm = CreateVm();
+        vm.IsCollection = true;
+        vm.LookupIsbn = "9780451178121";
+
+        await vm.LookupAsync(CreateGenrePicker());
+
+        // Book-level fields prefilled (the Book represents the collection).
+        Assert.Equal("The Bachman Books", vm.BookInput.Title);
+        Assert.Equal("https://example.invalid/cover.jpg", vm.BookInput.DefaultCoverArtUrl);
+        Assert.Equal("9780451178121", vm.EditionInput.Isbn);
+        // Work-level fields untouched — the lookup describes the collection,
+        // not its constituent works.
+        Assert.Null(vm.WorkInput.Title);
+        Assert.Empty(vm.WorkInput.Authors);
+        // Genre candidates and series suggestion suppressed in collection mode.
+        Assert.Empty(vm.LookupCandidates);
+        Assert.Null(vm.SeriesSuggestion);
+    }
+
+    [Fact]
     public async Task AcceptSeriesSuggestion_OnLocalFallbackReason_IsNoOp()
     {
         // Seed: an author with 2+ ungrouped works → MatchReason.AuthorHasMultipleBooks

--- a/BookTracker.Tests/ViewModels/BookListViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/BookListViewModelTests.cs
@@ -204,6 +204,59 @@ public class BookListViewModelTests
     }
 
     [Fact]
+    public async Task ToggleGroupAsync_MultiWorkBook_SuppressesSubtitleAndReportsWorkCount()
+    {
+        // For collections (Book.Works.Count > 1), the subtitle of an arbitrary
+        // inner Work is data noise — list view shows "N works" instead.
+        var factory = new TestDbContextFactory();
+        using (var db = factory.CreateDbContext())
+        {
+            var king = new Author { Name = "Stephen King" };
+            db.Authors.Add(king);
+
+            db.Books.AddRange(
+                new Book
+                {
+                    // Single-work book — its Work subtitle should surface.
+                    Title = "The Shining",
+                    Works = [new Work
+                    {
+                        Title = "The Shining",
+                        Subtitle = "A Novel",
+                        WorkAuthors = [new WorkAuthor { Author = king, Order = 0 }]
+                    }]
+                },
+                new Book
+                {
+                    // Multi-work collection — even though Work[0] has a subtitle,
+                    // the list should suppress it and report WorkCount=3.
+                    Title = "The Bachman Books",
+                    Works =
+                    [
+                        new Work { Title = "Rage", Subtitle = "Subtitle from a single story", WorkAuthors = [new WorkAuthor { Author = king, Order = 0 }] },
+                        new Work { Title = "The Long Walk", WorkAuthors = [new WorkAuthor { Author = king, Order = 0 }] },
+                        new Work { Title = "Roadwork", WorkAuthors = [new WorkAuthor { Author = king, Order = 0 }] },
+                    ]
+                });
+            await db.SaveChangesAsync();
+        }
+
+        var vm = new BookListViewModel(factory) { SelectedGroupBy = LibraryGroupBy.Author };
+        await vm.InitializeAsync();
+        var kingGroup = vm.Groups.First(g => g.Label == "Stephen King");
+        await vm.ToggleGroupAsync(kingGroup.Key);
+
+        var loaded = vm.LoadedGroups[kingGroup.Key].Books;
+        var single = loaded.Single(b => b.Title == "The Shining");
+        var collection = loaded.Single(b => b.Title == "The Bachman Books");
+
+        Assert.Equal("A Novel", single.Subtitle);
+        Assert.Equal(1, single.WorkCount);
+        Assert.Null(collection.Subtitle);
+        Assert.Equal(3, collection.WorkCount);
+    }
+
+    [Fact]
     public async Task GroupByGenre_GenreFilterReducesGroupsAndCounts()
     {
         var factory = new TestDbContextFactory();

--- a/BookTracker.Web/Components/Pages/Books/Add.razor
+++ b/BookTracker.Web/Components/Pages/Books/Add.razor
@@ -13,9 +13,13 @@
         <div class="col-12">
             <div class="card">
                 <div class="card-body">
-                    <div class="form-check form-switch mb-3">
+                    <div class="form-check form-switch mb-2">
                         <input type="checkbox" id="noIsbnToggle" class="form-check-input" @bind="VM.NoIsbnMode" />
                         <label for="noIsbnToggle" class="form-check-label">No ISBN (pre-1974 book)</label>
+                    </div>
+                    <div class="form-check form-switch mb-3">
+                        <input type="checkbox" id="collectionToggle" class="form-check-input" @bind="VM.IsCollection" />
+                        <label for="collectionToggle" class="form-check-label">This is a collection (multiple works in one book)</label>
                     </div>
 
                     @if (!VM.NoIsbnMode)
@@ -180,16 +184,65 @@
             <BookForm Input="VM.BookInput" />
         </div>
 
-        <div class="col-12">
-            <WorkForm Input="VM.WorkInput" Title="Work (story / novel)" />
-        </div>
+        @if (!VM.IsCollection)
+        {
+            <div class="col-12">
+                <WorkForm Input="VM.WorkInput" Title="Work (story / novel)" />
+            </div>
 
-        <div class="col-12">
-            <GenrePicker @ref="genrePicker"
-                         SelectedGenreIds="selectedGenreIds"
-                         SelectedGenreIdsChanged="ids => selectedGenreIds = ids"
-                         LookupCandidates="VM.LookupCandidates" />
-        </div>
+            <div class="col-12">
+                <GenrePicker @ref="genrePicker"
+                             SelectedGenreIds="selectedGenreIds"
+                             SelectedGenreIdsChanged="ids => selectedGenreIds = ids"
+                             LookupCandidates="VM.LookupCandidates" />
+            </div>
+        }
+        else
+        {
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-header bg-white"><h2 class="h5 mb-0">Works in this collection</h2></div>
+                    <div class="card-body">
+                        @for (var i = 0; i < VM.CollectionWorks.Count; i++)
+                        {
+                            var index = i;
+                            var work = VM.CollectionWorks[i];
+                            <div class="border rounded p-3 mb-3">
+                                <div class="d-flex justify-content-between align-items-center mb-2">
+                                    <strong>Work @(index + 1)</strong>
+                                    @if (VM.CollectionWorks.Count > 1)
+                                    {
+                                        <button type="button" class="btn btn-sm btn-outline-danger" @onclick="() => VM.RemoveCollectionWorkRow(index)">Remove</button>
+                                    }
+                                </div>
+                                <div class="row g-2">
+                                    <div class="col-md-7">
+                                        <label class="form-label small">Title</label>
+                                        <InputText @bind-Value="work.Title" class="form-control" />
+                                    </div>
+                                    <div class="col-md-5">
+                                        <label class="form-label small">Author(s)</label>
+                                        <MudAuthorPicker Authors="work.Authors"
+                                                         AuthorsChanged="list => work.Authors = list"
+                                                         Label="Add author" />
+                                    </div>
+                                    <div class="col-md-7">
+                                        <label class="form-label small">Subtitle <span class="text-muted">(optional)</span></label>
+                                        <InputText @bind-Value="work.Subtitle" class="form-control" />
+                                    </div>
+                                    <div class="col-md-5">
+                                        <label class="form-label small">First published <span class="text-muted">(optional)</span></label>
+                                        <InputText @bind-Value="work.FirstPublishedDate" class="form-control" placeholder="e.g. 1934" />
+                                    </div>
+                                </div>
+                            </div>
+                        }
+                        <button type="button" class="btn btn-outline-primary btn-sm" @onclick="VM.AddCollectionWorkRow">+ Add another work</button>
+                        <div class="form-text mt-2">Genres and series are set per-work after saving — open each work from the book detail page to tag.</div>
+                    </div>
+                </div>
+            </div>
+        }
 
         <div class="col-12">
             <EditionCopyForm EditionInput="VM.EditionInput" CopyInput="VM.CopyInput" Title="First edition & copy" />
@@ -219,10 +272,7 @@
 
     private async Task LookupAsync()
     {
-        if (genrePicker is not null)
-        {
-            await VM.LookupAsync(genrePicker.ViewModel);
-        }
+        await VM.LookupAsync(genrePicker?.ViewModel);
     }
 
     private async Task SearchAsync()
@@ -232,10 +282,7 @@
 
     private async Task ApplyCandidateAsync(BookSearchCandidate candidate)
     {
-        if (genrePicker is not null)
-        {
-            await VM.ApplyCandidateAsync(candidate, genrePicker.ViewModel);
-        }
+        await VM.ApplyCandidateAsync(candidate, genrePicker?.ViewModel);
     }
 
     private async Task SaveAsync()
@@ -270,8 +317,7 @@
 
     private void ResetForNextBook()
     {
-        if (genrePicker is null) return;
-        VM.Reset(genrePicker.ViewModel);
+        VM.Reset(genrePicker?.ViewModel);
         selectedGenreIds = [];
         StateHasChanged();
     }

--- a/BookTracker.Web/Components/Pages/Books/List.razor
+++ b/BookTracker.Web/Components/Pages/Books/List.razor
@@ -346,6 +346,10 @@
                         {
                             <MudText Typo="Typo.body2" Color="Color.Secondary">@context.Subtitle</MudText>
                         }
+                        else if (context.WorkCount > 1)
+                        {
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">@context.WorkCount works</MudText>
+                        }
                     </MudTd>
                     <MudTd>@context.Author</MudTd>
                     <MudTd>
@@ -388,6 +392,10 @@
                     <div class="flex-grow-1 min-width-0">
                         <MudText Style="font-weight: 500; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">@book.Title</MudText>
                         <MudText Typo="Typo.body2" Color="Color.Secondary">@book.Author</MudText>
+                        @if (book.WorkCount > 1)
+                        {
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">@book.WorkCount works</MudText>
+                        }
                         <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center" Class="mt-1" Wrap="Wrap.Wrap">
                             <MudChip T="string" Size="Size.Small" Color="@StatusColor(book.Status)">@book.Status.ToString()</MudChip>
                             <MudRating ReadOnly="true" SelectedValue="@book.Rating" MaxValue="5" Size="Size.Small" />

--- a/BookTracker.Web/ViewModels/BookAddViewModel.cs
+++ b/BookTracker.Web/ViewModels/BookAddViewModel.cs
@@ -26,6 +26,25 @@ public class BookAddViewModel(
     // title/author search that returns work-level candidates from Open
     // Library; selecting one prefills the form like an ISBN lookup would.
     public bool NoIsbnMode { get; set; }
+
+    // Collection mode (web-prioritised): a single Book containing multiple
+    // Works (e.g. "The Bachman Books", anthologies). Toggling on swaps the
+    // single WorkForm for a repeatable Works builder; lookup fills only the
+    // collection's Book.Title + cover and skips the work-specific fields.
+    // Genres and series suggestions are deferred to per-work editing on
+    // /books/{id}/edit — applying them to all works at save time would be
+    // wrong (each work has its own).
+    public bool IsCollection { get; set; }
+    public List<WorkFormViewModel.WorkFormInput> CollectionWorks { get; set; } = [new(), new()];
+
+    public void AddCollectionWorkRow() => CollectionWorks.Add(new());
+
+    public void RemoveCollectionWorkRow(int index)
+    {
+        if (index < 0 || index >= CollectionWorks.Count) return;
+        CollectionWorks.RemoveAt(index);
+        if (CollectionWorks.Count == 0) CollectionWorks.Add(new());
+    }
     public string? SearchTitle { get; set; }
     public string? SearchAuthor { get; set; }
     public IReadOnlyList<BookSearchCandidate> SearchCandidates { get; private set; } = [];
@@ -78,7 +97,7 @@ public class BookAddViewModel(
     public ExistingBookMatch? ExistingBook { get; private set; }
     public bool AddingCopy { get; private set; }
 
-    public async Task LookupAsync(GenrePickerViewModel genrePicker)
+    public async Task LookupAsync(GenrePickerViewModel? genrePicker)
     {
         LookupMessage = null;
         ExistingBook = null;
@@ -128,17 +147,22 @@ public class BookAddViewModel(
 
             // The Add page creates a Book with one Work. Lookup result
             // populates both: Book.Title mirrors the Work title, plus
-            // cover; Work gets title/subtitle/author/genres.
+            // cover; Work gets title/subtitle/author/genres. In Collection
+            // mode the work-specific fields are skipped because the lookup
+            // result describes the *collection*, not its constituent works.
             if (string.IsNullOrWhiteSpace(BookInput.Title)) BookInput.Title = result.Title ?? "";
             if (string.IsNullOrWhiteSpace(BookInput.DefaultCoverArtUrl)) BookInput.DefaultCoverArtUrl = result.CoverUrl;
-            if (string.IsNullOrWhiteSpace(WorkInput.Title)) WorkInput.Title = result.Title ?? "";
-            if (string.IsNullOrWhiteSpace(WorkInput.Subtitle)) WorkInput.Subtitle = result.Subtitle;
-            // Lookup gives a single author string — seed the chip list with it
-            // when empty. User can add additional co-authors via the picker
-            // before saving.
-            if (WorkInput.Authors.Count == 0 && !string.IsNullOrWhiteSpace(result.Author))
+            if (!IsCollection)
             {
-                WorkInput.Authors = [result.Author];
+                if (string.IsNullOrWhiteSpace(WorkInput.Title)) WorkInput.Title = result.Title ?? "";
+                if (string.IsNullOrWhiteSpace(WorkInput.Subtitle)) WorkInput.Subtitle = result.Subtitle;
+                // Lookup gives a single author string — seed the chip list with it
+                // when empty. User can add additional co-authors via the picker
+                // before saving.
+                if (WorkInput.Authors.Count == 0 && !string.IsNullOrWhiteSpace(result.Author))
+                {
+                    WorkInput.Authors = [result.Author];
+                }
             }
             if (string.IsNullOrWhiteSpace(EditionInput.Isbn)) EditionInput.Isbn = result.Isbn;
             if (string.IsNullOrWhiteSpace(EditionInput.Publisher)) EditionInput.Publisher = result.Publisher;
@@ -147,19 +171,34 @@ public class BookAddViewModel(
                 EditionInput.DatePrinted = PartialDateParser.Format(d, result.DatePrintedPrecision);
             }
 
-            LookupCandidates = result.GenreCandidates.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
-            genrePicker.LookupCandidates = LookupCandidates;
-            genrePicker.ApplyLookupCandidates(LookupCandidates);
+            // Genre candidates and series suggestions are work-level; not
+            // meaningful in Collection mode where each work has its own.
+            if (!IsCollection)
+            {
+                LookupCandidates = result.GenreCandidates.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+                if (genrePicker is not null)
+                {
+                    genrePicker.LookupCandidates = LookupCandidates;
+                    genrePicker.ApplyLookupCandidates(LookupCandidates);
+                }
+
+                SeriesSuggestion = await seriesMatch.FindMatchAsync(result);
+                SeriesSuggestionDismissed = false;
+                // Fresh lookup → clear any acceptance carried over from a prior
+                // ISBN attempt in this session (e.g. user typed wrong ISBN,
+                // accepted a Discworld suggestion, then corrected to a non-series
+                // book — the prior accept must not silently apply).
+                UndoSeriesSuggestionAccept();
+            }
+            else
+            {
+                LookupCandidates = [];
+                SeriesSuggestion = null;
+                SeriesSuggestionDismissed = false;
+                UndoSeriesSuggestionAccept();
+            }
 
             LookupMessage = $"Prefilled from {result.Source}. Edit anything before saving.";
-
-            SeriesSuggestion = await seriesMatch.FindMatchAsync(result);
-            SeriesSuggestionDismissed = false;
-            // Fresh lookup → clear any acceptance carried over from a prior
-            // ISBN attempt in this session (e.g. user typed wrong ISBN,
-            // accepted a Discworld suggestion, then corrected to a non-series
-            // book — the prior accept must not silently apply).
-            UndoSeriesSuggestionAccept();
         }
         finally
         {
@@ -197,7 +236,7 @@ public class BookAddViewModel(
     }
 
     /// <summary>Resets all input state so the page is ready for the next book.</summary>
-    public void Reset(GenrePickerViewModel genrePicker)
+    public void Reset(GenrePickerViewModel? genrePicker)
     {
         BookInput = new();
         WorkInput = new();
@@ -215,8 +254,13 @@ public class BookAddViewModel(
         SearchCandidates = [];
         SearchMessage = null;
         NoIsbnMode = false;
-        genrePicker.SelectedGenreIds = [];
-        genrePicker.LookupCandidates = [];
+        IsCollection = false;
+        CollectionWorks = [new(), new()];
+        if (genrePicker is not null)
+        {
+            genrePicker.SelectedGenreIds = [];
+            genrePicker.LookupCandidates = [];
+        }
     }
 
     public record ExistingBookMatch(int BookId, int EditionId, string Title, string Author, int CopyCount);
@@ -249,7 +293,7 @@ public class BookAddViewModel(
         }
     }
 
-    public async Task ApplyCandidateAsync(BookSearchCandidate candidate, GenrePickerViewModel genrePicker)
+    public async Task ApplyCandidateAsync(BookSearchCandidate candidate, GenrePickerViewModel? genrePicker)
     {
         if (string.IsNullOrWhiteSpace(BookInput.Title)) BookInput.Title = candidate.Title ?? "";
         if (string.IsNullOrWhiteSpace(BookInput.DefaultCoverArtUrl)) BookInput.DefaultCoverArtUrl = candidate.CoverUrl;
@@ -300,51 +344,105 @@ public class BookAddViewModel(
                 }
             }
 
-            var authors = await AuthorResolver.FindOrCreateAllAsync(WorkInput.Authors, db);
-            if (authors.Count == 0)
+            List<Work> works;
+            if (IsCollection)
             {
-                throw new InvalidOperationException("At least one author is required to save a Work.");
-            }
-            var firstPub = PartialDateParser.TryParse(WorkInput.FirstPublishedDate) ?? PartialDate.Empty;
-            var work = new Work
-            {
-                Title = (WorkInput.Title ?? BookInput.Title)!.Trim(),
-                Subtitle = string.IsNullOrWhiteSpace(WorkInput.Subtitle) ? null : WorkInput.Subtitle!.Trim(),
-                FirstPublishedDate = firstPub.Date,
-                FirstPublishedDatePrecision = firstPub.Precision,
-                Genres = selectedGenres,
-            };
-            // Dual-write: Work.Author = lead chip (legacy FK compat); Work.WorkAuthors
-            // = all chips with Order ascending. PR2 will drop Author/AuthorId and
-            // switch reads to the join.
-            AuthorResolver.AssignAuthors(work, authors);
+                // Collection mode: build N Works, one per row. Genres and series
+                // suggestions are deferred to per-work editing on /books/{id}/edit
+                // — the lookup flow can't pick them per-work, and applying to all
+                // would be wrong (each Work has its own).
+                var rows = CollectionWorks
+                    .Where(w => !string.IsNullOrWhiteSpace(w.Title) && w.Authors.Count > 0)
+                    .ToList();
+                if (rows.Count == 0)
+                {
+                    throw new InvalidOperationException("A collection must contain at least one work with a title and an author.");
+                }
+                // Resolve the union of distinct author names across all rows
+                // in one pass — calling FindOrCreate per row would create
+                // duplicate Author entities when the same name appears in
+                // multiple stories (the existence check queries the committed
+                // DB, missing pending entities in the change tracker).
+                var allNames = rows.SelectMany(r => r.Authors);
+                var allAuthors = await AuthorResolver.FindOrCreateAllAsync(allNames, db);
+                var byName = allAuthors.ToDictionary(a => a.Name, StringComparer.OrdinalIgnoreCase);
 
-            // Attach to the accepted series, if any. AcceptedSeriesId points at
-            // an existing local Series row; AcceptedSeriesName (without an Id)
-            // means the upstream API named a series we don't have yet — find-
-            // or-create it by name. Default new series to SeriesType.Series
-            // (numbered) per the Q1/Q2 defaults — user can flip to Collection
-            // on /series/{id} later if wrong.
-            if (SeriesSuggestionAccepted)
-            {
-                if (AcceptedSeriesId is int existingId)
+                works = new List<Work>(rows.Count);
+                foreach (var row in rows)
                 {
-                    work.SeriesId = existingId;
-                    work.SeriesOrder = AcceptedSeriesOrder;
-                }
-                else if (!string.IsNullOrWhiteSpace(AcceptedSeriesName))
-                {
-                    var seriesName = AcceptedSeriesName.Trim();
-                    var series = await db.Series
-                        .FirstOrDefaultAsync(s => s.Name.ToLower() == seriesName.ToLower());
-                    if (series is null)
+                    var rowAuthors = row.Authors
+                        .Select(n => n?.Trim())
+                        .Where(n => !string.IsNullOrEmpty(n))
+                        .Distinct(StringComparer.OrdinalIgnoreCase)
+                        .Select(n => byName[n!])
+                        .ToList();
+                    if (rowAuthors.Count == 0)
                     {
-                        series = new Series { Name = seriesName, Type = SeriesType.Series };
-                        db.Series.Add(series);
+                        throw new InvalidOperationException($"Each work in the collection needs at least one author (work \"{row.Title}\" had none).");
                     }
-                    work.Series = series;
-                    work.SeriesOrder = AcceptedSeriesOrder;
+                    var rowFirstPub = PartialDateParser.TryParse(row.FirstPublishedDate) ?? PartialDate.Empty;
+                    var w = new Work
+                    {
+                        Title = row.Title!.Trim(),
+                        Subtitle = string.IsNullOrWhiteSpace(row.Subtitle) ? null : row.Subtitle!.Trim(),
+                        FirstPublishedDate = rowFirstPub.Date,
+                        FirstPublishedDatePrecision = rowFirstPub.Precision,
+                        Genres = [],
+                    };
+                    AuthorResolver.AssignAuthors(w, rowAuthors);
+                    works.Add(w);
                 }
+            }
+            else
+            {
+                var authors = await AuthorResolver.FindOrCreateAllAsync(WorkInput.Authors, db);
+                if (authors.Count == 0)
+                {
+                    throw new InvalidOperationException("At least one author is required to save a Work.");
+                }
+                var firstPub = PartialDateParser.TryParse(WorkInput.FirstPublishedDate) ?? PartialDate.Empty;
+                var work = new Work
+                {
+                    Title = (WorkInput.Title ?? BookInput.Title)!.Trim(),
+                    Subtitle = string.IsNullOrWhiteSpace(WorkInput.Subtitle) ? null : WorkInput.Subtitle!.Trim(),
+                    FirstPublishedDate = firstPub.Date,
+                    FirstPublishedDatePrecision = firstPub.Precision,
+                    Genres = selectedGenres,
+                };
+                // Dual-write: Work.Author = lead chip (legacy FK compat); Work.WorkAuthors
+                // = all chips with Order ascending. PR2 will drop Author/AuthorId and
+                // switch reads to the join.
+                AuthorResolver.AssignAuthors(work, authors);
+
+                // Attach to the accepted series, if any. AcceptedSeriesId points at
+                // an existing local Series row; AcceptedSeriesName (without an Id)
+                // means the upstream API named a series we don't have yet — find-
+                // or-create it by name. Default new series to SeriesType.Series
+                // (numbered) per the Q1/Q2 defaults — user can flip to Collection
+                // on /series/{id} later if wrong.
+                if (SeriesSuggestionAccepted)
+                {
+                    if (AcceptedSeriesId is int existingId)
+                    {
+                        work.SeriesId = existingId;
+                        work.SeriesOrder = AcceptedSeriesOrder;
+                    }
+                    else if (!string.IsNullOrWhiteSpace(AcceptedSeriesName))
+                    {
+                        var seriesName = AcceptedSeriesName.Trim();
+                        var series = await db.Series
+                            .FirstOrDefaultAsync(s => s.Name.ToLower() == seriesName.ToLower());
+                        if (series is null)
+                        {
+                            series = new Series { Name = seriesName, Type = SeriesType.Series };
+                            db.Series.Add(series);
+                        }
+                        work.Series = series;
+                        work.SeriesOrder = AcceptedSeriesOrder;
+                    }
+                }
+
+                works = [work];
             }
 
             var datePrinted = PartialDateParser.TryParse(EditionInput.DatePrinted) ?? PartialDate.Empty;
@@ -356,7 +454,7 @@ public class BookAddViewModel(
                 Status = BookInput.Status,
                 Rating = BookInput.Rating,
                 DefaultCoverArtUrl = string.IsNullOrWhiteSpace(BookInput.DefaultCoverArtUrl) ? null : BookInput.DefaultCoverArtUrl.Trim(),
-                Works = [work],
+                Works = works,
                 Editions =
                 [
                     new Edition

--- a/BookTracker.Web/ViewModels/BookListViewModel.cs
+++ b/BookTracker.Web/ViewModels/BookListViewModel.cs
@@ -366,7 +366,11 @@ public class BookListViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
     private static BookListItem ToBookListItem(Book b) => new(
         b.Id,
         b.Title,
-        b.Works.FirstOrDefault()?.Subtitle,
+        // Subtitle only renders for single-Work books — for collections (Works
+        // > 1) the inner-Work subtitle would be the subtitle of an arbitrary
+        // story, which reads as data noise in the list. Collections surface
+        // their multi-Work-ness via the WorkCount indicator below the title.
+        b.Works.Count == 1 ? b.Works.First().Subtitle : null,
         // Comma-join unique author names across all Works on this Book. For a
         // single-Work co-authored book this renders "Preston, Child" rather
         // than the prettier "Preston & Child" — list views stay uniform; the
@@ -376,6 +380,7 @@ public class BookListViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
         b.DefaultCoverArtUrl,
         b.Status,
         b.Rating,
+        b.Works.Count,
         b.Works.SelectMany(w => w.Genres).Select(g => g.Name).Distinct().ToList(),
         b.Tags.Select(t => t.Name).ToList());
 
@@ -428,7 +433,7 @@ public class BookListViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
 
     public record BookListItem(
         int Id, string Title, string? Subtitle, string Author, string? CoverUrl,
-        BookStatus Status, int Rating, List<string> Genres, List<string> Tags);
+        BookStatus Status, int Rating, int WorkCount, List<string> Genres, List<string> Tags);
 
     public record GenreOption(int Id, string Name, int? ParentGenreId);
     public record TagOption(int Id, string Name);


### PR DESCRIPTION
Display fix (the headline behaviour change):
- Library list suppresses Subtitle when Book.Works > 1 (the inner-Work
  subtitle is the subtitle of one arbitrary story, not the collection)
  and shows a muted "N works" indicator below the title in both desktop
  and mobile layouts. BookListItem gains WorkCount.

Add flow (new toggle on /books/add):
- "This is a collection (multiple works in one book)" switch alongside
  the No-ISBN switch. When on, the single WorkForm is replaced by a
  repeatable Works builder with Title + MudAuthorPicker + optional
  Subtitle + optional first-published date per row, plus + / − controls.
- Lookup fills only Book.Title and cover in collection mode; work-level
  fields are skipped because the lookup describes the collection, not
  its constituent works. Genre candidates and series suggestions are
  also suppressed (each Work has its own genre / series).
- Save creates Book + N Works, dropping rows that lack a title or any
  authors. Author union is resolved in one pass so a name shared across
  rows resolves to the same Author entity (per-row FindOrCreate would
  insert duplicates because the lookup queries committed rows only).

Web-prioritised by design — the per-row card stack is functional on
mobile but the chip-picker + four fields per row is busy on small
screens; auto-detecting collection contents from upstream APIs is PR2.
