### PR TITLE
perf(book-detail): AsNoTracking on read-only EF queries

### DIFF
--- a/BookTracker.Web/ViewModels/BookDetailViewModel.cs
+++ b/BookTracker.Web/ViewModels/BookDetailViewModel.cs
@@ -49,6 +49,7 @@ public class BookDetailViewModel(
         await using var db = await dbFactory.CreateDbContextAsync();
 
         var book = await db.Books
+            .AsNoTracking()
             .Include(b => b.Tags)
             .Include(b => b.Editions)
                 .ThenInclude(e => e.Copies)
@@ -294,6 +295,7 @@ public class BookDetailViewModel(
         var q = (query ?? "").Trim().ToLowerInvariant();
 
         var names = await db.Tags
+            .AsNoTracking()
             .Where(t => string.IsNullOrEmpty(q) || t.Name.Contains(q))
             .OrderBy(t => t.Name)
             .Select(t => t.Name)


### PR DESCRIPTION
Two read paths in BookDetailViewModel materialise entities that the VM
immediately projects into records and never mutates: InitializeAsync
(the big multi-include book load) and SearchTagsAsync (tag autocomplete).
Both queries left tracking enabled by default, paying change-tracking
overhead and holding entities live in the DbContext for the duration of
the projection.

AsNoTracking() drops both costs. The DbContext is disposed
immediately after the projection in both methods, so tracking was
already unused — this is a pure overhead reduction. No behavioural
change.

Slim follow-up to PR #191 + PR #193 (SQL S0). Modal-close in-place
patches deliberately deferred — wider scope than the gain warrants
without post-S0 telemetry to justify it.

All 387 tests pass.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
