### PR TITLE
feat(bookshop): catalog-snapshot API endpoint (PR 1 of bookshop-mode arc)

### DIFF
--- a/BookTracker.Tests/Services/CatalogSnapshotServiceTests.cs
+++ b/BookTracker.Tests/Services/CatalogSnapshotServiceTests.cs
@@ -1,0 +1,208 @@
+using BookTracker.Data.Models;
+using BookTracker.Web.Services.Catalog;
+
+namespace BookTracker.Tests.Services;
+
+[Trait("Category", TestCategories.Integration)]
+public class CatalogSnapshotServiceTests
+{
+    private readonly TestDbContextFactory _factory = new();
+
+    private CatalogSnapshotService CreateService() => new(_factory);
+
+    [Fact]
+    public async Task GetSnapshotAsync_PrimaryAndAllAuthors_OnSingleWorkBook()
+    {
+        using (var db = _factory.CreateDbContext())
+        {
+            var asimov = new Author { Name = "Isaac Asimov" };
+            db.Authors.Add(asimov);
+            db.Books.Add(new Book
+            {
+                Title = "Foundation",
+                Works = [new Work { Title = "Foundation", WorkAuthors = [new WorkAuthor { Author = asimov, Order = 0 }] }]
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var snapshot = await CreateService().GetSnapshotAsync();
+
+        var book = Assert.Single(snapshot.Books);
+        Assert.Equal("Foundation", book.Title);
+        Assert.Equal("Isaac Asimov", book.PrimaryAuthor);
+        Assert.Equal(["Isaac Asimov"], book.AllAuthors);
+    }
+
+    [Fact]
+    public async Task GetSnapshotAsync_PrimaryAndAllAuthors_OnMultiWorkCompendium()
+    {
+        // Compendium with three Works, each by a different author. Primary
+        // author = first Work's lowest-Order WorkAuthor; AllAuthors lists
+        // every credited contributor.
+        using (var db = _factory.CreateDbContext())
+        {
+            var asimov = new Author { Name = "Isaac Asimov" };
+            var king = new Author { Name = "Stephen King" };
+            var bradbury = new Author { Name = "Ray Bradbury" };
+            db.Authors.AddRange(asimov, king, bradbury);
+            db.Books.Add(new Book
+            {
+                Title = "The Funhouse",
+                Works =
+                [
+                    new Work { Title = "Asimov story", WorkAuthors = [new WorkAuthor { Author = asimov, Order = 0 }] },
+                    new Work { Title = "King story", WorkAuthors = [new WorkAuthor { Author = king, Order = 0 }] },
+                    new Work { Title = "Bradbury story", WorkAuthors = [new WorkAuthor { Author = bradbury, Order = 0 }] },
+                ]
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var snapshot = await CreateService().GetSnapshotAsync();
+
+        var book = Assert.Single(snapshot.Books);
+        Assert.Equal("Isaac Asimov", book.PrimaryAuthor);
+        Assert.Equal(["Isaac Asimov", "Stephen King", "Ray Bradbury"], book.AllAuthors);
+    }
+
+    [Fact]
+    public async Task GetSnapshotAsync_AliasBookCounts_RolledUpAtCanonical_NotAtAlias()
+    {
+        // King canonical, Bachman alias. Carrie credited to King, The Long
+        // Walk credited to Bachman. Canonical row should show the rolled-up
+        // count (2); alias row shows just its direct count (1).
+        using (var db = _factory.CreateDbContext())
+        {
+            var king = new Author { Name = "Stephen King" };
+            db.Authors.Add(king);
+            await db.SaveChangesAsync();
+
+            var bachman = new Author { Name = "Richard Bachman", CanonicalAuthorId = king.Id };
+            db.Authors.Add(bachman);
+            db.Books.AddRange(
+                new Book { Title = "Carrie", Works = [new Work { Title = "Carrie", WorkAuthors = [new WorkAuthor { Author = king, Order = 0 }] }] },
+                new Book { Title = "The Long Walk", Works = [new Work { Title = "The Long Walk", WorkAuthors = [new WorkAuthor { Author = bachman, Order = 0 }] }] });
+            await db.SaveChangesAsync();
+        }
+
+        var snapshot = await CreateService().GetSnapshotAsync();
+
+        var kingRow = snapshot.Authors.Single(a => a.Name == "Stephen King");
+        var bachmanRow = snapshot.Authors.Single(a => a.Name == "Richard Bachman");
+
+        Assert.Equal(kingRow.Id, kingRow.CanonicalId);
+        Assert.Equal(2, kingRow.BookCount);
+
+        Assert.Equal(kingRow.Id, bachmanRow.CanonicalId);
+        Assert.Equal(1, bachmanRow.BookCount);
+    }
+
+    [Fact]
+    public async Task GetSnapshotAsync_BookCreditedToBothCanonicalAndAlias_NotDoubleCountedInRollup()
+    {
+        // Edge case: a single book has WorkAuthors crediting both King AND
+        // Bachman (rare but possible — e.g. a foreword/author note that
+        // names the alias). Canonical rollup must not double-count.
+        using (var db = _factory.CreateDbContext())
+        {
+            var king = new Author { Name = "Stephen King" };
+            db.Authors.Add(king);
+            await db.SaveChangesAsync();
+
+            var bachman = new Author { Name = "Richard Bachman", CanonicalAuthorId = king.Id };
+            db.Authors.Add(bachman);
+            db.Books.Add(new Book
+            {
+                Title = "The Bachman Books",
+                Works = [new Work
+                {
+                    Title = "The Bachman Books",
+                    WorkAuthors =
+                    [
+                        new WorkAuthor { Author = king, Order = 0 },
+                        new WorkAuthor { Author = bachman, Order = 1 },
+                    ]
+                }]
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var snapshot = await CreateService().GetSnapshotAsync();
+        var kingRow = snapshot.Authors.Single(a => a.Name == "Stephen King");
+
+        // Despite the book being credited to both King AND Bachman (whose
+        // canonical is King), the rollup should count it once.
+        Assert.Equal(1, kingRow.BookCount);
+    }
+
+    [Fact]
+    public async Task GetSnapshotAsync_CollectsIsbnsAcrossEditions()
+    {
+        // A Book with two Editions, different ISBNs — both should appear
+        // in BookSnapshot.Isbns. Empty / null ISBNs are filtered out.
+        using (var db = _factory.CreateDbContext())
+        {
+            var clarke = new Author { Name = "Arthur C. Clarke" };
+            db.Authors.Add(clarke);
+            db.Books.Add(new Book
+            {
+                Title = "Rendezvous with Rama",
+                Works = [new Work { Title = "Rendezvous with Rama", WorkAuthors = [new WorkAuthor { Author = clarke, Order = 0 }] }],
+                Editions =
+                [
+                    new Edition { Isbn = "9780553287899", Format = BookFormat.MassMarketPaperback },
+                    new Edition { Isbn = "9780575094192", Format = BookFormat.TradePaperback },
+                    new Edition { Isbn = null, Format = BookFormat.Hardcover },
+                ]
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var snapshot = await CreateService().GetSnapshotAsync();
+        var book = Assert.Single(snapshot.Books);
+
+        Assert.Equal(2, book.Isbns.Count);
+        Assert.Contains("9780553287899", book.Isbns);
+        Assert.Contains("9780575094192", book.Isbns);
+    }
+
+    [Fact]
+    public async Task GetSnapshotAsync_VersionAndSyncedAtPopulated()
+    {
+        // Catalog version is the deployed commit SHA (or "dev" locally)
+        // so the SW can detect a deploy and invalidate cached snapshots.
+        // SyncedAt is server clock at projection time.
+        var before = DateTime.UtcNow.AddSeconds(-5);
+        var snapshot = await CreateService().GetSnapshotAsync();
+        var after = DateTime.UtcNow.AddSeconds(5);
+
+        Assert.False(string.IsNullOrWhiteSpace(snapshot.Version));
+        Assert.InRange(snapshot.SyncedAt, before, after);
+    }
+
+    [Fact]
+    public async Task GetSnapshotAsync_BookStatusAndRatingProjected()
+    {
+        // Status + rating need to make the trip — the bookshop result
+        // card displays both.
+        using (var db = _factory.CreateDbContext())
+        {
+            var clarke = new Author { Name = "Arthur C. Clarke" };
+            db.Authors.Add(clarke);
+            db.Books.Add(new Book
+            {
+                Title = "2001: A Space Odyssey",
+                Status = BookStatus.Read,
+                Rating = 5,
+                Works = [new Work { Title = "2001", WorkAuthors = [new WorkAuthor { Author = clarke, Order = 0 }] }]
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var snapshot = await CreateService().GetSnapshotAsync();
+        var book = Assert.Single(snapshot.Books);
+
+        Assert.Equal(BookStatus.Read, book.Status);
+        Assert.Equal(5, book.Rating);
+    }
+}

--- a/BookTracker.Web/Api/CatalogEndpoints.cs
+++ b/BookTracker.Web/Api/CatalogEndpoints.cs
@@ -1,0 +1,36 @@
+using BookTracker.Web.Services.Catalog;
+
+namespace BookTracker.Web.Api;
+
+// First first-class API surface in the project. Convention going forward:
+// each domain gets its own *Endpoints.cs static class with an extension
+// method on IEndpointRouteBuilder; ProgramSetup.cs maps them all together.
+// Single-endpoint pattern is fine for now — abstractions follow when a
+// second endpoint joins the family.
+//
+// Auth: Easy Auth at the App Service platform layer gates every request,
+// matching every other route in the app. There's deliberately no app-side
+// authentication / authorization middleware (the project doesn't register
+// AddAuthentication / AddAuthorization) — Easy Auth + the
+// `globalValidation.requireAuthentication: true` setting in
+// infra/modules/app-config.bicep handle the gate. See SECURITY-AUDIT.md
+// (SEC-006) for the verification.
+public static class CatalogEndpoints
+{
+    public static IEndpointRouteBuilder MapCatalogEndpoints(this IEndpointRouteBuilder app)
+    {
+        // GET /api/catalog-snapshot — slim catalog JSON for the bookshop
+        // offline cache. ~150KB gzipped at the 3000+ books target. Service
+        // worker pre-caches the response; IndexedDB stores client-side.
+        // See docs/bookshop-mode-design.md for the full architecture.
+        app.MapGet("/api/catalog-snapshot", async (
+            ICatalogSnapshotService service,
+            CancellationToken ct) =>
+        {
+            var snapshot = await service.GetSnapshotAsync(ct);
+            return Results.Ok(snapshot);
+        });
+
+        return app;
+    }
+}

--- a/BookTracker.Web/ProgramSetup.cs
+++ b/BookTracker.Web/ProgramSetup.cs
@@ -1,6 +1,8 @@
 using BookTracker.Data;
+using BookTracker.Web.Api;
 using BookTracker.Web.Components;
 using BookTracker.Web.Services;
+using BookTracker.Web.Services.Catalog;
 using BookTracker.Web.Services.Covers;
 using BookTracker.Web.Telemetry;
 using BookTracker.Web.ViewModels;
@@ -90,6 +92,7 @@ public static class ProgramSetup
 
         builder.Services.AddTransient<SeriesMatchService>();
 
+        builder.Services.AddScoped<ICatalogSnapshotService, CatalogSnapshotService>();
         builder.Services.AddScoped<IDuplicateDetectionService, DuplicateDetectionService>();
         builder.Services.AddScoped<IAuthorMergeService, AuthorMergeService>();
         builder.Services.AddScoped<IWorkMergeService, WorkMergeService>();
@@ -207,5 +210,10 @@ public static class ProgramSetup
 
         app.MapRazorComponents<App>()
             .AddInteractiveServerRenderMode();
+
+        // API endpoints (Minimal API). First family is the bookshop catalog
+        // snapshot; future API surfaces add their own *Endpoints.cs class
+        // and Map* call here.
+        app.MapCatalogEndpoints();
     }
 }

--- a/BookTracker.Web/Services/Catalog/CatalogSnapshotService.cs
+++ b/BookTracker.Web/Services/Catalog/CatalogSnapshotService.cs
@@ -1,0 +1,154 @@
+using BookTracker.Data;
+using BookTracker.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookTracker.Web.Services.Catalog;
+
+// Slim catalog projection consumed by the bookshop-mode offline cache
+// (see docs/bookshop-mode-design.md). Returns just enough data for the
+// killer mobile use cases — ISBN-have-I-got-this and author-lookup —
+// without the bandwidth or PII of a full edit-flow payload.
+//
+// Size budget at the 3000+ books target: ~480KB raw / ~150KB gzipped.
+// Single endpoint hit; SW pre-caches; IndexedDB stores client-side.
+//
+// Deliberately omits cover URLs, notes, tags, edition/copy detail.
+// Bookshop mode is read-only-lookup; full detail is reachable via
+// "Open in app" deep-links to /books/{id} (online only).
+public interface ICatalogSnapshotService
+{
+    Task<CatalogSnapshot> GetSnapshotAsync(CancellationToken ct = default);
+}
+
+public class CatalogSnapshotService(
+    IDbContextFactory<BookTrackerDbContext> dbFactory) : ICatalogSnapshotService
+{
+    public async Task<CatalogSnapshot> GetSnapshotAsync(CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+
+        // Books — pull a flat shape and project in-memory. Bounded by total
+        // catalog size (3000+ target), so the materialise-then-project cost
+        // is fine. AsNoTracking per scale-audit defaults; this is a read-
+        // only path with immediate projection into records.
+        var booksRaw = await db.Books
+            .AsNoTracking()
+            .Select(b => new
+            {
+                b.Id,
+                b.Title,
+                b.Status,
+                b.Rating,
+                Authors = b.Works.SelectMany(w => w.WorkAuthors.Select(wa => new
+                {
+                    wa.Author.Name,
+                    WorkId = w.Id,
+                    wa.Order,
+                })).ToList(),
+                Isbns = b.Editions
+                    .Where(e => e.Isbn != null && e.Isbn != "")
+                    .Select(e => e.Isbn!)
+                    .ToList(),
+            })
+            .ToListAsync(ct);
+
+        var books = booksRaw
+            .Select(b => new BookSnapshot(
+                b.Id,
+                b.Title,
+                // Primary author = lowest-Order WorkAuthor of the first
+                // Work (by Work.Id). Single-Work books are unambiguous;
+                // compendiums get the primary of whichever Work sorts
+                // first. Same shape as the library-grouping-respects-
+                // author-filter fix uses.
+                b.Authors.OrderBy(a => a.WorkId).ThenBy(a => a.Order).Select(a => a.Name).FirstOrDefault() ?? "(unknown)",
+                // All credited authors, in (Work.Id, Order) sequence,
+                // distinct by name. Renders as the result-card subtitle
+                // when the book is shown in bookshop mode.
+                b.Authors.OrderBy(a => a.WorkId).ThenBy(a => a.Order).Select(a => a.Name).Distinct().ToList(),
+                b.Status,
+                b.Rating,
+                b.Isbns.Distinct().ToList()))
+            .OrderBy(b => b.Title)
+            .ToList();
+
+        // Authors — direct counts per row. For canonicals, the rolled-up
+        // count (canonical + all aliases' books) needs a separate query
+        // to avoid double-counting books that are credited to BOTH a
+        // canonical and its alias.
+        var directCounts = await db.Authors
+            .AsNoTracking()
+            .Select(a => new
+            {
+                a.Id,
+                a.Name,
+                CanonicalId = a.CanonicalAuthorId ?? a.Id,
+                DirectBookCount = a.Works.SelectMany(w => w.Books).Select(b => b.Id).Distinct().Count(),
+            })
+            .ToListAsync(ct);
+
+        // Distinct (canonical_id, book_id) pairs across the whole
+        // WorkAuthor graph. Group-by canonical gives the rolled-up
+        // count without double-counting books credited to both
+        // canonical and alias.
+        var canonicalBookPairs = await db.WorkAuthors
+            .AsNoTracking()
+            .SelectMany(wa => wa.Work.Books.Select(b => new
+            {
+                CanonicalId = wa.Author.CanonicalAuthorId ?? wa.AuthorId,
+                BookId = b.Id,
+            }))
+            .Distinct()
+            .ToListAsync(ct);
+
+        var canonicalCounts = canonicalBookPairs
+            .GroupBy(x => x.CanonicalId)
+            .ToDictionary(g => g.Key, g => g.Count());
+
+        var authors = directCounts
+            .Select(a => new AuthorSnapshot(
+                a.Id,
+                a.Name,
+                a.CanonicalId,
+                // Canonical row → use the rolled-up count.
+                // Alias row → use its own direct count (so tapping
+                // "Richard Bachman" shows just Bachman's titles, while
+                // tapping "Stephen King" shows the rolled-up total).
+                BookCount: a.Id == a.CanonicalId
+                    ? canonicalCounts.GetValueOrDefault(a.CanonicalId, 0)
+                    : a.DirectBookCount))
+            .OrderBy(a => a.Name)
+            .ToList();
+
+        // Version is the deployed commit SHA when available (so the
+        // client-side cache can detect a deploy and trigger a refresh)
+        // or "dev" when running locally without the build-time SHA
+        // injection. SyncedAt is server clock at projection time.
+        return new CatalogSnapshot(
+            BuildInfo.ShortSha ?? "dev",
+            DateTime.UtcNow,
+            books,
+            authors);
+    }
+}
+
+public record CatalogSnapshot(
+    string Version,
+    DateTime SyncedAt,
+    IReadOnlyList<BookSnapshot> Books,
+    IReadOnlyList<AuthorSnapshot> Authors);
+
+public record BookSnapshot(
+    int Id,
+    string Title,
+    string PrimaryAuthor,
+    IReadOnlyList<string> AllAuthors,
+    BookStatus Status,
+    int Rating,
+    IReadOnlyList<string> Isbns);
+
+public record AuthorSnapshot(
+    int Id,
+    string Name,
+    int CanonicalId,
+    int BookCount);


### PR DESCRIPTION
First PR of the bookshop-mode architecture per docs/bookshop-mode-design.md.
Lands the slim catalog snapshot API surface that subsequent PRs (SW +
IndexedDB infra, the /bookshop UI itself) will consume. Self-contained:
ships an endpoint nobody uses yet, costs nothing operationally,
unblocks PR 2 + PR 3.

New files:
- BookTracker.Web/Services/Catalog/CatalogSnapshotService.cs — service
  + DTOs (CatalogSnapshot, BookSnapshot, AuthorSnapshot). Slim shape,
  tuned to the bookshop killer use cases: ISBN lookup, author lookup,
  status/rating display. Deliberately omits cover URLs, notes, tags,
  edition/copy detail (online-only via /books/{id} deep-links).
- BookTracker.Web/Api/CatalogEndpoints.cs — Minimal API endpoint
  registration. Sets the *Endpoints.cs convention for future API
  surfaces.

ProgramSetup.cs:
- Service registration (AddScoped<ICatalogSnapshotService, ...>).
- MapCatalogEndpoints() after MapRazorComponents.

Auth: Easy Auth at the App Service platform layer gates this endpoint
the same way it gates every other route — no app-side
AddAuthentication / AddAuthorization is registered (and adding it
would be a bigger architectural change). Documented in CatalogEndpoints.cs.

Service-layer correctness highlights:
- Primary author = lowest-Order WorkAuthor of the first Work (by Work.Id),
  matching the library-grouping-respects-author-filter pattern.
- Author bookCount: canonical rows show the rolled-up count via a
  separate (canonical_id, book_id) Distinct query; alias rows show
  their direct count. The rollup uses Distinct pairs to avoid
  double-counting books credited to BOTH a canonical and its alias.
- AsNoTracking + immediate projection per scale-audit defaults.
- Version field sources from BuildInfo.ShortSha so the SW can detect
  a deploy and invalidate cached snapshots.

Tests: 7 new, all passing. Cover primary-vs-all-author projection on
single-Work + multi-Work, alias rollup correctness, double-credit
edge case, ISBN collection across editions, version/syncedAt
population, status/rating projection. All 398 + 1 skipped tests
in the broader suite still pass.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
