### PR TITLE
feat(bookshop): polish — staleness, offline banner, auth, toasts (PR 5)

### DIFF
--- a/BookTracker.Web/Components/Pages/Bookshop/Index.razor
+++ b/BookTracker.Web/Components/Pages/Bookshop/Index.razor
@@ -24,6 +24,14 @@
     <h1 class="h4 mb-3 mt-2">Bookshop mode</h1>
     <p class="text-muted small mb-3">Look up books from your library — works offline.</p>
 
+    @* Offline banner — JS reveals when navigator.onLine === false.
+       Stays visible the whole time the user is offline so they
+       know lookups are coming from cache. Updates on online /
+       offline / visibilitychange events. *@
+    <div id="bookshop-offline-banner" class="alert alert-secondary py-2 small d-none" role="status">
+        📵 Offline — showing cached data. Lookups still work; refresh and "Open in app" need a connection.
+    </div>
+
     @* Mode toggle. JS swaps btn-primary / btn-outline-primary on
        click and shows the matching #bookshop-mode-* container. *@
     <div class="btn-group w-100 mb-3" role="group" aria-label="Bookshop mode">
@@ -87,6 +95,15 @@
 
     <div id="bookshop-footer" class="text-center text-muted small mt-4 mb-3">
         <div id="bookshop-meta">Loading catalog…</div>
+
+        @* Stale-cache warning — JS reveals when syncedAt is older
+           than 7 days. Lenient threshold per design doc: most "do I
+           have this?" answers are correct against a week-old
+           snapshot, but past that the user should know to refresh. *@
+        <div id="bookshop-stale-warning" class="alert alert-warning py-2 mt-2 mb-0 small d-none" role="status">
+            ⚠ Catalog last synced <span id="bookshop-stale-days"></span> days ago. Refresh when online to be sure.
+        </div>
+
         <button id="bookshop-refresh" type="button" class="btn btn-outline-secondary btn-sm mt-2">
             <span data-state="idle">Refresh</span>
             <span data-state="busy" class="d-none">
@@ -94,8 +111,29 @@
                 Refreshing…
             </span>
         </button>
+
+        @* Auth-expired prompt — surfaced when /api/catalog-snapshot
+           returns 401 or redirects through /.auth/, which happens
+           when the Easy Auth session has expired (typically after
+           the user has been offline for a while). The link kicks
+           off the AAD sign-in flow with a post-login bounce back
+           to /bookshop. *@
+        <div id="bookshop-auth-prompt" class="alert alert-info mt-2 mb-0 py-2 small d-none" role="alert">
+            Your sign-in expired.
+            <a href="/.auth/login/aad?post_login_redirect_uri=/bookshop">Sign in again</a>
+            to refresh.
+        </div>
     </div>
 </div>
+
+@* Toast host — fixed-position stack of transient messages
+   (refresh success / error). JS appends/removes toast divs;
+   pointer-events: none on the host so toasts don't block taps
+   beneath when the screen is busy. *@
+<div id="bookshop-toast-host"
+     class="position-fixed bottom-0 start-50 translate-middle-x pb-3 d-flex flex-column align-items-center"
+     style="z-index: 1080; pointer-events: none;"
+     aria-live="polite"></div>
 
 @code {
     protected override async Task OnAfterRenderAsync(bool firstRender)

--- a/BookTracker.Web/wwwroot/js/bookshop-page.js
+++ b/BookTracker.Web/wwwroot/js/bookshop-page.js
@@ -363,21 +363,86 @@
         return `${days}d ago`;
     }
 
