### PR TITLE
feat(bookshop): SW catalog caching + IndexedDB schema (PR 2 of bookshop arc)

### DIFF
--- a/BookTracker.Web/Components/App.razor
+++ b/BookTracker.Web/Components/App.razor
@@ -56,6 +56,12 @@
     <script src="@Assets["js/navbar-collapse.js"]"></script>
     <script src="@Assets["js/scroll-to.js"]"></script>
     <script src="@Assets["js/chip-picker-keys.js"]"></script>
+    @* Bookshop offline cache — pure-JS IndexedDB module. Loaded on every
+       page so it's available from the DevTools console for testing while
+       the /bookshop UI (PR 3) is still in flight. Self-attaches to
+       window.catalogCache; no init runs at script load — pages call
+       catalogCache.init() explicitly when they need the cache populated. *@
+    <script src="@Assets["js/catalog-cache.js"]"></script>
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>
     <script src="@Assets["service-worker-register.js"]"></script>
 </body>

--- a/BookTracker.Web/wwwroot/js/catalog-cache.js
+++ b/BookTracker.Web/wwwroot/js/catalog-cache.js
@@ -1,0 +1,227 @@
+// catalog-cache.js — IndexedDB-backed offline cache for the bookshop mode.
+//
+// Pure JS module attached to window.catalogCache. No Blazor dependency;
+// callable from Razor pages (PR 3+) and from the browser DevTools console
+// for direct testing. Reads /api/catalog-snapshot via fetch (which the
+// service worker caches with stale-while-revalidate semantics, see
+// service-worker.js); writes the slim catalog into IndexedDB; serves
+// lookup queries entirely client-side.
+//
+// Database layout (DB version 1):
+//   - books store: keyPath=id, multiEntry index on `isbns`,
+//     index on `primaryAuthor`.
+//   - authors store: keyPath=id, index on `canonicalId`.
+//   - meta store: keyPath=key. Holds version, syncedAt, bookCount,
+//     authorCount entries.
+//
+// Public surface:
+//   await catalogCache.init()                    — opens DB, populates if empty
+//   await catalogCache.refresh()                 — refetch + repopulate from server
+//   await catalogCache.lookupByIsbn(isbn)        — book or null
+//   await catalogCache.lookupByAuthor(canonicalId) — books credited to canonical
+//                                                    or any of its aliases
+//   await catalogCache.searchAuthors(q, limit)   — canonical author rows matching name
+//   await catalogCache.getMeta()                 — { version, syncedAt, bookCount, authorCount }
+//
+// Manual test (browser DevTools console, on any BookTracker page):
+//   await catalogCache.init();
+//   await catalogCache.getMeta();
+//   await catalogCache.lookupByIsbn('9780553287899');
+//   await catalogCache.searchAuthors('asimov', 5);
+//   await catalogCache.refresh();
+
+(function () {
+    const DB_NAME = 'booktracker-catalog';
+    const DB_VERSION = 1;
+    const STORE_BOOKS = 'books';
+    const STORE_AUTHORS = 'authors';
+    const STORE_META = 'meta';
+    const SNAPSHOT_URL = '/api/catalog-snapshot';
+
+    let dbInstance = null;
+
+    function openDb() {
+        if (dbInstance) return Promise.resolve(dbInstance);
+        return new Promise((resolve, reject) => {
+            const req = indexedDB.open(DB_NAME, DB_VERSION);
+            req.onerror = () => reject(req.error);
+            req.onupgradeneeded = (e) => {
+                const db = e.target.result;
+                // Create stores + indexes for v1. Future schema changes
+                // bump DB_VERSION and add migration logic here.
+                if (!db.objectStoreNames.contains(STORE_BOOKS)) {
+                    const books = db.createObjectStore(STORE_BOOKS, { keyPath: 'id' });
+                    books.createIndex('isbns', 'isbns', { multiEntry: true, unique: false });
+                    books.createIndex('primaryAuthor', 'primaryAuthor', { unique: false });
+                }
+                if (!db.objectStoreNames.contains(STORE_AUTHORS)) {
+                    const authors = db.createObjectStore(STORE_AUTHORS, { keyPath: 'id' });
+                    authors.createIndex('canonicalId', 'canonicalId', { unique: false });
+                }
+                if (!db.objectStoreNames.contains(STORE_META)) {
+                    db.createObjectStore(STORE_META, { keyPath: 'key' });
+                }
+            };
+            req.onsuccess = () => {
+                dbInstance = req.result;
+                resolve(dbInstance);
+            };
+        });
+    }
+
+    function getAll(db, storeName) {
+        return new Promise((resolve, reject) => {
+            const tx = db.transaction(storeName, 'readonly');
+            const req = tx.objectStore(storeName).getAll();
+            req.onsuccess = () => resolve(req.result || []);
+            req.onerror = () => reject(req.error);
+        });
+    }
+
+    async function init() {
+        await openDb();
+        const meta = await getMeta();
+        if (!meta || !meta.syncedAt) {
+            // First-time setup: try to populate. Don't fail loudly if
+            // offline — caller will see empty results until next refresh.
+            try {
+                await refresh();
+            } catch (err) {
+                console.warn('[catalog-cache] Initial fetch failed (likely offline):', err);
+            }
+        }
+    }
+
+    async function refresh() {
+        const response = await fetch(SNAPSHOT_URL, { credentials: 'same-origin' });
+        if (!response.ok) {
+            throw new Error(`Catalog snapshot fetch failed: ${response.status} ${response.statusText}`);
+        }
+        const snapshot = await response.json();
+        await populate(snapshot);
+        return await getMeta();
+    }
+
+    function populate(snapshot) {
+        return new Promise(async (resolve, reject) => {
+            const db = await openDb();
+            const tx = db.transaction([STORE_BOOKS, STORE_AUTHORS, STORE_META], 'readwrite');
+            tx.oncomplete = () => resolve();
+            tx.onerror = () => reject(tx.error);
+            tx.onabort = () => reject(tx.error || new Error('Transaction aborted'));
+
+            // Wipe existing rows so a shrink (e.g. Drew deletes a book)
+            // doesn't leave stale entries. Snapshot is the source of truth.
+            tx.objectStore(STORE_BOOKS).clear();
+            tx.objectStore(STORE_AUTHORS).clear();
+            tx.objectStore(STORE_META).clear();
+
+            const booksStore = tx.objectStore(STORE_BOOKS);
+            for (const book of snapshot.books || []) {
+                booksStore.put(book);
+            }
+
+            const authorsStore = tx.objectStore(STORE_AUTHORS);
+            for (const author of snapshot.authors || []) {
+                authorsStore.put(author);
+            }
+
+            const metaStore = tx.objectStore(STORE_META);
+            metaStore.put({ key: 'version', value: snapshot.version || null });
+            metaStore.put({ key: 'syncedAt', value: snapshot.syncedAt || new Date().toISOString() });
+            metaStore.put({ key: 'bookCount', value: (snapshot.books || []).length });
+            metaStore.put({ key: 'authorCount', value: (snapshot.authors || []).length });
+        });
+    }
+
+    async function lookupByIsbn(isbn) {
+        if (!isbn) return null;
+        const db = await openDb();
+        return new Promise((resolve, reject) => {
+            const tx = db.transaction(STORE_BOOKS, 'readonly');
+            const idx = tx.objectStore(STORE_BOOKS).index('isbns');
+            const req = idx.get(isbn);
+            req.onsuccess = () => resolve(req.result || null);
+            req.onerror = () => reject(req.error);
+        });
+    }
+
+    async function lookupByAuthor(canonicalId) {
+        if (canonicalId == null) return [];
+        const db = await openDb();
+
+        // Names to match against book.allAuthors: the canonical's own
+        // name plus every alias's name. Walks the authors store once.
+        const allAuthors = await getAll(db, STORE_AUTHORS);
+        const matchNames = new Set(
+            allAuthors
+                .filter(a => a.canonicalId === canonicalId)
+                .map(a => a.name)
+        );
+        if (matchNames.size === 0) return [];
+
+        // Walk books, intersect on author names. At the 3000+ books target,
+        // this is a low-millisecond JS filter — well below the 200ms
+        // bookshop-mode lookup budget. If profiling ever shows this on the
+        // critical path, switch to storing canonical-id arrays per book +
+        // a multiEntry index.
+        const allBooks = await getAll(db, STORE_BOOKS);
+        return allBooks
+            .filter(b => Array.isArray(b.allAuthors) && b.allAuthors.some(n => matchNames.has(n)))
+            .sort((a, b) => a.title.localeCompare(b.title));
+    }
+
+    async function searchAuthors(query, limit) {
+        const cap = (typeof limit === 'number' && limit > 0) ? limit : 20;
+        if (!query || !query.trim()) return [];
+        const lowerQuery = query.trim().toLowerCase();
+
+        const db = await openDb();
+        const allAuthors = await getAll(db, STORE_AUTHORS);
+
+        // Match by substring on the typed name (canonical OR alias).
+        // A "Bachman" search hits the alias row, which we resolve to King.
+        const matches = allAuthors.filter(a =>
+            typeof a.name === 'string' && a.name.toLowerCase().includes(lowerQuery)
+        );
+
+        // Resolve each hit to its canonical row, dedupe by canonicalId.
+        const seenCanonical = new Set();
+        const result = [];
+        for (const match of matches) {
+            if (seenCanonical.has(match.canonicalId)) continue;
+            seenCanonical.add(match.canonicalId);
+            const canonical = (match.id === match.canonicalId)
+                ? match
+                : allAuthors.find(a => a.id === match.canonicalId);
+            if (canonical) result.push(canonical);
+            if (result.length >= cap) break;
+        }
+        return result.sort((a, b) => a.name.localeCompare(b.name));
+    }
+
+    async function getMeta() {
+        const db = await openDb();
+        const all = await getAll(db, STORE_META);
+        if (all.length === 0) return null;
+        const lookup = name => {
+            const row = all.find(x => x.key === name);
+            return row ? row.value : null;
+        };
+        return {
+            version: lookup('version'),
+            syncedAt: lookup('syncedAt'),
+            bookCount: lookup('bookCount') || 0,
+            authorCount: lookup('authorCount') || 0,
+        };
+    }
+
+    window.catalogCache = {
+        init,
+        refresh,
+        lookupByIsbn,
+        lookupByAuthor,
+        searchAuthors,
+        getMeta,
+    };
+})();

