### PR TITLE
fix(library): collapse group-by-author fan-out when narrowed by filter

### DIFF
--- a/BookTracker.Tests/ViewModels/BookListViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/BookListViewModelTests.cs
@@ -257,6 +257,153 @@ public class BookListViewModelTests
     }
 
     [Fact]
+    public async Task GroupByAuthor_AuthorFilter_ShowsOnlySelectedAuthorEvenWithCompendiumCoauthors()
+    {
+        // Repro of the Asimov case: filtering by a single author with grouping
+        // by Author should NOT fan out across co-authors of compendiums the
+        // selected author contributed to. One filter, one group.
+        var factory = new TestDbContextFactory();
+        using (var db = factory.CreateDbContext())
+        {
+            var asimov = new Author { Name = "Isaac Asimov" };
+            var king = new Author { Name = "Stephen King" };
+            var bradbury = new Author { Name = "Ray Bradbury" };
+            db.Authors.AddRange(asimov, king, bradbury);
+            await db.SaveChangesAsync();
+
+            db.Books.AddRange(
+                new Book
+                {
+                    Title = "Foundation",
+                    Works = [new Work { Title = "Foundation", WorkAuthors = [new WorkAuthor { Author = asimov, Order = 0 }] }]
+                },
+                // Compendium with Asimov + co-authors. Pre-fix this would surface
+                // King and Bradbury as separate group rows when filtering for Asimov.
+                new Book
+                {
+                    Title = "The Funhouse",
+                    Works =
+                    [
+                        new Work { Title = "Asimov story", WorkAuthors = [new WorkAuthor { Author = asimov, Order = 0 }] },
+                        new Work { Title = "King story", WorkAuthors = [new WorkAuthor { Author = king, Order = 0 }] },
+                        new Work { Title = "Bradbury story", WorkAuthors = [new WorkAuthor { Author = bradbury, Order = 0 }] },
+                    ]
+                });
+            await db.SaveChangesAsync();
+        }
+
+        var vm = new BookListViewModel(factory)
+        {
+            SelectedGroupBy = LibraryGroupBy.Author,
+            SelectedAuthor = "Isaac Asimov",
+        };
+        await vm.InitializeAsync();
+
+        Assert.Single(vm.Groups);
+        Assert.Equal("Isaac Asimov", vm.Groups[0].Label);
+        Assert.Equal(2, vm.Groups[0].Count); // Foundation + The Funhouse.
+    }
+
+    [Fact]
+    public async Task GroupByAuthor_AuthorFilterByAlias_ResolvesGroupToCanonical()
+    {
+        // Filtering by an alias name should produce the canonical's group row,
+        // matching the rollup behaviour the unfiltered path asserts.
+        var factory = new TestDbContextFactory();
+        await SeedSampleLibraryAsync(factory);
+
+        var vm = new BookListViewModel(factory)
+        {
+            SelectedGroupBy = LibraryGroupBy.Author,
+            SelectedAuthor = "Richard Bachman",
+        };
+        await vm.InitializeAsync();
+
+        Assert.Single(vm.Groups);
+        Assert.Equal("Stephen King", vm.Groups[0].Label);
+        // Only "The Long Walk" matches the alias filter — Carrie's author is
+        // King, whose Name is "Stephen King" (not the alias) and whose
+        // CanonicalAuthor is null.
+        Assert.Equal(1, vm.Groups[0].Count);
+    }
+
+    [Fact]
+    public async Task GroupByAuthor_BookSearchOnCompendium_GroupsByPrimaryAuthor()
+    {
+        // Searching for a book title shouldn't fan out the result book's
+        // co-authors as separate group rows. Group by the primary
+        // (lowest-Order, first-Work) author of each matched book.
+        var factory = new TestDbContextFactory();
+        using (var db = factory.CreateDbContext())
+        {
+            var asimov = new Author { Name = "Isaac Asimov" };
+            var king = new Author { Name = "Stephen King" };
+            var bradbury = new Author { Name = "Ray Bradbury" };
+            db.Authors.AddRange(asimov, king, bradbury);
+            await db.SaveChangesAsync();
+
+            db.Books.Add(new Book
+            {
+                Title = "The Funhouse",
+                Works =
+                [
+                    new Work { Title = "Asimov story", WorkAuthors = [new WorkAuthor { Author = asimov, Order = 0 }] },
+                    new Work { Title = "King story", WorkAuthors = [new WorkAuthor { Author = king, Order = 0 }] },
+                    new Work { Title = "Bradbury story", WorkAuthors = [new WorkAuthor { Author = bradbury, Order = 0 }] },
+                ]
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var vm = new BookListViewModel(factory)
+        {
+            SelectedGroupBy = LibraryGroupBy.Author,
+            SearchTerm = "Funhouse",
+        };
+        await vm.InitializeAsync();
+
+        Assert.Single(vm.Groups);
+        // Primary attribution = Asimov (first Work, lowest Order WorkAuthor).
+        Assert.Equal("Isaac Asimov", vm.Groups[0].Label);
+        Assert.Equal(1, vm.Groups[0].Count);
+    }
+
+    [Fact]
+    public async Task GroupByAuthor_NoFilter_KeepsFanOutBehaviour()
+    {
+        // Regression guard: the unfiltered path keeps the post-PR2 fan-out
+        // (compendiums + co-authored works appear under each canonical). The
+        // narrowed paths above are the only ones that collapse.
+        var factory = new TestDbContextFactory();
+        using (var db = factory.CreateDbContext())
+        {
+            var asimov = new Author { Name = "Isaac Asimov" };
+            var king = new Author { Name = "Stephen King" };
+            db.Authors.AddRange(asimov, king);
+            await db.SaveChangesAsync();
+
+            db.Books.Add(new Book
+            {
+                Title = "The Funhouse",
+                Works =
+                [
+                    new Work { Title = "Asimov story", WorkAuthors = [new WorkAuthor { Author = asimov, Order = 0 }] },
+                    new Work { Title = "King story", WorkAuthors = [new WorkAuthor { Author = king, Order = 0 }] },
+                ]
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var vm = new BookListViewModel(factory) { SelectedGroupBy = LibraryGroupBy.Author };
+        await vm.InitializeAsync();
+
+        // Both authors should have a group row (the deliberate fan-out).
+        Assert.Equal(2, vm.Groups.Count);
+        Assert.Contains(vm.Groups, g => g.Label == "Isaac Asimov" && g.Count == 1);
+        Assert.Contains(vm.Groups, g => g.Label == "Stephen King" && g.Count == 1);
+    }
+
+    [Fact]
     public async Task GroupByGenre_GenreFilterReducesGroupsAndCounts()
     {
         var factory = new TestDbContextFactory();

--- a/BookTracker.Web/ViewModels/BookListViewModel.cs
+++ b/BookTracker.Web/ViewModels/BookListViewModel.cs
@@ -227,10 +227,26 @@ public class BookListViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
 
     private async Task<List<GroupRow>> GroupByAuthorAsync(BookTrackerDbContext db, IQueryable<Book> filtered)
     {
-        // Roll up by canonical author id (CanonicalAuthorId ?? Id) so a
-        // Bachman title appears under King. Co-authored works expand into
-        // one row per credited author — Preston + Child appears under both
-        // canonicals (post-PR2 behaviour change vs the lead-only legacy).
+        // Filter-aware grouping. When the user has explicitly narrowed the
+        // result set, the default fan-out across every credited author of
+        // every matched book becomes confusing — filtering for "Asimov" on a
+        // library with an Asimov-contributed compendium would surface every
+        // co-author of that compendium (King, Bradbury, …) as separate group
+        // rows. Same shape happens with a book-title search hitting a
+        // compendium. Two narrowed paths, one default fan-out:
+        if (!string.IsNullOrWhiteSpace(SelectedAuthor))
+        {
+            return await SingleAuthorGroupAsync(db, filtered, SelectedAuthor.Trim());
+        }
+
+        if (!string.IsNullOrWhiteSpace(SearchTerm))
+        {
+            return await PrimaryAuthorGroupAsync(db, filtered);
+        }
+
+        // Default: fan out across all credited authors, rolling aliases up
+        // to canonicals. A Bachman title appears under King; a Preston +
+        // Child co-authored work appears under BOTH (post-PR2 behaviour).
         var raw = await filtered
             .SelectMany(b => b.Works.SelectMany(w => w.Authors.Select(a => new
             {
@@ -241,6 +257,73 @@ public class BookListViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
             .GroupBy(x => x.CanonicalId)
             .Select(g => new { CanonicalId = g.Key, Count = g.Count() })
             .ToListAsync();
+
+        var canonicalIds = raw.Select(r => r.CanonicalId).ToList();
+        var names = await db.Authors
+            .Where(a => canonicalIds.Contains(a.Id))
+            .Select(a => new { a.Id, a.Name })
+            .ToDictionaryAsync(x => x.Id, x => x.Name);
+
+        return raw
+            .Select(r => new GroupRow(
+                Key: r.CanonicalId.ToString(),
+                Label: names.GetValueOrDefault(r.CanonicalId) ?? "(unknown)",
+                Count: r.Count))
+            .OrderBy(g => g.Label)
+            .ToList();
+    }
+
+    private async Task<List<GroupRow>> SingleAuthorGroupAsync(BookTrackerDbContext db, IQueryable<Book> filtered, string selectedName)
+    {
+        // Resolve the typed name to its canonical author. The name might be
+        // an alias (e.g. "Richard Bachman"); the group should still be keyed
+        // and labelled by the canonical (King), matching the rollup behaviour
+        // of the unfiltered fan-out path.
+        var matched = await db.Authors
+            .Where(a => a.Name == selectedName)
+            .Select(a => new
+            {
+                CanonicalId = a.CanonicalAuthorId ?? a.Id,
+                CanonicalName = a.CanonicalAuthor != null ? a.CanonicalAuthor.Name : a.Name,
+            })
+            .FirstOrDefaultAsync();
+
+        if (matched is null) return [];
+
+        var count = await filtered.CountAsync();
+        return count == 0
+            ? []
+            : [new GroupRow(matched.CanonicalId.ToString(), matched.CanonicalName, count)];
+    }
+
+    private async Task<List<GroupRow>> PrimaryAuthorGroupAsync(BookTrackerDbContext db, IQueryable<Book> filtered)
+    {
+        // For each matched book, attribute it to its primary author —
+        // the lowest-Order WorkAuthor of the first Work (by Work.Id). For
+        // single-Work books this is unambiguous; for compendiums it's the
+        // primary of whichever Work sorts first, which avoids the M-author
+        // fan-out at the cost of a small simplification (other Works'
+        // primaries don't get separate group rows). The book itself still
+        // renders its full author list inside the group (via ToBookListItem).
+        var rawAuthors = await filtered
+            .SelectMany(b => b.Works.SelectMany(w => w.WorkAuthors.Select(wa => new
+            {
+                BookId = b.Id,
+                CanonicalId = wa.Author.CanonicalAuthorId ?? wa.AuthorId,
+                WorkId = w.Id,
+                wa.Order,
+            })))
+            .ToListAsync();
+
+        // Pick the primary (smallest WorkId, then smallest Order) per book
+        // in-memory. Bounded by matched-books × authors-per-book; fine at the
+        // 3000+ books target since search narrows the set first.
+        var raw = rawAuthors
+            .GroupBy(x => x.BookId)
+            .Select(g => g.OrderBy(x => x.WorkId).ThenBy(x => x.Order).First())
+            .GroupBy(x => x.CanonicalId)
+            .Select(g => new { CanonicalId = g.Key, Count = g.Count() })
+            .ToList();
 
         var canonicalIds = raw.Select(r => r.CanonicalId).ToList();
         var names = await db.Authors


### PR DESCRIPTION
When the user filters /books by SelectedAuthor or SearchTerm and
groups by Author, the post-PR2 fan-out across every credited author
of every matched book was producing surprising group rows. Filtering
for "Isaac Asimov" on a library with an Asimov-contributed compendium
(say "The Funhouse") would surface every co-author of that compendium
(King, Bradbury, ...) as separate group rows, each showing one book —
the same compendium projected through each contributor.

Fix in GroupByAuthorAsync, two narrowed paths added before the default
fan-out:

(1) SelectedAuthor active: SingleAuthorGroupAsync resolves the typed
name to its canonical author (alias-aware) and returns exactly one
group row for the canonical with the matched-book count. "Filter for
Asimov" -> one Asimov group containing all Asimov's books, including
his compendium contributions.

(2) SearchTerm active (no author filter): PrimaryAuthorGroupAsync
attributes each matched book to its primary author — the lowest-Order
WorkAuthor of the first Work (by Work.Id). Single-Work books are
unambiguous; compendiums get a single group row keyed on their first
Work's primary, avoiding the M-author fan-out at the cost of a small
simplification (other Works' primaries don't get separate rows).

(3) No filter: existing fan-out behaviour preserved — compendiums and
co-authored works still appear under each canonical author's group,
which is the post-PR2 design.

Tests:
- GroupByAuthor_AuthorFilter_ShowsOnlySelectedAuthorEvenWithCompendiumCoauthors
- GroupByAuthor_AuthorFilterByAlias_ResolvesGroupToCanonical
- GroupByAuthor_BookSearchOnCompendium_GroupsByPrimaryAuthor
- GroupByAuthor_NoFilter_KeepsFanOutBehaviour (regression guard)

All 391 tests pass.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
