### PR TITLE
feat(bookshop): /bookshop route + Scan mode UI (PR 3 of bookshop arc)

### DIFF
--- a/BookTracker.Web/Components/App.razor
+++ b/BookTracker.Web/Components/App.razor
@@ -62,6 +62,10 @@
        window.catalogCache; no init runs at script load — pages call
        catalogCache.init() explicitly when they need the cache populated. *@
     <script src="@Assets["js/catalog-cache.js"]"></script>
+    @* Bookshop page glue — DOM event wiring + result rendering for
+       /bookshop. Self-gates on path so the load cost on other pages
+       is just the script download. *@
+    <script src="@Assets["js/bookshop-page.js"]"></script>
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>
     <script src="@Assets["service-worker-register.js"]"></script>
 </body>

--- a/BookTracker.Web/Components/Layout/MainLayout.razor
+++ b/BookTracker.Web/Components/Layout/MainLayout.razor
@@ -55,6 +55,9 @@
                         <NavLink class="nav-link" href="shopping">Shopping</NavLink>
                     </li>
                     <li class="nav-item">
+                        <NavLink class="nav-link" href="bookshop">Bookshop</NavLink>
+                    </li>
+                    <li class="nav-item">
                         <NavLink class="nav-link" href="assistant">AI Assistant</NavLink>
                     </li>
                     <li class="nav-item">

--- a/BookTracker.Web/Components/Pages/Bookshop/Index.razor
+++ b/BookTracker.Web/Components/Pages/Bookshop/Index.razor
@@ -55,7 +55,14 @@
     <div id="bookshop-result" class="mb-3" aria-live="polite"></div>
 
     <div id="bookshop-footer" class="text-center text-muted small mt-4 mb-3">
-        <span id="bookshop-meta">Loading catalog…</span>
+        <div id="bookshop-meta">Loading catalog…</div>
+        <button id="bookshop-refresh" type="button" class="btn btn-outline-secondary btn-sm mt-2">
+            <span data-state="idle">Refresh</span>
+            <span data-state="busy" class="d-none">
+                <span class="spinner-border spinner-border-sm" role="status"></span>
+                Refreshing…
+            </span>
+        </button>
     </div>
 </div>
 

--- a/BookTracker.Web/Components/Pages/Bookshop/Index.razor
+++ b/BookTracker.Web/Components/Pages/Bookshop/Index.razor
@@ -1,0 +1,51 @@
+@* Bookshop mode — offline-capable mobile lookup surface. See
+   docs/bookshop-mode-design.md.
+
+   Pure HTML markup intentionally: no @onclick / @bind / @code. All
+   interactivity flows through wwwroot/js/bookshop-page.js, which
+   reads/writes IndexedDB via wwwroot/js/catalog-cache.js. The page
+   inherits the project's global InteractiveServer rendermode but
+   doesn't use the Blazor circuit — when offline, the SW serves the
+   cached HTML and the JS layer keeps working unaided. *@
+@page "/bookshop"
+
+<PageTitle>Bookshop - BookTracker</PageTitle>
+
+<div class="container-fluid px-2" style="max-width: 600px;">
+    <h1 class="h4 mb-3 mt-2">Bookshop mode</h1>
+    <p class="text-muted small mb-3">Look up books from your library — works offline.</p>
+
+    <div class="card mb-3">
+        <div class="card-body">
+            <button id="bookshop-scan-toggle" type="button" class="btn btn-primary w-100">
+                <span data-state="idle">📷 Scan ISBN</span>
+                <span data-state="active" class="d-none">Stop scanner</span>
+            </button>
+            <div id="bookshop-scanner-error" class="alert alert-warning mt-2 mb-0 py-2 small d-none"></div>
+        </div>
+    </div>
+
+    <div id="bookshop-scanner-panel" class="card mb-3 d-none">
+        <div class="card-body text-center">
+            <div id="bookshop-barcode-reader" class="scanner-container"></div>
+            <div class="form-text mt-2">Point your camera at the ISBN barcode.</div>
+        </div>
+    </div>
+
+    <div class="card mb-3">
+        <div class="card-body">
+            <label for="bookshop-isbn-input" class="form-label small mb-1">Or enter ISBN manually:</label>
+            <div class="input-group">
+                <input id="bookshop-isbn-input" type="text" inputmode="numeric"
+                       class="form-control" placeholder="9780553287899" autocomplete="off" />
+                <button id="bookshop-isbn-lookup" type="button" class="btn btn-outline-primary">Lookup</button>
+            </div>
+        </div>
+    </div>
+
+    <div id="bookshop-result" class="mb-3" aria-live="polite"></div>
+
+    <div id="bookshop-footer" class="text-center text-muted small mt-4 mb-3">
+        <span id="bookshop-meta">Loading catalog…</span>
+    </div>
+</div>

