### PR TITLE
chore(memory): land May 2026 incident runbooks at bookshop arc close

### DIFF
--- a/.claude-memory/MEMORY.md
+++ b/.claude-memory/MEMORY.md
@@ -16,3 +16,5 @@
 - [Keep ARCHITECTURE.md updated](feedback_architecture_doc.md) — update when structural changes are made (entities, pages, services, patterns).
 - [Blog post backlog](blog_post_backlog.md) — corpus-derived candidate posts mineable from existing retros + `patterns.md`. 7 shipped + 7 strong / 6 possible candidates remaining from the 2026-04-28 catch-up mine.
 - [Security-audit skill chassis pilot](retros/retro_security_audit_skill_poc.md) — two-stack validation worked; three durable lessons (relocate audit-rules/ out of `.claude/`, add Blazor JS interop rule, formalise "no applicable surface yet" as a pass-with-evidence shape).
+- [Runbook: SQL DB restart for SqlClient pool zombies](runbook_sqlclient_pool_zombies.md) — when both slots Running but won't serve and Stop+Start doesn't help, restart the SQL DB to break stuck connection state.
+- [Runbook: container warmup timeout calibration](runbook_container_warmup_calibration.md) — Linux App Service default 230s probe is too tight under AAD-auth + cold cert update; `WEBSITES_CONTAINER_START_TIME_LIMIT=600` now in Bicep.

--- a/.claude-memory/runbook_container_warmup_calibration.md
+++ b/.claude-memory/runbook_container_warmup_calibration.md
@@ -1,0 +1,21 @@
+---
+name: WEBSITES_CONTAINER_START_TIME_LIMIT calibration for AAD-authed Linux App Service
+description: Default 230s warmup probe is too tight when cold-start stacks ca-cert update + AAD handshake + EF migration + app init. Set to 600s; now in Bicep.
+type: project
+originSessionId: 06e95d36-5868-496f-9999-8b65f480b83c
+---
+Linux App Service's warmup probe gives a container 230 seconds to come up before declaring failure and entering a kill-and-restart loop. BookTracker's cold-start adds up to ~250s under realistic conditions, so the default eventually trips on a slow day. Hard-set to 600s in Bicep via `WEBSITES_CONTAINER_START_TIME_LIMIT: '600'` in `infra/modules/app-config.bicep` `commonAppSettings` (PR #192).
+
+**Why:** Cold start stacks:
+- Platform `update-ca-certificates` (5-80s — variable, sometimes very slow on regional bad days)
+- Dotnet bootstrap (~15s)
+- First SQL connection with AAD-only auth on Basic tier (~30-40s — Managed Identity token acquisition + AAD validation against SQL)
+- EF migration applock + history check (~10s)
+- App initialisation, Kestrel binding (~30-40s)
+
+Once a container crosses 230s, the platform kills it. The fresh container starts the whole sequence again, which makes the next attempt slower because cert updates and AAD calls happen across more concurrent containers. The restart loop reinforces itself.
+
+**How to apply:** Already permanent in Bicep. If the value comes into question:
+- The setting must be on both prod and staging slots; it's environment-shape, not slot-sticky.
+- During the May 2026 incident, Drew set it manually via `az webapp config appsettings set`. Because it's not slot-sticky, a swap *moves it with the bits* — meaning a manual fix can be lost on swap. Putting it in Bicep prevents that, but if anyone reaches for the manual command again, remember that setting it on both slots before swapping is the safe shape.
+- Max is 1800s. 600s gives generous headroom; reach higher only if cold-start measurements legitimately exceed 5 minutes.

--- a/.claude-memory/runbook_sqlclient_pool_zombies.md
+++ b/.claude-memory/runbook_sqlclient_pool_zombies.md
@@ -1,0 +1,19 @@
+---
+name: SQL DB restart breaks SqlClient pool zombies
+description: When both App Service slots report Running but won't serve and Stop+Start doesn't help, restart the SQL database to break stuck connection-pool state.
+type: project
+originSessionId: 06e95d36-5868-496f-9999-8b65f480b83c
+---
+When both App Service slots report `Running` but neither serves traffic, and Stop+Start of both slots doesn't recover them, restart the SQL database (Portal preview feature, or `az sql db restart`). This force-kills every server-side connection.
+
+**Why:** SqlClient's connection pool can hold "zombie" connections — physical connections the client believes are alive but the server has lost or is no longer responding to. Worker threads waiting on those connections never time out. App Service's graceful-shutdown sequence waits for those threads, so `Stop` reports success while the worker is still partly hung. The fresh worker that `Start` spawns immediately tries to use the pool and inherits the same wedge because the SQL-side state outlives the App Service worker process.
+
+**How to apply:** Use this when:
+- Both prod and staging slots show state `Running` via `az webapp show`
+- Neither slot serves HTTP requests (curl times out, log streams silent, App Insights Live Metrics silent)
+- `az webapp stop` + `az webapp start` on both slots has been tried and didn't recover service
+- SQL DB itself shows `Online` via `az sql db show -n <db> -g <rg> -s <server> --query status -o tsv`
+
+Restart the SQL database. Workers will get fast `connection died` errors instead of indefinite hangs, hung threads will exit, and the next worker spawn will start with a clean pool. Distinct recovery move from the April incident — that one was AAD-token cache lag, where Stop+Start of slots was sufficient.
+
+First confirmed: 2026-05-08 perf-fix deploy. The pre-deploy bug (a render-tree cartesian on the Publishers page) wedged workers in a way that obstructed the deploy of its own fix; SQL-restart broke the wedge cleanly.


### PR DESCRIPTION
Two project-type runbooks captured during the May 2026 perf-fix
deploy incident, plus the MEMORY.md index entries for them.
Bookshop arc closing is the arc-close trigger per the
memory-landing rule.

- runbook_sqlclient_pool_zombies.md — when both slots Running
  but neither serves traffic and Stop+Start of slots doesn't
  recover, restart the SQL DB to break stuck connection-pool
  state. Distinct recovery move from the April AAD-token-cache
  incident (which Stop+Start fixed). Captures the SqlClient
  zombie-pool mechanism — workers wedge on physical
  connections the server has lost; App Service's graceful-
  shutdown sequence waits for those threads, so Stop reports
  success while the worker is still hung; the fresh worker
  inherits the wedge because SQL-side state outlives the worker
  process.

- runbook_container_warmup_calibration.md — why 230s default
  warmup probe is too tight under AAD-auth + cold cert update
  + EF migration + app init. WEBSITES_CONTAINER_START_TIME_LIMIT
  now hard-set to 600s in Bicep. Includes the slot-sticky
  caveat: a manual `az webapp config appsettings set` fix can
  move with the bits on swap, which is why the value belongs
  in IaC.
