### PR TITLE
chore(infra): set WEBSITES_CONTAINER_START_TIME_LIMIT=600

### DIFF
--- a/infra/modules/app-config.bicep
+++ b/infra/modules/app-config.bicep
@@ -63,6 +63,15 @@ var coverStorageConnRef = '@Microsoft.KeyVault(SecretUri=${kvBase}/CoverStorageC
 var commonAppSettings = {
   ASPNETCORE_ENVIRONMENT: 'Production'
   APPLICATIONINSIGHTS_CONNECTION_STRING: appInsightsConnectionString
+  // App Service Linux warmup probe gives the container 230s by default
+  // before declaring failure and entering a kill-and-restart loop.
+  // BookTracker's startup adds up to ~250s under realistic conditions:
+  // platform `update-ca-certificates` (5-80s, regional), dotnet bootstrap
+  // (~15s), first SQL connection with AAD-only auth on Basic tier
+  // (~30-40s), EF migration applock + history check (~10s), then app
+  // initialisation. 600s gives generous headroom for slow days without
+  // letting genuinely broken bits hide forever.
+  WEBSITES_CONTAINER_START_TIME_LIMIT: '600'
   MICROSOFT_PROVIDER_AUTHENTICATION_SECRET: authClientSecretRef
   AI__DefaultProvider: aiDefaultProvider
   AI__AzureOpenAI__Endpoint: aiAzureOpenAIEndpoint


### PR DESCRIPTION
Today's deploy surfaced a pre-existing platform issue: the App Service
Linux container takes ~230-260s to start serving (cert update + dotnet
bootstrap + first AAD-authed SQL connection on Basic tier + EF migration
check + app init). The default 230s warmup-probe timeout means a slow
day pushes startup past the limit, the platform kills and restarts the
container, and the restart loop only makes the next attempt slower.

Setting WEBSITES_CONTAINER_START_TIME_LIMIT=600 gives 10 minutes —
generous headroom for slow days without letting genuinely broken
bits hide forever. Same setting on both slots (via commonAppSettings),
not slot-sticky since it's an environment-shape value not a per-slot one.

Drew applied this manually via az CLI during the incident to break the
loop; this commit makes it permanent so the next deploy survives.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