--- a/BookTracker.Web/Components/Pages/Bookshop/Index.razor
+++ b/BookTracker.Web/Components/Pages/Bookshop/Index.razor
@@ -1,13 +1,22 @@
 @* Bookshop mode — offline-capable mobile lookup surface. See
    docs/bookshop-mode-design.md.
 
-   Pure HTML markup intentionally: no @onclick / @bind / @code. All
-   interactivity flows through wwwroot/js/bookshop-page.js, which
-   reads/writes IndexedDB via wwwroot/js/catalog-cache.js. The page
-   inherits the project's global InteractiveServer rendermode but
-   doesn't use the Blazor circuit — when offline, the SW serves the
-   cached HTML and the JS layer keeps working unaided. *@
+   Markup-only by intent: no @onclick / @bind. All UX flows through
+   wwwroot/js/bookshop-page.js, which reads IndexedDB via
+   wwwroot/js/catalog-cache.js. The page inherits the project's
+   global InteractiveServer rendermode but doesn't *use* the Blazor
+   circuit for any interaction — when offline, the SW serves the
+   cached HTML and the JS layer keeps working unaided.
+
+   The single @code below is just the first-render JS kick: because
+   the project uses InteractiveServer globally, in-app navigation
+   patches the DOM via SignalR rather than full-page-loading, so
+   DOMContentLoaded never fires for the new page DOM. We poke the
+   JS module from OnAfterRenderAsync(firstRender) instead. The
+   module's own DOMContentLoaded path still covers the cold-load
+   case (direct URL, SW-served offline HTML). *@
 @page "/bookshop"
+@inject IJSRuntime JS
 
 <PageTitle>Bookshop - BookTracker</PageTitle>
 
@@ -49,3 +58,18 @@
         <span id="bookshop-meta">Loading catalog…</span>
     </div>
 </div>
+
+@code {
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            // Trigger the JS module to wire DOM events + load the
+            // catalog footer. The module is idempotent — its
+            // DOMContentLoaded path may have already fired in some
+            // load cases, and re-calling init() is a no-op in that
+            // event.
+            await JS.InvokeVoidAsync("BookshopPage.init");
+        }
+    }
+}

--- a/BookTracker.Web/wwwroot/js/barcode-scanner.js
+++ b/BookTracker.Web/wwwroot/js/barcode-scanner.js
@@ -56,5 +56,52 @@ window.BarcodeScanner = {
             try { await scanner.stop(); } catch { }
             scanner = null;
         }
+    },
+
+    // JS-callback variant of start() — used by pages without an active
+    // Blazor circuit (e.g. /bookshop offline mode). Same scanning
+    // behaviour as start(), but invokes the supplied JS functions
+    // instead of crossing the Blazor JS interop boundary.
+    startJs: async function (elementId, onScan, onError) {
+        if (scanner) {
+            try { await scanner.stop(); } catch { }
+            scanner = null;
+        }
+
+        lastScannedCode = null;
+        lastScannedTime = 0;
+
+        scanner = new Html5Qrcode(elementId);
+
+        const config = {
+            fps: 10,
+            qrbox: { width: 280, height: 80 },
+            aspectRatio: 2.0,
+            formatsToSupport: [
+                Html5QrcodeSupportedFormats.EAN_13,
+                Html5QrcodeSupportedFormats.EAN_8
+            ]
+        };
+
+        try {
+            await scanner.start(
+                { facingMode: "environment" },
+                config,
+                (decodedText) => {
+                    const now = Date.now();
+                    if (decodedText === lastScannedCode && (now - lastScannedTime) < DEBOUNCE_MS) {
+                        return;
+                    }
+                    lastScannedCode = decodedText;
+                    lastScannedTime = now;
+                    if (typeof onScan === 'function') onScan(decodedText);
+                },
+                (_errorMessage) => {
+                    // Per-frame scan failures are normal; ignore.
+                }
+            );
+        } catch (err) {
+            if (typeof onError === 'function') onError(err.toString());
+        }
     }
 };

