### PR TITLE
fix(perf): keep SQL pool warm + AsSplitQuery + lazy publisher merge picker

### DIFF
--- a/BookTracker.Web/Components/Pages/Publishers/Index.razor
+++ b/BookTracker.Web/Components/Pages/Publishers/Index.razor
@@ -95,19 +95,23 @@
                                 <MudButton Size="Size.Small" Variant="Variant.Outlined" StartIcon="@Icons.Material.Filled.Edit"
                                            OnClick="@(() => StartRename(publisher))">Rename</MudButton>
 
-                                <MudSelect T="int?"
-                                           Value="null"
-                                           ValueChanged="@((int? id) => { if (id is int tid) StartMerge(publisher.Id, tid); })"
-                                           Label="Merge into…"
-                                           Variant="Variant.Outlined"
-                                           Margin="Margin.Dense"
-                                           Dense="true"
-                                           Style="max-width: 260px;">
-                                    @foreach (var other in VM.Publishers.Where(p => p.Id != publisher.Id))
-                                    {
-                                        <MudSelectItem T="int?" Value="@((int?)other.Id)">@other.Name</MudSelectItem>
-                                    }
-                                </MudSelect>
+                                @* Lazy autocomplete instead of MudSelect: every row used to render
+                                   one MudSelectItem per other publisher (N rows × N-1 items = O(N²)
+                                   render-tree blow-up that spiked working set to 700MB+ at ~200
+                                   publishers). Autocomplete only materialises items when the user
+                                   types, so per-row cost drops to O(1). *@
+                                <MudAutocomplete T="PublisherListViewModel.PublisherRow"
+                                                 Value="null"
+                                                 ValueChanged="@((PublisherListViewModel.PublisherRow? other) => { if (other is not null) StartMerge(publisher.Id, other.Id); })"
+                                                 SearchFunc="@((string? value, CancellationToken _) => Task.FromResult(SearchMergeTargets(publisher.Id, value)))"
+                                                 ToStringFunc="@(p => p?.Name ?? string.Empty)"
+                                                 Label="Merge into…"
+                                                 Variant="Variant.Outlined"
+                                                 Margin="Margin.Dense"
+                                                 Dense="true"
+                                                 Clearable="true"
+                                                 ResetValueOnEmptyText="true"
+                                                 Style="max-width: 260px;" />
 
                                 @if (publisher.EditionCount == 0)
                                 {
@@ -219,5 +223,15 @@
     {
         await VM.MergeAsync(sourceId, targetId);
         ClearPendingMerge();
+    }
+
+    private IEnumerable<PublisherListViewModel.PublisherRow> SearchMergeTargets(int sourceId, string? term)
+    {
+        IEnumerable<PublisherListViewModel.PublisherRow> q = VM.Publishers.Where(p => p.Id != sourceId);
+        if (!string.IsNullOrWhiteSpace(term))
+        {
+            q = q.Where(p => p.Name.Contains(term, StringComparison.OrdinalIgnoreCase));
+        }
+        return q.Take(20);
     }
 }

