### PR TITLE
chore(infra): bump SQL prod + staging from Basic to Standard S0

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -17,8 +17,8 @@ All tagged with `Client = Drew` and `Environment = Production`.
 | Staging slot | `staging` on the App Service | `australiaeast` | own system-assigned identity; CI deploys here, `swap.yml` promotes |
 | System-assigned managed identities | on prod + staging slots | — | granted SQL DB roles + Key Vault Secrets User + Cognitive Services User on OpenAI |
 | Azure SQL logical server | `booktracker-sql-<hash>` | `australiaeast` | **AAD-only auth**; `publicNetworkAccess = Disabled` by default |
-| Azure SQL database (prod) | `booktracker` | `australiaeast` | Basic tier, 5 DTU; reached by the prod slot only |
-| Azure SQL database (staging) | `booktracker-staging` | `australiaeast` | Basic tier, 5 DTU; reached by the staging slot only. Empty on first deploy — migrate-on-startup creates the schema. |
+| Azure SQL database (prod) | `booktracker` | `australiaeast` | Standard S0, 10 DTU; reached by the prod slot only |
+| Azure SQL database (staging) | `booktracker-staging` | `australiaeast` | Standard S0, 10 DTU; reached by the staging slot only. Empty on first deploy — migrate-on-startup creates the schema. |
 | Azure SQL Private Endpoint | `booktracker-sql-<hash>-pe` | `australiaeast` | in primary `private-endpoints` subnet; serves both DBs |
 | Key Vault | `booktracker-kv-<hash>` | `australiaeast` | Standard, RBAC auth, `defaultAction = Deny`; holds AuthClientSecret + AI keys |
 | Key Vault Private Endpoint | `booktracker-kv-<hash>-pe` | `australiaeast` | in primary `private-endpoints` subnet |

--- a/infra/modules/sql.bicep
+++ b/infra/modules/sql.bicep
@@ -38,15 +38,21 @@ resource sqlServer 'Microsoft.Sql/servers@2023-08-01-preview' = {
   }
 }
 
+// Standard S0 (10 DTU). Bumped from Basic (5 DTU) after the May 2026 perf
+// investigation: AAD-authed handshake on Basic was running 8-27s on cold
+// connections and contributing to deploy-time wedges. S0 has materially
+// better connection-acquisition latency and double the DTU headroom for
+// query throughput. maxSizeBytes stays at 2GB — Drew's library is well
+// under that.
 resource sqlDb 'Microsoft.Sql/servers/databases@2023-08-01-preview' = {
   parent: sqlServer
   name: sqlDatabaseName
   location: location
   tags: tags
   sku: {
-    name: 'Basic'
-    tier: 'Basic'
-    capacity: 5
+    name: 'S0'
+    tier: 'Standard'
+    capacity: 10
   }
   properties: {
     collation: 'SQL_Latin1_General_CP1_CI_AS'
@@ -57,7 +63,7 @@ resource sqlDb 'Microsoft.Sql/servers/databases@2023-08-01-preview' = {
 // Separate database for the staging slot so deploys against staging can't
 // touch prod data (a destructive migration would otherwise take prod down
 // before any swap, and slot swap-back would give old binaries against the
-// new schema). Same Basic SKU as prod for symmetric provisioning shape;
+// new schema). Same S0 SKU as prod for symmetric provisioning shape;
 // AAD-only auth and Private Endpoint are inherited from the parent server.
 // First deploy lands an empty DB — migrate-on-startup creates the schema
 // against it on the next app start. See infra/README.md for ordering.
@@ -67,9 +73,9 @@ resource sqlStagingDb 'Microsoft.Sql/servers/databases@2023-08-01-preview' = {
   location: location
   tags: tags
   sku: {
-    name: 'Basic'
-    tier: 'Basic'
-    capacity: 5
+    name: 'S0'
+    tier: 'Standard'
+    capacity: 10
   }
   properties: {
     collation: 'SQL_Latin1_General_CP1_CI_AS'


### PR DESCRIPTION
Basic (5 DTU) was contributing materially to the May 2026 perf
investigation: AAD-authed connection handshake on Basic was running
8-27s on cold connections (App Insights InternalOpenAsync p95=27.5s),
and a load spike during the deploy of PR #191 wedged workers in a way
that took an SQL DB restart to clear. Standard S0 has materially better
connection-acquisition latency and double the DTU headroom for query
throughput.

maxSizeBytes stays at 2GB — Drew's library is well under that, no need
to provision more storage. Same SKU on both slots for symmetric shape.

Cost delta: ~$10/mo per DB, so ~$20/mo total. The Min Pool Size=3 +
WEBSITES_CONTAINER_START_TIME_LIMIT=600 changes already shipped
mitigate the cold-handshake floor; this change attacks the floor itself.

README updated to match.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