--- a/BookTracker.Web/wwwroot/js/bookshop-page.js
+++ b/BookTracker.Web/wwwroot/js/bookshop-page.js
@@ -237,6 +237,23 @@
     async function init() {
         if (!isBookshopPage()) return;
 
+        // Idempotent guard. init() can fire from two sources — the
+        // module's DOMContentLoaded handler (cold direct-URL load,
+        // SW-served offline HTML) AND from the page's
+        // OnAfterRenderAsync (Blazor-SPA navigation patches the DOM
+        // without firing DOMContentLoaded). We don't want to attach
+        // event listeners twice; the sentinel attribute on the toggle
+        // is a stable proxy for "this DOM has already been wired."
+        // Note: Blazor in-app nav replaces the DOM, so the sentinel
+        // disappears when leaving and reappearing — re-init is correct.
+        const toggle = $('bookshop-scan-toggle');
+        if (toggle && toggle.dataset.bookshopInitialized === '1') {
+            // Already wired this DOM. Just refresh the footer in case
+            // syncedAt has moved on.
+            await refreshFooter();
+            return;
+        }
+
         // Init the cache. If offline + first-ever visit this throws
         // internally and surfaces empty results — the user sees the
         // "not synced yet" footer message and can't look anything up,
@@ -249,7 +266,6 @@
 
         await refreshFooter();
 
-        const toggle = $('bookshop-scan-toggle');
         if (toggle) {
             toggle.addEventListener('click', async () => {
                 if (scannerActive) {
@@ -258,6 +274,7 @@
                     await startScanner();
                 }
             });
+            toggle.dataset.bookshopInitialized = '1';
         }
 
         const lookup = $('bookshop-isbn-lookup');
@@ -274,7 +291,8 @@
 
         // Online/offline transitions update the footer label so the
         // user sees the state change live. Doesn't trigger a refresh
-        // by itself — that's PR 5 polish.
+        // by itself — that's PR 5 polish. Bound to window once;
+        // subsequent inits skip via the sentinel guard above.
         window.addEventListener('online', refreshFooter);
         window.addEventListener('offline', refreshFooter);
     }