--- a/BookTracker.Web/wwwroot/service-worker.js
+++ b/BookTracker.Web/wwwroot/service-worker.js
@@ -1,19 +1,29 @@
 // Service worker for the BookTracker PWA.
 //
-// Strategy: network-first with cache fallback for same-origin GETs. The
-// Blazor SignalR hub at /_blazor is always passed straight through — we
-// never want to cache hub traffic. Caching the static assets + HTML shell
-// means the install screen still shows when the network's flaky, and
-// subsequent loads get an instant-feeling paint while the network response
-// refreshes the cache in the background.
+// Strategy: network-first with cache fallback for same-origin GETs by
+// default. Two route-specific overrides that need offline-first
+// semantics for the bookshop mode (see docs/bookshop-mode-design.md):
 //
-// Bump CACHE_VERSION whenever cache semantics need to invalidate cleanly.
+//   - /api/catalog-snapshot — cache-first with stale-while-revalidate.
+//     The bookshop offline cache must read this from disk when offline;
+//     network-first would fail and break the killer use cases.
+//
+//   - /bookshop* navigations — cache-first. The /bookshop page is
+//     Static SSR (no SignalR / Interactive Server) and must work
+//     offline. This is the ONE navigation path the SW intercepts;
+//     everything else still passes through (Blazor Server pages
+//     need a live request to render).
+//
+// The Blazor SignalR hub at /_blazor is always passed straight through.
+//
+// Cache layout: two named caches.
+//   booktracker-vN — assets (network-first), bumps invalidate cleanly.
+//   booktracker-catalog-vM — catalog snapshot data (cache-first),
+//     versioned independently so SW shape changes don't blow the
+//     catalog cache, and vice versa.
 
