### PR TITLE
fix(cover-upload): hint mobile browsers to default to rear camera

### DIFF
--- a/BookTracker.Web/Components/Shared/EditionCoverUploadDialog.razor
+++ b/BookTracker.Web/Components/Shared/EditionCoverUploadDialog.razor
@@ -15,10 +15,19 @@
                 Upload a photo of this edition's cover. Mobile users get the rear camera by default. Max @(BookDetailViewModel.MaxUploadBytes / 1024 / 1024) MB.
             </MudText>
 
+            @* capture="environment" hints to mobile browsers that the rear
+               camera should be the default (vs. gallery picker). Without it,
+               some Android browsers don't surface the camera option at all
+               for accept="image/*" alone — they fall back to the file picker.
+               iOS Safari respects the hint by pre-selecting "Take Photo or
+               Video" in the action sheet but still allows gallery via the
+               same sheet. Forwarded through MudFileUpload's InputAttributes
+               which propagate to the underlying <input type="file">. *@
             <MudFileUpload T="IBrowserFile"
                            FilesChanged="OnFileChanged"
                            Accept="image/*"
-                           MaximumFileCount="1">
+                           MaximumFileCount="1"
+                           InputAttributes="@(new Dictionary<string, object?> { ["capture"] = "environment" })">
                 <ActivatorContent>
                     <MudButton Variant="Variant.Outlined"
                                StartIcon="@Icons.Material.Filled.CameraAlt"


### PR DESCRIPTION
Cover upload dialog had Accept="image/*" but no capture hint on the
underlying input. On iOS the picker still surfaces "Take Photo" via
the action sheet, but Android Chrome (and some other Android browsers)
only show the file picker and not the camera option without an
explicit capture attribute.

Forwards capture="environment" through MudFileUpload's InputAttributes
to the underlying <input type="file">. Mobile users now get the rear
camera by default; gallery selection still available via the same
sheet/picker. The dialog text already promised "Mobile users get the
rear camera by default" — the markup now matches.

The MUD0002 analyzer warning on this file's MudFileUpload usage is a
known false positive (the analyzer flags Blazor parameters that look
like HTML attribute names; InputAttributes and ChildContent are both
real component parameters). Pre-existing warnings on this file
already include the ChildContent case.

All 387 tests pass.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