--- a/BookTracker.Web/wwwroot/js/bookshop-page.js
+++ b/BookTracker.Web/wwwroot/js/bookshop-page.js
@@ -1,0 +1,292 @@
+// bookshop-page.js — page-specific glue for /bookshop.
+//
+// Responsibility: wire DOM events on the /bookshop page to
+// window.catalogCache (IndexedDB) + window.BarcodeScanner. Pure JS,
+// no Blazor dependency — the page has no Blazor circuit even when
+// online (it inherits the project's InteractiveServer rendermode but
+// uses no @onclick / @bind / @code), so everything has to flow
+// through native DOM events. Loaded globally from App.razor; gates
+// itself on path so non-/bookshop pages pay nothing but the script
+// download.
+
+(function () {
+    function isBookshopPage() {
+        return window.location.pathname.toLowerCase().startsWith('/bookshop');
+    }
+
+    function $(id) { return document.getElementById(id); }
+
+    // HTML escape — all dynamic strings (titles, author names, ISBNs)
+    // pass through this before being injected into innerHTML. Cheap
+    // belt-and-braces against a malformed catalog row taking out the
+    // page; the snapshot endpoint already returns plain JSON, so the
+    // realistic risk is a quote / angle bracket in a book title.
+    function esc(s) {
+        if (s == null) return '';
+        return String(s)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
+
+    function showError(msg) {
+        const el = $('bookshop-scanner-error');
+        if (!el) return;
+        el.textContent = msg;
+        el.classList.remove('d-none');
+    }
+
+    function clearError() {
+        const el = $('bookshop-scanner-error');
+        if (!el) return;
+        el.textContent = '';
+        el.classList.add('d-none');
+    }
+
+    function setScannerActive(active) {
+        const toggle = $('bookshop-scan-toggle');
+        const panel = $('bookshop-scanner-panel');
+        if (!toggle || !panel) return;
+        const idle = toggle.querySelector('[data-state="idle"]');
+        const live = toggle.querySelector('[data-state="active"]');
+        if (active) {
+            toggle.classList.remove('btn-primary');
+            toggle.classList.add('btn-danger');
+            idle.classList.add('d-none');
+            live.classList.remove('d-none');
+            panel.classList.remove('d-none');
+        } else {
+            toggle.classList.remove('btn-danger');
+            toggle.classList.add('btn-primary');
+            idle.classList.remove('d-none');
+            live.classList.add('d-none');
+            panel.classList.add('d-none');
+        }
+    }
+
+    let scannerActive = false;
+
+    async function startScanner() {
+        clearError();
+        scannerActive = true;
+        setScannerActive(true);
+
+        try {
+            await window.BarcodeScanner.startJs(
+                'bookshop-barcode-reader',
+                onBarcodeScanned,
+                onScannerError
+            );
+        } catch (err) {
+            scannerActive = false;
+            setScannerActive(false);
+            showError('Camera error: ' + (err && err.toString ? err.toString() : err));
+        }
+    }
+
+    async function stopScanner() {
+        scannerActive = false;
+        setScannerActive(false);
+        try { await window.BarcodeScanner.stop(); } catch { /* ignore */ }
+    }
+
+    async function onBarcodeScanned(decodedText) {
+        // Stop the scanner on a successful scan — same UX as
+        // /shopping. Avoids re-firing while the user reads the result.
+        await stopScanner();
+        const isbn = (decodedText || '').trim();
+        if (!isbn) return;
+        await lookupAndRender(isbn);
+    }
+
+    function onScannerError(err) {
+        scannerActive = false;
+        setScannerActive(false);
+        showError('Camera error: ' + err);
+    }
+
+    async function manualLookup() {
+        const input = $('bookshop-isbn-input');
+        if (!input) return;
+        const raw = (input.value || '').trim();
+        // Strip non-alphanumeric (allow trailing X for ISBN-10 check
+        // digits) so "978-0-553-28789-9" pasted from a website still
+        // resolves. The cache stores ISBNs unhyphenated.
+        const cleaned = raw.replace(/[^0-9Xx]/g, '');
+        if (cleaned.length < 10 || cleaned.length > 13) {
+            renderResult({
+                kind: 'error',
+                message: 'Enter a 10- or 13-digit ISBN.'
+            });
+            return;
+        }
+        await lookupAndRender(cleaned);
+    }
+
+    async function lookupAndRender(isbn) {
+        try {
+            const book = await window.catalogCache.lookupByIsbn(isbn);
+            if (book) {
+                renderResult({ kind: 'found', isbn, book });
+            } else {
+                renderResult({ kind: 'notfound', isbn });
+            }
+        } catch (err) {
+            renderResult({
+                kind: 'error',
+                message: 'Lookup failed: ' + (err && err.message ? err.message : err)
+            });
+        }
+    }
+
+    function renderStarRow(rating) {
+        if (!rating || rating < 1) return '';
+        const filled = '★'.repeat(Math.max(0, Math.min(5, rating)));
+        const empty = '☆'.repeat(Math.max(0, 5 - rating));
+        return `<span class="text-warning" aria-label="Rating ${rating} of 5">${filled}<span class="text-muted">${empty}</span></span>`;
+    }
+
+    function renderResult(result) {
+        const container = $('bookshop-result');
+        if (!container) return;
+
+        if (result.kind === 'error') {
+            container.innerHTML = `
+                <div class="card border-warning">
+                    <div class="card-body">
+                        <div class="alert alert-warning mb-0 py-2">${esc(result.message)}</div>
+                    </div>
+                </div>`;
+            return;
+        }
+
+        if (result.kind === 'notfound') {
+            container.innerHTML = `
+                <div class="card">
+                    <div class="card-body text-center">
+                        <span class="badge bg-secondary fs-6 mb-2">Not in your library</span>
+                        <p class="text-muted small mb-2">ISBN <span class="font-monospace">${esc(result.isbn)}</span> isn't in your collection.</p>
+                        <div class="d-flex gap-2 justify-content-center flex-wrap">
+                            <a href="/books/add" class="btn btn-primary btn-sm">Add to library</a>
+                            <a href="/shopping" class="btn btn-outline-secondary btn-sm">Add to wishlist</a>
+                        </div>
+                        <p class="text-muted small mt-2 mb-0">(both require an online connection)</p>
+                    </div>
+                </div>`;
+            return;
+        }
+
+        // Found
+        const b = result.book;
+        const status = b.status != null ? String(b.status) : '';
+        const authorLine = (b.allAuthors && b.allAuthors.length > 1)
+            ? b.allAuthors.join(', ')
+            : (b.primaryAuthor || '');
+        const ratingHtml = renderStarRow(b.rating);
+        const statusBadge = status ? `<span class="badge bg-light text-dark border ms-1">${esc(status)}</span>` : '';
+
+        container.innerHTML = `
+            <div class="card border-success">
+                <div class="card-body">
+                    <span class="badge bg-success mb-2">In your library</span>
+                    <div class="fw-semibold fs-5">${esc(b.title || '(untitled)')}</div>
+                    <div class="text-muted">${esc(authorLine)}</div>
+                    <div class="mt-1">${ratingHtml}${statusBadge}</div>
+                    <div class="text-muted small mt-2">ISBN: <span class="font-monospace">${esc(result.isbn)}</span></div>
+                    <div class="mt-3">
+                        <a href="/books/${encodeURIComponent(b.id)}" class="btn btn-outline-primary btn-sm">Open in app →</a>
+                    </div>
+                </div>
+            </div>`;
+    }
+
+    function formatRelative(iso) {
+        if (!iso) return 'never';
+        const then = new Date(iso).getTime();
+        if (isNaN(then)) return 'unknown';
+        const diff = Date.now() - then;
+        const mins = Math.floor(diff / 60000);
+        if (mins < 1) return 'just now';
+        if (mins < 60) return `${mins}m ago`;
+        const hours = Math.floor(mins / 60);
+        if (hours < 24) return `${hours}h ago`;
+        const days = Math.floor(hours / 24);
+        return `${days}d ago`;
+    }
+
+    async function refreshFooter() {
+        const meta = $('bookshop-meta');
+        if (!meta) return;
+        try {
+            const m = await window.catalogCache.getMeta();
+            if (!m || !m.syncedAt) {
+                meta.textContent = 'Catalog not synced yet — connect online to sync.';
+                return;
+            }
+            const offline = (typeof navigator !== 'undefined' && navigator.onLine === false);
+            const syncStr = formatRelative(m.syncedAt);
+            const statePrefix = offline ? '📵 Offline · ' : '';
+            meta.textContent = `${statePrefix}Catalog: ${m.bookCount || 0} books · synced ${syncStr}`;
+        } catch (err) {
+            meta.textContent = 'Catalog status unavailable.';
+        }
+    }
+
+    async function init() {
+        if (!isBookshopPage()) return;
+
+        // Init the cache. If offline + first-ever visit this throws
+        // internally and surfaces empty results — the user sees the
+        // "not synced yet" footer message and can't look anything up,
+        // which is the correct state.
+        try {
+            await window.catalogCache.init();
+        } catch (err) {
+            console.warn('[bookshop] catalog init failed:', err);
+        }
+
+        await refreshFooter();
+
+        const toggle = $('bookshop-scan-toggle');
+        if (toggle) {
+            toggle.addEventListener('click', async () => {
+                if (scannerActive) {
+                    await stopScanner();
+                } else {
+                    await startScanner();
+                }
+            });
+        }
+
+        const lookup = $('bookshop-isbn-lookup');
+        if (lookup) {
+            lookup.addEventListener('click', () => { manualLookup(); });
+        }
+
+        const input = $('bookshop-isbn-input');
+        if (input) {
+            input.addEventListener('keyup', (e) => {
+                if (e.key === 'Enter') manualLookup();
+            });
+        }
+
+        // Online/offline transitions update the footer label so the
+        // user sees the state change live. Doesn't trigger a refresh
+        // by itself — that's PR 5 polish.
+        window.addEventListener('online', refreshFooter);
+        window.addEventListener('offline', refreshFooter);
+    }
+
+    // Self-init. Loaded globally from App.razor; on non-/bookshop
+    // pages the isBookshopPage() guard makes init() a no-op.
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+
+    // Expose for DevTools poking — same pattern as catalogCache.
+    window.BookshopPage = { init };
+})();

--- a/BookTracker.Web/wwwroot/js/bookshop-page.js
+++ b/BookTracker.Web/wwwroot/js/bookshop-page.js
@@ -289,12 +289,44 @@
             });
         }
 