-// v2: pass navigations through entirely (see fetch handler). Bumping
-// the cache name forces the activate handler to drop the v1 cache,
-// which had been storing HTML pages alongside assets — those are
-// stale-prone for an authenticated server-rendered app.
-const CACHE_VERSION = 'booktracker-v2';
+const CACHE_VERSION = 'booktracker-v3';
+const CATALOG_CACHE = 'booktracker-catalog-v1';
 
 self.addEventListener('install', event => {
     // Activate as soon as possible — no need to wait for all tabs to close.
@@ -25,7 +35,7 @@ self.addEventListener('activate', event => {
         const keys = await caches.keys();
         await Promise.all(
             keys
-                .filter(k => k !== CACHE_VERSION)
+                .filter(k => k !== CACHE_VERSION && k !== CATALOG_CACHE)
                 .map(k => caches.delete(k))
         );
         await self.clients.claim();
@@ -41,26 +51,76 @@ self.addEventListener('fetch', event => {
         return;
     }
 
-    // Pass navigations through — Blazor Server pages need a live
-    // request to render (the SignalR circuit alone can't serve them
-    // from cache), and intercepting navigation fetches caused
+    // /api/catalog-snapshot — cache-first with stale-while-revalidate.
+    // Returns cached bytes immediately when available; kicks off a
+    // background refresh that updates the cache for next time. When
+    // offline and uncached, surfaces the fetch error to the caller
+    // (catalog-cache.js init() catches and degrades).
+    if (request.method === 'GET'
+        && url.origin === location.origin
+        && url.pathname === '/api/catalog-snapshot') {
+        event.respondWith(cacheFirstWithStaleWhileRevalidate(request, CATALOG_CACHE));
+        return;
+    }
+
+    // /bookshop* navigations — cache-first. The page itself is
+    // Static SSR + JS-only; doesn't need a live SignalR circuit.
+    // First visit fetches + caches; subsequent visits serve from
+    // cache instantly even offline.
+    if ((request.mode === 'navigate' || request.destination === 'document')
+        && url.pathname.startsWith('/bookshop')) {
+        event.respondWith(cacheFirstWithStaleWhileRevalidate(request, CACHE_VERSION));
+        return;
+    }
+
+    // Pass non-bookshop navigations through — Blazor Server pages need
+    // a live request to render (the SignalR circuit alone can't serve
+    // them from cache), and intercepting navigation fetches caused
     // (a) the post-form-POST redirect to /series/{id} surfacing as
     //     "Fetch failed and no cached response" because the SW couldn't
     //     reach the server's redirect handling cleanly, and
     // (b) any genuinely offline navigation falling into the same
     //     no-cached-fallback hole.
-    // Service worker is for static-asset caching only.
     if (request.mode === 'navigate' || request.destination === 'document') {
         return;
     }
 
-    // Only handle same-origin GET requests for assets.
+    // Same-origin GET assets — network-first with cache fallback (existing).
     if (request.method !== 'GET' || url.origin !== location.origin) {
         return;
     }
 
     event.respondWith(networkFirstWithCacheFallback(request));
 });
+
+// Cache-first with background revalidate. Returns the cached response
+// immediately if present; kicks off a non-blocking fetch that updates
+// the cache for next time. On a true cache miss, awaits the network
+// fetch and caches the result.
+async function cacheFirstWithStaleWhileRevalidate(request, cacheName) {
+    const cache = await caches.open(cacheName);
+    const cached = await cache.match(request);
+    if (cached) {
+        // Background refresh — fire and forget. Failures are silent;
+        // the cached response we just returned is the answer.
+        fetch(request)
+            .then(response => {
+                if (response.ok) cache.put(request, response.clone());
+            })
+            .catch(() => { /* offline / 5xx / etc. — keep cached */ });
+        return cached;
+    }
+    // No cache hit — try network, cache the result.
+    try {
+        const response = await fetch(request);
+        if (response.ok) {
+            cache.put(request, response.clone());
+        }
+        return response;
+    } catch (err) {
+        throw new Error(`Fetch failed and no cached response for ${request.url}`);
+    }
+}
 
 async function networkFirstWithCacheFallback(request) {
     const cache = await caches.open(CACHE_VERSION);


### PR DESCRIPTION
Second PR of the bookshop-mode architecture per
docs/bookshop-mode-design.md. Lands the offline-cache infrastructure
PR 3's /bookshop UI will consume. No UI yet — deployable
infrastructure that ships and sits ready.

service-worker.js:
- Bumped CACHE_VERSION to v3 (asset cache wipes cleanly on activate).
- New CATALOG_CACHE = 'booktracker-catalog-v1' for the snapshot
  response. Versioned independently from the asset cache so SW shape
  changes don't blow the catalog and vice versa.
- Two route-specific cache-first paths added before the existing
  default network-first behaviour:
    /api/catalog-snapshot — cache-first with stale-while-revalidate.
      Returns cached bytes immediately; kicks off background refresh.
      Critical for offline operation of bookshop mode.
    /bookshop* navigations — cache-first. Page is Static SSR
      (no SignalR / Interactive Server in PR 3); must work offline.
      The ONE navigation path the SW intercepts; all other navigations
      still pass through to keep Blazor Server pages happy.
- Existing pass-throughs (SignalR /_blazor, non-bookshop navigations)
  preserved verbatim; the post-form-POST redirect bug from the May 5
  series-create arc stays fixed.

wwwroot/js/catalog-cache.js — new module:
- Pure JS attached to window.catalogCache. No Blazor dependency;
  callable from Razor pages and from DevTools console for testing.
- IndexedDB schema (DB version 1):
    books store — keyPath=id, multiEntry index on `isbns`,
      index on `primaryAuthor`.
    authors store — keyPath=id, index on `canonicalId`.
    meta store — keyPath=key (version, syncedAt, bookCount, authorCount).
- Public surface: init(), refresh(), lookupByIsbn(isbn),
  lookupByAuthor(canonicalId), searchAuthors(query, limit), getMeta().
- lookupByAuthor walks books filtering by author-name intersection
  (canonical's name + all alias names). Sub-millisecond at the 3000+
  books target; if profiling ever puts this on the critical path,
  switch to canonical-id arrays per book + a multiEntry index
  (documented in-line).
- searchAuthors matches alias names too — typing "Bachman" hits the
  alias row, which we resolve to the canonical (King) for display.
  Per design doc decision: result list shows canonicals only; alias
  awareness lives in the search match step.
- populate() clears + repopulates atomically inside one transaction so
  a shrink (book deleted server-side) doesn't leave stale entries.

App.razor:
- <script src="@Assets["js/catalog-cache.js"]"></script> added so the
  module is loaded on every page. No init() at script-load — pages
  call catalogCache.init() explicitly when they need the cache
  populated. Available from DevTools console on any page for direct
  testing while PR 3's UI is in flight.

Manual test plan (browser DevTools console on a deployed BookTracker
page, signed in):
  await catalogCache.init()
  await catalogCache.getMeta()
  // → { version, syncedAt, bookCount, authorCount }
  await catalogCache.lookupByIsbn('9780553287899')
  // → BookSnapshot if you have it; null if not
  await catalogCache.searchAuthors('asimov', 5)
  // → array of matching canonical AuthorSnapshot rows
  await catalogCache.lookupByAuthor(<id from the searchAuthors result>)
  // → array of BookSnapshots, sorted by title
  await catalogCache.refresh()
  // → forces a fresh fetch + repopulate

Then in DevTools Network tab, set offline mode and re-run the lookup
calls — they should still return data (from IndexedDB, no network).

All 398 server-side tests still pass. No new C# tests in this PR
(the changes are JS-only); a future PR could add Playwright e2e
coverage for the catalog flow, but that's out of scope for the
v1 chassis.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
