### PR TITLE
chore(memory): land pending memory updates

### DIFF
--- a/.claude-memory/blog_post_backlog.md
+++ b/.claude-memory/blog_post_backlog.md
@@ -4,10 +4,10 @@ description: One-time mine of all retros + patterns.md as of 2026-04-28. Each en
 type: project
 originSessionId: 21e97fa1-cba4-4b67-9d43-dc109098d6b2
 ---
-## Status as of 2026-05-06
+## Status as of 2026-05-07
 
 - **7 posts shipped** (covered).
-- **7 strong catch-up candidates** (clear angle, durable lesson, transferable beyond this stack).
+- **8 strong catch-up candidates** (clear angle, durable lesson, transferable beyond this stack).
 - **6 possible catch-up candidates** (could be a post or could fold into another — TBD when picked up).
 - **15+ retros with no obvious blog hook on their own** (specific, dated, or already covered — listed at the bottom for the definitive count).
 
@@ -40,6 +40,8 @@ Concrete angle, durable lesson, transferable beyond BookTracker's stack. Order i
 - **"Auto-fill-empties beat strict-replace"** — `retro_edition_merge_and_enrichment.md`. The first version was strict-replace; failed the first time it was used. Pivoted to auto-fill-empties + retrofit existing records. The lesson is bigger than dedup: "designed-with-no-data" defaults often pick the wrong semantics. Audience: data-modelling, dedup-curious.
 
 - **"Lookup data is messier than your tests"** — `patterns.md §10`, anchored by `retro_genre_matcher.md` (the bidirectional `Contains()` bug), `retro_format_detection.md`, `retro_imprecise_dates.md`, `retro_trove_fallback.md`. Real-surface examples from Open Library + Google Books + Trove. Budget for "lookup data quality" as ongoing, not one-time. Audience: anyone integrating external metadata APIs.
+
+- **"Bugs only the human can make"** — cover-storage PR1 debugging arc (2026-05-07). Drew copy-pasted the new `CoverStorage` config block into `appsettings.Development.json` but landed it nested inside `Logging` rather than as a sibling. Symptom: options blank in constructor. My diagnostic was "paste me the JSON" rather than guessing — Drew spotted it instantly the moment he looked at it. The point: some bug classes are uniquely human-shaped (literal-text manipulation, where-the-cursor-was), counterpart to the AI-shaped failures in #6 (chip-picker) and #7 (sledgehammer). The asks-instead-of-guesses move keeps the loop cheap on the symmetric case — same human-in-the-loop discipline, different direction. Drew flagged it as blog material in-chat ("file away for a blog coming soon") with a self-aimed rejoinder *"And that is why you can't have shiny toys Drew"* that gives the post its hook. Closes the symmetry trio: #6 names the gap, #7 names the response when the gap bites mid-fix from the AI side, this one names what cheap-loop looks like when the gap bites from the human side. Audience: AI-collaboration readers (the blog's core).
 
 ## Possible catch-up candidates
 

--- a/.claude-memory/feedback_avoid_encoded_powershell.md
+++ b/.claude-memory/feedback_avoid_encoded_powershell.md
@@ -1,10 +1,12 @@
 ---
 name: Avoid encoded PowerShell command-line args
-description: PowerShell here-strings and other long inline args get serialised as `-EncodedCommand <base64>` by the tool layer, which Drew's security tooling flags as a malware indicator. Prefer file-based or short inline alternatives for long commands (especially git commit messages).
+description: PowerShell here-strings AND multi-line ad-hoc command bodies (assemble-then-inspect, if/else with semicolons, embedded-variable scripts) get serialised as `-EncodedCommand <base64>` by the tool layer, which Drew's security tooling flags as a malware indicator. The trigger is "long enough or complex enough that the harness encodes it" — applies to any PowerShell call, not just commit messages.
 type: feedback
 originSessionId: 21e97fa1-cba4-4b67-9d43-dc109098d6b2
 ---