+        const refreshBtn = $('bookshop-refresh');
+        if (refreshBtn) {
+            refreshBtn.addEventListener('click', () => doRefresh(refreshBtn));
+        }
+
         // Online/offline transitions update the footer label so the
         // user sees the state change live. Doesn't trigger a refresh
         // by itself — that's PR 5 polish. Bound to window once;
         // subsequent inits skip via the sentinel guard above.
         window.addEventListener('online', refreshFooter);
         window.addEventListener('offline', refreshFooter);
+    }
+
+    async function doRefresh(btn) {
+        // The fetch path through catalog-cache.refresh() bypasses the
+        // SW's stale-while-revalidate via the X-Catalog-Refresh header
+        // — so this trip both updates the SW cache and repopulates
+        // IndexedDB on the same call. Footer reflects new data
+        // immediately on success.
+        btn.disabled = true;
+        const idle = btn.querySelector('[data-state="idle"]');
+        const busy = btn.querySelector('[data-state="busy"]');
+        if (idle) idle.classList.add('d-none');
+        if (busy) busy.classList.remove('d-none');
+        try {
+            await window.catalogCache.refresh();
+            await refreshFooter();
+        } catch (err) {
+            const meta = $('bookshop-meta');
+            if (meta) {
+                meta.textContent = 'Refresh failed: '
+                    + (err && err.message ? err.message : String(err));
+            }
+        } finally {
+            btn.disabled = false;
+            if (idle) idle.classList.remove('d-none');
+            if (busy) busy.classList.add('d-none');
+        }
     }
 
     // Self-init. Loaded globally from App.razor; on non-/bookshop