+    const STALE_DAYS_THRESHOLD = 7;
+
+    function daysSince(iso) {
+        if (!iso) return null;
+        const then = new Date(iso).getTime();
+        if (isNaN(then)) return null;
+        return Math.floor((Date.now() - then) / (24 * 60 * 60 * 1000));
+    }
+
+    function isOffline() {
+        return (typeof navigator !== 'undefined' && navigator.onLine === false);
+    }
+
+    function setOfflineBanner(visible) {
+        const banner = $('bookshop-offline-banner');
+        if (!banner) return;
+        if (visible) banner.classList.remove('d-none');
+        else banner.classList.add('d-none');
+    }
+
+    function setStaleWarning(days) {
+        const warn = $('bookshop-stale-warning');
+        const span = $('bookshop-stale-days');
+        if (!warn) return;
+        if (days != null && days >= STALE_DAYS_THRESHOLD) {
+            if (span) span.textContent = String(days);
+            warn.classList.remove('d-none');
+        } else {
+            warn.classList.add('d-none');
+        }
+    }
+
+    function setAuthPrompt(visible) {
+        const el = $('bookshop-auth-prompt');
+        if (!el) return;
+        if (visible) el.classList.remove('d-none');
+        else el.classList.add('d-none');
+    }
+
+    // Transient toast — appended to the fixed host, auto-dismissed
+    // after 3s with a fade-out. Plain DOM rather than a Bootstrap
+    // toast instance because the page deliberately avoids depending
+    // on Bootstrap JS APIs (the page must keep working when offline,
+    // and Bootstrap.Toast.dispose has bitten the project before).
+    function showToast(message, kind) {
+        const host = $('bookshop-toast-host');
+        if (!host) return;
+        const colorClass = kind === 'success' ? 'bg-success'
+            : kind === 'error' ? 'bg-danger'
+            : 'bg-secondary';
+        const toast = document.createElement('div');
+        toast.className = `${colorClass} text-white px-3 py-2 rounded shadow-sm mb-2`;
+        toast.style.maxWidth = '90vw';
+        toast.style.pointerEvents = 'auto';
+        toast.style.transition = 'opacity 300ms';
+        toast.textContent = message;
+        host.appendChild(toast);
+        setTimeout(() => {
+            toast.style.opacity = '0';
+            setTimeout(() => toast.remove(), 320);
+        }, 2700);
+    }
+
     async function refreshFooter() {
         const meta = $('bookshop-meta');
         if (!meta) return;
+        setOfflineBanner(isOffline());
         try {
             const m = await window.catalogCache.getMeta();
             if (!m || !m.syncedAt) {
                 meta.textContent = 'Catalog not synced yet — connect online to sync.';
+                setStaleWarning(null);
                 return;
             }
-            const offline = (typeof navigator !== 'undefined' && navigator.onLine === false);
             const syncStr = formatRelative(m.syncedAt);
-            const statePrefix = offline ? '📵 Offline · ' : '';
-            meta.textContent = `${statePrefix}Catalog: ${m.bookCount || 0} books · synced ${syncStr}`;
+            meta.textContent = `Catalog: ${m.bookCount || 0} books · synced ${syncStr}`;
+            setStaleWarning(daysSince(m.syncedAt));
         } catch (err) {
             meta.textContent = 'Catalog status unavailable.';
+            setStaleWarning(null);
         }
     }
 
@@ -475,12 +540,19 @@
         const back = $('bookshop-author-back');
         if (back) back.addEventListener('click', backToAuthorList);
 
-        // Online/offline transitions update the footer label so the
-        // user sees the state change live. Doesn't trigger a refresh
-        // by itself — that's PR 5 polish. Bound to window once;
-        // subsequent inits skip via the sentinel guard above.
+        // Online/offline transitions update the footer label, the
+        // offline banner, and (via refreshFooter) the relative-time
+        // string + stale warning. Bound to window once; subsequent
+        // inits skip via the sentinel guard above. visibilitychange
+        // catches the case where the tab was hidden during a
+        // network state change — without it, returning to the tab
+        // shows yesterday's online/offline state until the next
+        // user interaction.
         window.addEventListener('online', refreshFooter);
         window.addEventListener('offline', refreshFooter);