--- a/BookTracker.Web/Services/DuplicateDetectionService.cs
+++ b/BookTracker.Web/Services/DuplicateDetectionService.cs
@@ -214,7 +214,13 @@ public class DuplicateDetectionService(IDbContextFactory<BookTrackerDbContext> d
         // count) bucket together for duplicate detection. Single-author works
         // get a single-id fingerprint; "Preston, Child" works share a
         // fingerprint distinct from a "Preston" solo work.
+        //
+        // AsSplitQuery: the projection traverses two collection navigations
+        // (WorkAuthors twice, Books). Without splitting, EF emits a single
+        // query with multi-LEFT-JOIN cartesian — slow plus the row count
+        // multiplies materialisation memory.
         var works = (await db.Works
+            .AsSplitQuery()
             .Select(w => new
             {
                 w.Id,
@@ -264,7 +270,13 @@ public class DuplicateDetectionService(IDbContextFactory<BookTrackerDbContext> d
         CancellationToken ct)
     {
         // Project once; re-use for both detection strategies.
+        //
+        // AsSplitQuery: the projection touches Editions, Editions.Copies,
+        // Works, and Works.WorkAuthors — four collection navigations. Without
+        // splitting, EF SingleQuery cartesian-joins them and the row count
+        // explodes (the warning logged in App Insights trace 3.a).
         var books = await db.Books
+            .AsSplitQuery()
             .Select(b => new
             {
                 b.Id,

--- a/infra/modules/app-config.bicep
+++ b/infra/modules/app-config.bicep
@@ -164,7 +164,11 @@ resource connStrings 'Microsoft.Web/sites/config@2023-12-01' = {
   name: 'connectionstrings'
   properties: {
     DefaultConnection: {
-      value: 'Server=tcp:${sqlServerFqdn},1433;Database=${sqlDatabaseName};Authentication=Active Directory Default;Encrypt=True;TrustServerCertificate=False;'
+      // Min Pool Size=3 keeps a small warm pool so AAD-token + TLS handshake
+      // costs don't recur on every idle gap. Without it, sporadic mobile
+      // traffic was paying 8-27s connection-open latency (App Insights
+      // `InternalOpenAsync` p95) for every fresh physical connection.
+      value: 'Server=tcp:${sqlServerFqdn},1433;Database=${sqlDatabaseName};Authentication=Active Directory Default;Encrypt=True;TrustServerCertificate=False;Min Pool Size=3;'
       type: 'SQLAzure'
     }
   }
@@ -225,7 +229,7 @@ resource stagingConnStrings 'Microsoft.Web/sites/slots/config@2023-12-01' = {
   name: 'connectionstrings'
   properties: {
     DefaultConnection: {
-      value: 'Server=tcp:${sqlServerFqdn},1433;Database=${stagingSqlDatabaseName};Authentication=Active Directory Default;Encrypt=True;TrustServerCertificate=False;'
+      value: 'Server=tcp:${sqlServerFqdn},1433;Database=${stagingSqlDatabaseName};Authentication=Active Directory Default;Encrypt=True;TrustServerCertificate=False;Min Pool Size=3;'
       type: 'SQLAzure'
     }
   }


### PR DESCRIPTION
Three changes addressing perf issues surfaced by the App Insights
investigation logged at .claude-memory (and forthcoming blog post):

1. infra/modules/app-config.bicep — append Min Pool Size=3 to the prod
   and staging connection strings. App Insights showed InternalOpenAsync
   p50=8.6s, p95=27.5s — the AAD-token + TLS handshake recurs on every
   cold physical connection. A small warm pool keeps the cost amortised
   across idle gaps. Dev (localhost SQL, no AAD) is untouched.

2. BookTracker.Web/Services/DuplicateDetectionService.cs — add
   AsSplitQuery() to DetectWorksAsync and DetectBooksAsync. Both
   projections traverse multiple collection navigations
   (WorkAuthors twice + Books; Editions, Editions.Copies, Works,
   Works.WorkAuthors), which the EF SingleQuery default cartesian-joins
   into one query. The warning was logged in App Insights trace 3.a for
   the 31s /duplicates request.

3. BookTracker.Web/Components/Pages/Publishers/Index.razor — replace
   the per-row MudSelect (which eagerly rendered N-1 MudSelectItems for
   every visible row) with MudAutocomplete that searches lazily. The
   render-tree was O(N²) — at ~200 publishers it was materialising
   ~40,000 MudBlazor components and spiking working-set memory to 700MB+.
   New per-row cost is O(1) until the user types.

No new tests: existing 19 DuplicateDetectionServiceTests run against a
real SQL Server (Docker container via Respawn) and cover the result
shape — AsSplitQuery is a query-plan change, not a semantics change.
The Razor change is pure markup. All 387 tests pass.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