--- a/BookTracker.Web/wwwroot/js/catalog-cache.js
+++ b/BookTracker.Web/wwwroot/js/catalog-cache.js
@@ -93,7 +93,15 @@
     }
 
     async function refresh() {
-        const response = await fetch(SNAPSHOT_URL, { credentials: 'same-origin' });
+        // X-Catalog-Refresh: 1 tells the service worker to bypass the
+        // cache-first SWR pattern and go network-first (overwriting
+        // the cache). Without it, this fetch would return SW-cached
+        // bytes — meaning a user-triggered refresh would just rewrite
+        // IndexedDB with the same stale snapshot.
+        const response = await fetch(SNAPSHOT_URL, {
+            credentials: 'same-origin',
+            headers: { 'X-Catalog-Refresh': '1' },
+        });
         if (!response.ok) {
             throw new Error(`Catalog snapshot fetch failed: ${response.status} ${response.statusText}`);
         }

--- a/BookTracker.Web/wwwroot/service-worker.js
+++ b/BookTracker.Web/wwwroot/service-worker.js
@@ -51,15 +51,24 @@ self.addEventListener('fetch', event => {
         return;
     }
 
-    // /api/catalog-snapshot — cache-first with stale-while-revalidate.
-    // Returns cached bytes immediately when available; kicks off a
-    // background refresh that updates the cache for next time. When
-    // offline and uncached, surfaces the fetch error to the caller
-    // (catalog-cache.js init() catches and degrades).
+    // /api/catalog-snapshot — cache-first with stale-while-revalidate
+    // for the implicit page-load fetch (caller doesn't need fresh data
+    // right now; it'll get fresher data next time). For an explicit
+    // user-triggered refresh, catalog-cache.js's refresh() sends the
+    // X-Catalog-Refresh: 1 header — that branch is network-first and
+    // overwrites the cache with the fresh response, so the same trip
+    // returns new data to the caller AND the next page load is current.
+    // Without this distinction, a user adding a book would have to
+    // F5 twice to see the new count: once to trigger the SWR background
+    // fetch, again to read the now-updated cache.
     if (request.method === 'GET'
         && url.origin === location.origin
         && url.pathname === '/api/catalog-snapshot') {
-        event.respondWith(cacheFirstWithStaleWhileRevalidate(request, CATALOG_CACHE));
+        if (request.headers.get('X-Catalog-Refresh') === '1') {
+            event.respondWith(networkFirstUpdateCache(request, CATALOG_CACHE));
+        } else {
+            event.respondWith(cacheFirstWithStaleWhileRevalidate(request, CATALOG_CACHE));
+        }
         return;
     }
 
@@ -118,6 +127,26 @@ async function cacheFirstWithStaleWhileRevalidate(request, cacheName) {
         }
         return response;
     } catch (err) {
+        throw new Error(`Fetch failed and no cached response for ${request.url}`);
+    }
+}
+
+// Network-first that *updates* the named cache on success. Used by
+// the X-Catalog-Refresh: 1 path — explicit refresh wants both the
+// fresh response AND the cache replaced so the next page load is
+// current too. Falls back to cached on network failure (offline mid-
+// refresh) so the user sees something rather than a thrown error.
+async function networkFirstUpdateCache(request, cacheName) {
+    const cache = await caches.open(cacheName);
+    try {
+        const response = await fetch(request);
+        if (response.ok) {
+            cache.put(request, response.clone());
+        }
+        return response;
+    } catch (err) {
+        const cached = await cache.match(request);
+        if (cached) return cached;
         throw new Error(`Fetch failed and no cached response for ${request.url}`);
     }
 }