-Long inline arguments to PowerShell — multi-line here-strings (`@'...'@`), big multi-line `-Command` payloads, or `git commit -m` with a long here-string body — are serialised by the tool layer as `powershell.exe -EncodedCommand <base64-blob>`. Security tooling on Windows flags base64 command-line args as a malware indicator (legitimate use; it's a common obfuscation pattern). Drew has surfaced this triggering during a session.
+Long OR multi-statement inline arguments to PowerShell get serialised by the tool layer as `powershell.exe -EncodedCommand <base64-blob>`. Security tooling on Windows flags base64 command-line args as a malware indicator (legitimate use; it's a common obfuscation pattern). Drew has surfaced this triggering during sessions.
+
+**Decision rule before calling PowerShell:** if the command would span multiple visual lines, contains `if/else`, multiple statements joined with `;`, here-string `@'...'@`, or a multi-step pipeline with quoted file paths and variables — assume the harness will encode it. Reach for a temp file or split into separate calls instead. The trigger isn't "commit message" specifically; it's "this looks long/scripty when you write it out."
 
 **Why:** the encoded-command form is the standard way long PowerShell args get passed through tool boundaries safely; it's not malicious, but it's indistinguishable from malware on the wire to a scanner. The flag is reliable, not a false positive in the strict sense — the encoded form is what the scanner is configured to flag.
 
@@ -14,10 +16,11 @@ Long inline arguments to PowerShell — multi-line here-strings (`@'...'@`), big
 - **Short inline `-m`.** Keep commit messages to a single line short enough that PowerShell can pass them as a normal arg. Reasonable for tight bug fixes; not for substantial features.
 - **Bash heredoc — does NOT work for git on Windows.** `git commit -F /dev/stdin <<'EOF' ... EOF` fails with `fatal: could not read log file '/proc/self/fd/0'` because Git for Windows is a Windows-native binary that can't open POSIX paths. Don't reach for this; jump straight to the temp-file approach. (For non-git commands that read stdin natively, Bash heredoc may still work — but git is the common case where this comes up, and it doesn't.)
 
-**Specifically NOT:**
+**Specifically NOT — the patterns that have actually tripped this:**
 
-- `git commit -m @'multi-line here-string'@` via PowerShell — this is the exact pattern that triggered the flag.
-- Long multi-line PR body text inline to `gh pr create` via PowerShell — same shape, same problem. Use `--body-file <path>` instead.
-- Long inline scripts via `powershell -Command "..."` with embedded newlines.
+- `git commit -m @'multi-line here-string'@` via PowerShell — the original trigger.
+- Long multi-line PR body text inline to `gh pr create` via PowerShell — same shape. Use `--body-file <path>` instead.
+- **Multi-statement PowerShell smoke checks** like `dotnet build ...; $dll = "..."; if (Test-Path $dll) { $bytes = ...; $asm = [...]::Load($bytes); ... } else { ... }` — exactly the shape that re-triggered the AV during the BuildInfo work. If you need to do load-and-inspect, write the inspection script to a `.ps1` file via the Write tool and run that file, OR split into separate one-liner Bash/PowerShell calls, OR skip the smoke check if unit tests already cover the logic.
+- Any `powershell -Command "..."` with embedded newlines or multiple statements.
 
 Temp-file is the durable answer on this project even though the standing convention is PowerShell-first per `feedback_use_powershell.md`. The two rules complement: PowerShell for everyday short operations, temp-file commit-message workflow for anything multi-line. The temp file lives one command (Write tool); the next command uses it; the third deletes it. No long string ever crosses a process boundary in serialised form.


### PR DESCRIPTION
- blog_post_backlog: post #7 ("Going with the sledgehammer") moved
  from candidate to Already-shipped, "Bugs only the human can make"
  added to Strong candidates from the cover-storage JSON-nesting arc.
- feedback_avoid_encoded_powershell: rule broadened beyond commit
  messages to "any multi-statement / multi-line PowerShell" after the
  BuildInfo smoke-check re-triggered Drew's AV via assemble-then-
  inspect scripts. Adds the temp-file-as-default guidance and the
  Bash-heredoc-doesn't-work-for-git-on-Windows nuance.