+        document.addEventListener('visibilitychange', () => {
+            if (!document.hidden) refreshFooter();
+        });
     }
 
     async function doRefresh(btn) {
@@ -494,14 +566,24 @@
         const busy = btn.querySelector('[data-state="busy"]');
         if (idle) idle.classList.add('d-none');
         if (busy) busy.classList.remove('d-none');
+        setAuthPrompt(false);
         try {
             await window.catalogCache.refresh();
             await refreshFooter();
+            showToast('Catalog refreshed', 'success');
         } catch (err) {
-            const meta = $('bookshop-meta');
-            if (meta) {
-                meta.textContent = 'Refresh failed: '
-                    + (err && err.message ? err.message : String(err));
+            if (err && err.code === 'auth-expired') {
+                // Show the inline sign-in CTA instead of a toast
+                // shouting an opaque error. Footer stays on its
+                // last-known state so the user keeps seeing the
+                // info they had.
+                setAuthPrompt(true);
+                showToast('Sign-in expired', 'error');
+            } else if (isOffline()) {
+                showToast('Offline — can\'t refresh', 'error');
+            } else {
+                const msg = err && err.message ? err.message : String(err);
+                showToast('Refresh failed: ' + msg, 'error');
             }
         } finally {
             btn.disabled = false;

--- a/BookTracker.Web/wwwroot/js/catalog-cache.js
+++ b/BookTracker.Web/wwwroot/js/catalog-cache.js
@@ -102,8 +102,31 @@
             credentials: 'same-origin',
             headers: { 'X-Catalog-Refresh': '1' },
         });
+
+        // Auth-expired detection. Easy Auth's default behaviour for
+        // unauthenticated requests is configurable: 401 for API
+        // shapes, 302 → /.auth/login for browser-shaped requests.
+        // fetch() follows redirects by default so a 302 lands us on
+        // the login page (200 + text/html), which is why we also
+        // sniff the final URL and content-type. Throw a typed error
+        // so the caller can surface the sign-in CTA rather than a
+        // generic "Refresh failed" message.
+        if (response.status === 401
+            || (response.url && response.url.includes('/.auth/'))) {
+            const err = new Error('Authentication expired');
+            err.code = 'auth-expired';
+            throw err;
+        }
         if (!response.ok) {
             throw new Error(`Catalog snapshot fetch failed: ${response.status} ${response.statusText}`);
+        }
+        const contentType = response.headers.get('content-type') || '';
+        if (!contentType.toLowerCase().includes('application/json')) {
+            // Non-JSON 200 is almost always an HTML login page that
+            // followed a redirect we didn't catch by URL alone.
+            const err = new Error('Authentication expired (non-JSON response)');
+            err.code = 'auth-expired';
+            throw err;
         }
         const snapshot = await response.json();
         await populate(snapshot);


### PR DESCRIPTION
Closes the bookshop v1 arc with the four polish items from
docs/bookshop-mode-design.md § PR 5:

1. Stale-cache warning. New #bookshop-stale-warning alert in the
   footer, hidden by default; JS reveals it when syncedAt is more
   than 7 days old. The threshold is intentionally lenient — most
   "do I have this?" answers are still correct against a week-old
   snapshot, but past that the user should know they're operating
   on stale data.

2. Offline indicator. New #bookshop-offline-banner at the top of
   the page, hidden when online, surfaced when navigator.onLine is
   false. The previous "📵 Offline · " prefix on the meta line was
   too quiet to notice on a busy page; the banner is impossible to
   miss. Wired to existing online / offline events plus a new
   visibilitychange handler that re-checks state when the tab
   becomes visible again — without it, returning to a backgrounded
   tab showed yesterday's online/offline state until the next user
   interaction.

3. Auth-expired handling. catalog-cache.js refresh() now sniffs
   for 401, redirect-to-/.auth/, and non-JSON responses (the login
   page can land as 200 + text/html if fetch follows a 302), and
   throws a typed Error with code "auth-expired". bookshop-page.js
   doRefresh() catches that code and reveals a #bookshop-auth-prompt
   alert with a sign-in link (post_login_redirect_uri=/bookshop)
   instead of a generic "Refresh failed" message. Footer keeps its
   last-known state so the user doesn't lose info.

4. Refresh feedback toasts. Replaced the inline "Refresh failed"
   footer mutation with a transient bottom-of-screen toast that
   auto-dismisses after ~3s with a fade-out. Three kinds: success
   (green), error (red), neutral (grey). Plain DOM rather than
   Bootstrap.Toast — the page must keep working offline and
   Bootstrap.Toast.dispose has bitten the project before; pure
   CSS+JS keeps the dependency surface small.

Defers (still in scope for v2 if surfaced):
- Static SSR vs InteractiveServer rendermode (deferred decision in
  design doc § Open decisions). Current InteractiveServer +
  pure-JS approach works; the rendermode question only surfaces
  if the offline reconnect overlay turns out to be a problem in
  real use, which it hasn't been across PRs 3 and 4.
- Cover thumbnails on result cards (size budget said no in v1).
- Service Worker BackgroundSync API (Chrome only; iOS doesn't
  support it).

Manual test plan:
- /bookshop online: no offline banner, no stale warning (assuming
  fresh sync).
- DevTools → Network → Offline. Reload /bookshop: offline banner
  surfaces, footer keeps showing cached count + last sync time.
- Switch tabs / lock screen briefly while offline, return: banner
  still visible (visibilitychange handler re-checks state).
- Manually advance the system clock (or mock IndexedDB syncedAt
  to ~10 days ago): stale warning surfaces with the correct day
  count.
- Online + Refresh: green "Catalog refreshed" toast, ~3s.
- Offline + Refresh: red "Offline — can't refresh" toast.
- Sign out of Easy Auth in another tab, then Refresh /bookshop:
  red "Sign-in expired" toast + the inline sign-in CTA appears
  in the footer.