### PR DESCRIPTION
PR 3 of the offline-mobile-lookup arc (docs/bookshop-mode-design.md).
First user-visible delivery: a /bookshop page that answers
"do I have this book?" in <200ms regardless of network state, by
reading from the IndexedDB catalog cache populated in PR 2.

The page is intentionally markup-only — no @code, no @onclick, no
@bind. All interactivity flows through bookshop-page.js, which wires
DOM events to window.catalogCache (PR 2) and window.BarcodeScanner.
The page inherits the project's global InteractiveServer rendermode
but doesn't use the Blazor circuit for anything; when offline the SW
serves the cached HTML and the JS layer keeps working unaided.

Changes:
- New Components/Pages/Bookshop/Index.razor: scan toggle + scanner
  panel + manual ISBN input + result container + footer meta line.
- New wwwroot/js/bookshop-page.js: page glue — gates on path so
  non-/bookshop pages pay only the script-download cost. Uses the
  new BarcodeScanner.startJs callback variant, escapes all dynamic
  strings before innerHTML, formats relative sync time, refreshes
  footer on online/offline transitions.
- wwwroot/js/barcode-scanner.js: new startJs(elementId, onScan,
  onError) variant alongside the existing Blazor-DotNetObjectReference
  start(). Pure-JS callbacks for pages without an active circuit;
  same scanning behaviour and 3-second debounce.
- App.razor: script tag for bookshop-page.js, before MudBlazor /
  service-worker-register.

PR 4 will add the second mode (author lookup); PR 5 will polish the
refresh UX, staleness warnings, and offline indicator.

Manual test plan:
- Build + run; navigate to /bookshop. Expect "Loading catalog…"
  briefly, then "Catalog: N books · synced just now".
- Tap "Scan ISBN" — camera prompt; scanner panel renders.
- Scan a barcode for a book in the library — result card shows
  "In your library" + title + author + Open-in-app link.
- Scan one not in the library — result card shows "Not in your
  library" + Add-to-library / Add-to-wishlist buttons.
- Manual entry: paste a hyphenated ISBN like 978-0-553-28789-9 and
  press Enter — same lookup flow.
- DevTools → Application → Service Workers → check "Offline" box,
  hard-reload /bookshop. Page still loads; cached lookups still
  answer; footer prefixes with 📵 Offline.
- Visit any other page (e.g. /books) — bookshop-page.js loads but
  no-ops; no console errors.
