### PR TITLE
feat(mobile): BookTracker.Shared DTOs + API surface extension (Mobile PR 1)

### DIFF
--- a/BookTracker.Shared/BookTracker.Shared.csproj
+++ b/BookTracker.Shared/BookTracker.Shared.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Wire-format DTOs shared between BookTracker.Web (server) and the
+    future BookTracker.Mobile (.NET MAUI client). Deliberately no
+    references to BookTracker.Data — pulling EF Core into Shared
+    would bleed it into the mobile app, which only needs the
+    contract shapes. Enum fields use `string` rather than the
+    server-side enum types so this project stays free of model
+    coupling; the JsonStringEnumConverter on the Web side already
+    serialises that way.
+
+    See docs/mobile-app-design.md.
+  -->
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/BookTracker.Shared/Catalog/CatalogSnapshot.cs
+++ b/BookTracker.Shared/Catalog/CatalogSnapshot.cs
@@ -1,0 +1,45 @@
+namespace BookTracker.Shared.Catalog;
+
+// Wire-format DTOs for GET /api/catalog-snapshot, consumed by the
+// /bookshop offline cache today and the BookTracker.Mobile MAUI app
+// when that ships. See docs/mobile-app-design.md.
+//
+// `Status` and series `Type` are strings rather than the server-side
+// enum types (BookStatus, SeriesType) — keeps this project free of
+// the BookTracker.Data dependency. The JsonStringEnumConverter on the
+// Web side already serialises enums as strings on the wire, so the
+// shape doesn't change.
+
+public record CatalogSnapshot(
+    string Version,
+    DateTime SyncedAt,
+    IReadOnlyList<BookSnapshot> Books,
+    IReadOnlyList<AuthorSnapshot> Authors,
+    IReadOnlyList<SeriesSnapshot> Series);
+
+public record BookSnapshot(
+    int Id,
+    string Title,
+    string PrimaryAuthor,
+    IReadOnlyList<string> AllAuthors,
+    string Status,
+    int Rating,
+    IReadOnlyList<string> Isbns,
+    // Series membership lives on Work, not Book. For multi-Work
+    // compendiums the snapshot takes the first Work (by Work.Id),
+    // matching the same convention used for PrimaryAuthor. Nullable
+    // because most books aren't part of a series.
+    int? SeriesId,
+    int? SeriesOrder);
+
+public record AuthorSnapshot(
+    int Id,
+    string Name,
+    int CanonicalId,
+    int BookCount);
+
+public record SeriesSnapshot(
+    int Id,
+    string Name,
+    string Type,
+    int? ExpectedCount);

--- a/BookTracker.Shared/Wishlist/WishlistSnapshot.cs
+++ b/BookTracker.Shared/Wishlist/WishlistSnapshot.cs
@@ -1,0 +1,21 @@
+namespace BookTracker.Shared.Wishlist;
+
+// Wire-format DTOs for GET /api/wishlist-snapshot. Read-only mirror
+// of the user's wishlist for offline mobile consumption. Add /
+// remove / "bought" actions stay online-only on the Web app — the
+// mobile app reads but doesn't write in v1.
+
+public record WishlistSnapshot(
+    string Version,
+    DateTime SyncedAt,
+    IReadOnlyList<WishlistItemSnapshot> Items);
+
+public record WishlistItemSnapshot(
+    int Id,
+    string Title,
+    string Author,
+    string Priority,
+    string? Isbn,
+    int? SeriesId,
+    int? SeriesOrder,
+    DateTime DateAdded);

--- a/BookTracker.Tests/Services/CatalogSnapshotServiceTests.cs
+++ b/BookTracker.Tests/Services/CatalogSnapshotServiceTests.cs
@@ -1,4 +1,5 @@
 using BookTracker.Data.Models;
+using BookTracker.Shared.Catalog;
 using BookTracker.Web.Services.Catalog;
 
 namespace BookTracker.Tests.Services;
@@ -202,7 +203,97 @@ public class CatalogSnapshotServiceTests
         var snapshot = await CreateService().GetSnapshotAsync();
         var book = Assert.Single(snapshot.Books);
 
-        Assert.Equal(BookStatus.Read, book.Status);
+        // Status is serialised as the enum's string name, not its
+        // underlying int — the BookTracker.Shared DTOs are wire
+        // contracts and stay free of the BookTracker.Data dependency.
+        Assert.Equal("Read", book.Status);
         Assert.Equal(5, book.Rating);
+    }
+
+    [Fact]
+    public async Task GetSnapshotAsync_BookSeriesIdAndOrderProjectedFromFirstWork()
+    {
+        // Single-Work book in a numbered series: seriesId + seriesOrder
+        // come from that Work. Multi-Work compendium takes the first
+        // Work by Work.Id, matching the PrimaryAuthor convention.
+        using (var db = _factory.CreateDbContext())
+        {
+            var asimov = new Author { Name = "Isaac Asimov" };
+            db.Authors.Add(asimov);
+            var foundationSeries = new Series { Name = "Foundation", Type = SeriesType.Series, ExpectedCount = 7 };
+            db.Series.Add(foundationSeries);
+            await db.SaveChangesAsync();
+
+            db.Books.Add(new Book
+            {
+                Title = "Foundation",
+                Works =
+                [
+                    new Work
+                    {
+                        Title = "Foundation",
+                        SeriesId = foundationSeries.Id,
+                        SeriesOrder = 1,
+                        WorkAuthors = [new WorkAuthor { Author = asimov, Order = 0 }],
+                    },
+                ],
+            });
+            // Standalone book — no series.
+            db.Books.Add(new Book
+            {
+                Title = "Nightfall",
+                Works = [new Work { Title = "Nightfall", WorkAuthors = [new WorkAuthor { Author = asimov, Order = 0 }] }],
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var snapshot = await CreateService().GetSnapshotAsync();
+
+        var foundation = snapshot.Books.Single(b => b.Title == "Foundation");
+        Assert.NotNull(foundation.SeriesId);
+        Assert.Equal(1, foundation.SeriesOrder);
+
+        var nightfall = snapshot.Books.Single(b => b.Title == "Nightfall");
+        Assert.Null(nightfall.SeriesId);
+        Assert.Null(nightfall.SeriesOrder);
+    }
+
+    [Fact]
+    public async Task GetSnapshotAsync_SeriesListIncludesOnlySeriesWithBooksInCatalog()
+    {
+        // Series referenced by at least one Work that's in at least one
+        // Book ships in CatalogSnapshot.Series. An empty series (e.g.
+        // user creates "Wheel of Time" in advance, no books yet)
+        // doesn't — it's not useful for the bookshop "missing books"
+        // view client-side.
+        using (var db = _factory.CreateDbContext())
+        {
+            var asimov = new Author { Name = "Isaac Asimov" };
+            db.Authors.Add(asimov);
+            var foundation = new Series { Name = "Foundation", Type = SeriesType.Series, ExpectedCount = 7 };
+            var emptySeries = new Series { Name = "Empire of Light", Type = SeriesType.Series, ExpectedCount = 3 };
+            db.Series.AddRange(foundation, emptySeries);
+            await db.SaveChangesAsync();
+
+            db.Books.Add(new Book
+            {
+                Title = "Foundation",
+                Works = [new Work
+                {
+                    Title = "Foundation",
+                    SeriesId = foundation.Id,
+                    SeriesOrder = 1,
+                    WorkAuthors = [new WorkAuthor { Author = asimov, Order = 0 }],
+                }],
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var snapshot = await CreateService().GetSnapshotAsync();
+
+        var series = Assert.Single(snapshot.Series);
+        Assert.Equal("Foundation", series.Name);
+        Assert.Equal("Series", series.Type);
+        Assert.Equal(7, series.ExpectedCount);
     }
 }

--- a/BookTracker.Tests/Services/WishlistSnapshotServiceTests.cs
+++ b/BookTracker.Tests/Services/WishlistSnapshotServiceTests.cs
@@ -1,0 +1,99 @@
+using BookTracker.Data.Models;
+using BookTracker.Web.Services.Wishlist;
+
+namespace BookTracker.Tests.Services;
+
+[Trait("Category", TestCategories.Integration)]
+public class WishlistSnapshotServiceTests
+{
+    private readonly TestDbContextFactory _factory = new();
+
+    private WishlistSnapshotService CreateService() => new(_factory);
+
+    [Fact]
+    public async Task GetSnapshotAsync_EmptyWishlist_ReturnsEmptyItems()
+    {
+        var snapshot = await CreateService().GetSnapshotAsync();
+
+        Assert.Empty(snapshot.Items);
+        Assert.False(string.IsNullOrWhiteSpace(snapshot.Version));
+    }
+
+    [Fact]
+    public async Task GetSnapshotAsync_FieldsProjectedAndPriorityIsString()
+    {
+        // Status / priority fields ship as strings rather than the
+        // server-side enum types — keeps BookTracker.Shared free of
+        // the BookTracker.Data dependency. Same convention as
+        // BookSnapshot.Status.
+        using (var db = _factory.CreateDbContext())
+        {
+            db.WishlistItems.Add(new WishlistItem
+            {
+                Title = "The Dawn of Everything",
+                Author = "David Graeber, David Wengrow",
+                Priority = WishlistPriority.High,
+                Isbn = "9780374157357",
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var snapshot = await CreateService().GetSnapshotAsync();
+        var item = Assert.Single(snapshot.Items);
+
+        Assert.Equal("The Dawn of Everything", item.Title);
+        Assert.Equal("David Graeber, David Wengrow", item.Author);
+        Assert.Equal("High", item.Priority);
+        Assert.Equal("9780374157357", item.Isbn);
+    }
+
+    [Fact]
+    public async Task GetSnapshotAsync_OrderedByPriorityDescThenDateAddedAsc()
+    {
+        // "What to buy next" semantics — high-priority items the user
+        // added a while ago bubble to the top.
+        using (var db = _factory.CreateDbContext())
+        {
+            var earlier = DateTime.UtcNow.AddDays(-5);
+            var later = DateTime.UtcNow.AddDays(-1);
+            db.WishlistItems.AddRange(
+                new WishlistItem { Title = "Low older", Author = "x", Priority = WishlistPriority.Low, DateAdded = earlier },
+                new WishlistItem { Title = "High newer", Author = "x", Priority = WishlistPriority.High, DateAdded = later },
+                new WishlistItem { Title = "High older", Author = "x", Priority = WishlistPriority.High, DateAdded = earlier },
+                new WishlistItem { Title = "Medium newer", Author = "x", Priority = WishlistPriority.Medium, DateAdded = later });
+            await db.SaveChangesAsync();
+        }
+
+        var snapshot = await CreateService().GetSnapshotAsync();
+        var titles = snapshot.Items.Select(i => i.Title).ToList();
+
+        Assert.Equal(["High older", "High newer", "Medium newer", "Low older"], titles);
+    }
+
+    [Fact]
+    public async Task GetSnapshotAsync_PreservesSeriesLink()
+    {
+        using (var db = _factory.CreateDbContext())
+        {
+            var series = new Series { Name = "Cosmere", Type = SeriesType.Collection };
+            db.Series.Add(series);
+            await db.SaveChangesAsync();
+
+            db.WishlistItems.Add(new WishlistItem
+            {
+                Title = "Wind and Truth",
+                Author = "Brandon Sanderson",
+                Priority = WishlistPriority.Medium,
+                SeriesId = series.Id,
+                SeriesOrder = 5,
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var snapshot = await CreateService().GetSnapshotAsync();
+        var item = Assert.Single(snapshot.Items);
+
+        Assert.NotNull(item.SeriesId);
+        Assert.Equal(5, item.SeriesOrder);
+    }
+}

--- a/BookTracker.Tests/ViewModels/DuplicatesViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/DuplicatesViewModelTests.cs
@@ -13,13 +13,13 @@ public class DuplicatesViewModelTests
     private DuplicatesViewModel CreateVm() => new(_detector);
 
     private static AuthorDuplicatePair ActiveAuthorPair(int a, int b) =>
-        new(new AuthorSnapshot(a, $"Author {a}", 0, null, null),
-            new AuthorSnapshot(b, $"Author {b}", 0, null, null),
+        new(new DuplicateAuthorView(a, $"Author {a}", 0, null, null),
+            new DuplicateAuthorView(b, $"Author {b}", 0, null, null),
             null, "test");
 
     private static AuthorDuplicatePair DismissedAuthorPair(int a, int b, int ignoredId) =>
-        new(new AuthorSnapshot(a, $"Author {a}", 0, null, null),
-            new AuthorSnapshot(b, $"Author {b}", 0, null, null),
+        new(new DuplicateAuthorView(a, $"Author {a}", 0, null, null),
+            new DuplicateAuthorView(b, $"Author {b}", 0, null, null),
             new DismissalInfo(ignoredId, DateTime.UtcNow, null),
             "test");
 

--- a/BookTracker.Web/Api/WishlistEndpoints.cs
+++ b/BookTracker.Web/Api/WishlistEndpoints.cs
@@ -1,0 +1,29 @@
+using BookTracker.Web.Services.Wishlist;
+
+namespace BookTracker.Web.Api;
+
+// Second member of the *Endpoints.cs convention started by
+// CatalogEndpoints.cs. Auth: same Easy Auth platform-layer gate as
+// every other route in the app — see SECURITY-AUDIT.md (SEC-006)
+// for the verification.
+public static class WishlistEndpoints
+{
+    public static IEndpointRouteBuilder MapWishlistEndpoints(this IEndpointRouteBuilder app)
+    {
+        // GET /api/wishlist-snapshot — slim wishlist JSON for the
+        // future BookTracker.Mobile companion's offline read view.
+        // Unlike the catalog snapshot (already consumed by /bookshop
+        // today) this endpoint has no current Web caller; it ships
+        // as the contract MAUI will code against. See
+        // docs/mobile-app-design.md.
+        app.MapGet("/api/wishlist-snapshot", async (
+            IWishlistSnapshotService service,
+            CancellationToken ct) =>
+        {
+            var snapshot = await service.GetSnapshotAsync(ct);
+            return Results.Ok(snapshot);
+        });
+
+        return app;
+    }
+}

--- a/BookTracker.Web/BookTracker.Web.csproj
+++ b/BookTracker.Web/BookTracker.Web.csproj
@@ -26,6 +26,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\BookTracker.Data\BookTracker.Data.csproj" />
+    <ProjectReference Include="..\BookTracker.Shared\BookTracker.Shared.csproj" />
   </ItemGroup>
 
 </Project>

--- a/BookTracker.Web/Components/Pages/Duplicates/AuthorSide.razor
+++ b/BookTracker.Web/Components/Pages/Duplicates/AuthorSide.razor
@@ -12,5 +12,5 @@
 </div>
 
 @code {
-    [Parameter, EditorRequired] public AuthorSnapshot Snap { get; set; } = null!;
+    [Parameter, EditorRequired] public DuplicateAuthorView Snap { get; set; } = null!;
 }

--- a/BookTracker.Web/Components/Pages/Duplicates/BookSide.razor
+++ b/BookTracker.Web/Components/Pages/Duplicates/BookSide.razor
@@ -17,5 +17,5 @@
 </div>
 
 @code {
-    [Parameter, EditorRequired] public BookSnapshot Snap { get; set; } = null!;
+    [Parameter, EditorRequired] public DuplicateBookView Snap { get; set; } = null!;
 }

--- a/BookTracker.Web/Components/Pages/Duplicates/EditionSide.razor
+++ b/BookTracker.Web/Components/Pages/Duplicates/EditionSide.razor
@@ -27,5 +27,5 @@
 </div>
 
 @code {
-    [Parameter, EditorRequired] public EditionSnapshot Snap { get; set; } = null!;
+    [Parameter, EditorRequired] public DuplicateEditionView Snap { get; set; } = null!;
 }

--- a/BookTracker.Web/Components/Pages/Duplicates/WorkSide.razor
+++ b/BookTracker.Web/Components/Pages/Duplicates/WorkSide.razor
@@ -18,5 +18,5 @@
 </div>
 
 @code {
-    [Parameter, EditorRequired] public WorkSnapshot Snap { get; set; } = null!;
+    [Parameter, EditorRequired] public DuplicateWorkView Snap { get; set; } = null!;
 }

--- a/BookTracker.Web/ProgramSetup.cs
+++ b/BookTracker.Web/ProgramSetup.cs
@@ -4,6 +4,7 @@ using BookTracker.Web.Components;
 using BookTracker.Web.Services;
 using BookTracker.Web.Services.Catalog;
 using BookTracker.Web.Services.Covers;
+using BookTracker.Web.Services.Wishlist;
 using BookTracker.Web.Telemetry;
 using BookTracker.Web.ViewModels;
 using Microsoft.ApplicationInsights.Extensibility;
@@ -105,6 +106,7 @@ public static class ProgramSetup
         builder.Services.AddTransient<SeriesMatchService>();
 
         builder.Services.AddScoped<ICatalogSnapshotService, CatalogSnapshotService>();
+        builder.Services.AddScoped<IWishlistSnapshotService, WishlistSnapshotService>();
         builder.Services.AddScoped<IDuplicateDetectionService, DuplicateDetectionService>();
         builder.Services.AddScoped<IAuthorMergeService, AuthorMergeService>();
         builder.Services.AddScoped<IWorkMergeService, WorkMergeService>();
@@ -223,9 +225,11 @@ public static class ProgramSetup
         app.MapRazorComponents<App>()
             .AddInteractiveServerRenderMode();
 
-        // API endpoints (Minimal API). First family is the bookshop catalog
-        // snapshot; future API surfaces add their own *Endpoints.cs class
-        // and Map* call here.
+        // API endpoints (Minimal API). Each domain gets its own
+        // *Endpoints.cs class + Map* call here. Both endpoints are
+        // gated by Easy Auth at the platform layer (SECURITY-AUDIT.md
+        // §SEC-006).
         app.MapCatalogEndpoints();
+        app.MapWishlistEndpoints();
     }
 }

--- a/BookTracker.Web/Services/Catalog/CatalogSnapshotService.cs
+++ b/BookTracker.Web/Services/Catalog/CatalogSnapshotService.cs
@@ -1,13 +1,15 @@
 using BookTracker.Data;
-using BookTracker.Data.Models;
+using BookTracker.Shared.Catalog;
 using Microsoft.EntityFrameworkCore;
 
 namespace BookTracker.Web.Services.Catalog;
 
 // Slim catalog projection consumed by the bookshop-mode offline cache
-// (see docs/bookshop-mode-design.md). Returns just enough data for the
-// killer mobile use cases — ISBN-have-I-got-this and author-lookup —
-// without the bandwidth or PII of a full edit-flow payload.
+// (see docs/bookshop-mode-design.md) and by the future BookTracker.Mobile
+// MAUI app (see docs/mobile-app-design.md). Returns just enough data
+// for the killer mobile use cases — ISBN-have-I-got-this and
+// author-lookup — without the bandwidth or PII of a full edit-flow
+// payload.
 //
 // Size budget at the 3000+ books target: ~480KB raw / ~150KB gzipped.
 // Single endpoint hit; SW pre-caches; IndexedDB stores client-side.
@@ -15,6 +17,9 @@ namespace BookTracker.Web.Services.Catalog;
 // Deliberately omits cover URLs, notes, tags, edition/copy detail.
 // Bookshop mode is read-only-lookup; full detail is reachable via
 // "Open in app" deep-links to /books/{id} (online only).
+//
+// DTO records live in BookTracker.Shared.Catalog — no EF dependency
+// there so the mobile project can reference the contract cleanly.
 public interface ICatalogSnapshotService
 {
     Task<CatalogSnapshot> GetSnapshotAsync(CancellationToken ct = default);
@@ -49,6 +54,14 @@ public class CatalogSnapshotService(
                     .Where(e => e.Isbn != null && e.Isbn != "")
                     .Select(e => e.Isbn!)
                     .ToList(),
+                // Series membership lives on Work. For multi-Work
+                // compendiums take the first Work by Work.Id —
+                // matches the PrimaryAuthor convention. Single-Work
+                // books are unambiguous.
+                FirstWorkSeries = b.Works
+                    .OrderBy(w => w.Id)
+                    .Select(w => new { w.SeriesId, w.SeriesOrder })
+                    .FirstOrDefault(),
             })
             .ToListAsync(ct);
 
@@ -66,9 +79,11 @@ public class CatalogSnapshotService(
                 // distinct by name. Renders as the result-card subtitle
                 // when the book is shown in bookshop mode.
                 b.Authors.OrderBy(a => a.WorkId).ThenBy(a => a.Order).Select(a => a.Name).Distinct().ToList(),
-                b.Status,
+                b.Status.ToString(),
                 b.Rating,
-                b.Isbns.Distinct().ToList()))
+                b.Isbns.Distinct().ToList(),
+                b.FirstWorkSeries?.SeriesId,
+                b.FirstWorkSeries?.SeriesOrder))
             .OrderBy(b => b.Title)
             .ToList();
 
@@ -120,6 +135,33 @@ public class CatalogSnapshotService(
             .OrderBy(a => a.Name)
             .ToList();
 
+        // Series — only those referenced by at least one book in the
+        // snapshot. Derive the IDs from booksRaw (already materialised)
+        // rather than re-querying through Series→Works→Books — that
+        // 3-level nav-property chain doesn't translate cleanly under
+        // the M:N BookWork join table on EF Core 10.x. Side effect of
+        // the simpler shape: a series only attached via a non-first
+        // Work of a compendium won't surface here, which is fine for
+        // v1; the bookshop "missing books" view operates against books
+        // with a clear primary series anyway.
+        var referencedSeriesIds = booksRaw
+            .Select(b => b.FirstWorkSeries?.SeriesId)
+            .Where(id => id.HasValue)
+            .Select(id => id!.Value)
+            .Distinct()
+            .ToList();
+
+        var seriesRaw = await db.Series
+            .AsNoTracking()
+            .Where(s => referencedSeriesIds.Contains(s.Id))
+            .Select(s => new { s.Id, s.Name, s.Type, s.ExpectedCount })
+            .ToListAsync(ct);
+
+        var series = seriesRaw
+            .Select(s => new SeriesSnapshot(s.Id, s.Name, s.Type.ToString(), s.ExpectedCount))
+            .OrderBy(s => s.Name)
+            .ToList();
+
         // Version is the deployed commit SHA when available (so the
         // client-side cache can detect a deploy and trigger a refresh)
         // or "dev" when running locally without the build-time SHA
@@ -128,27 +170,7 @@ public class CatalogSnapshotService(
             BuildInfo.ShortSha ?? "dev",
             DateTime.UtcNow,
             books,
-            authors);
+            authors,
+            series);
     }
 }
-
-public record CatalogSnapshot(
-    string Version,
-    DateTime SyncedAt,
-    IReadOnlyList<BookSnapshot> Books,
-    IReadOnlyList<AuthorSnapshot> Authors);
-
-public record BookSnapshot(
-    int Id,
-    string Title,
-    string PrimaryAuthor,
-    IReadOnlyList<string> AllAuthors,
-    BookStatus Status,
-    int Rating,
-    IReadOnlyList<string> Isbns);
-
-public record AuthorSnapshot(
-    int Id,
-    string Name,
-    int CanonicalId,
-    int BookCount);

--- a/BookTracker.Web/Services/DuplicateDetectionService.cs
+++ b/BookTracker.Web/Services/DuplicateDetectionService.cs
@@ -21,17 +21,17 @@ public record DuplicateReport(
 
 public record DismissalInfo(int IgnoredDuplicateId, DateTime DismissedAt, string? Note);
 
-public record AuthorSnapshot(int Id, string Name, int WorkCount, int? CanonicalAuthorId, string? CanonicalName);
-public record AuthorDuplicatePair(AuthorSnapshot Lower, AuthorSnapshot Higher, DismissalInfo? Dismissed, string MatchReason);
+public record DuplicateAuthorView(int Id, string Name, int WorkCount, int? CanonicalAuthorId, string? CanonicalName);
+public record AuthorDuplicatePair(DuplicateAuthorView Lower, DuplicateAuthorView Higher, DismissalInfo? Dismissed, string MatchReason);
 
-public record WorkSnapshot(int Id, string Title, string? Subtitle, string AuthorName, int BookCount, int? FirstPublishedYear);
-public record WorkDuplicatePair(WorkSnapshot Lower, WorkSnapshot Higher, DismissalInfo? Dismissed, string MatchReason);
+public record DuplicateWorkView(int Id, string Title, string? Subtitle, string AuthorName, int BookCount, int? FirstPublishedYear);
+public record WorkDuplicatePair(DuplicateWorkView Lower, DuplicateWorkView Higher, DismissalInfo? Dismissed, string MatchReason);
 
-public record BookSnapshot(int Id, string Title, string? AuthorName, int EditionCount, int CopyCount, DateTime DateAdded);
-public record BookDuplicatePair(BookSnapshot Lower, BookSnapshot Higher, DismissalInfo? Dismissed, string MatchReason);
+public record DuplicateBookView(int Id, string Title, string? AuthorName, int EditionCount, int CopyCount, DateTime DateAdded);
+public record BookDuplicatePair(DuplicateBookView Lower, DuplicateBookView Higher, DismissalInfo? Dismissed, string MatchReason);
 
-public record EditionSnapshot(int Id, string? Isbn, BookFormat Format, string? PublisherName, DateOnly? DatePrinted, int CopyCount, int BookId, string BookTitle);
-public record EditionDuplicatePair(EditionSnapshot Lower, EditionSnapshot Higher, DismissalInfo? Dismissed, string MatchReason);
+public record DuplicateEditionView(int Id, string? Isbn, BookFormat Format, string? PublisherName, DateOnly? DatePrinted, int CopyCount, int BookId, string BookTitle);
+public record EditionDuplicatePair(DuplicateEditionView Lower, DuplicateEditionView Higher, DismissalInfo? Dismissed, string MatchReason);
 
 public class DuplicateDetectionService(IDbContextFactory<BookTrackerDbContext> dbFactory) : IDuplicateDetectionService
 {
@@ -156,8 +156,8 @@ public class DuplicateDetectionService(IDbContextFactory<BookTrackerDbContext> d
             var lower = key.Item1 == a.Id ? a : b;
             var higher = key.Item1 == a.Id ? b : a;
             pairs.Add(new AuthorDuplicatePair(
-                Lower: new AuthorSnapshot(lower.Id, lower.Name, lower.WorkCount, lower.CanonicalAuthorId, lower.CanonicalName),
-                Higher: new AuthorSnapshot(higher.Id, higher.Name, higher.WorkCount, higher.CanonicalAuthorId, higher.CanonicalName),
+                Lower: new DuplicateAuthorView(lower.Id, lower.Name, lower.WorkCount, lower.CanonicalAuthorId, lower.CanonicalName),
+                Higher: new DuplicateAuthorView(higher.Id, higher.Name, higher.WorkCount, higher.CanonicalAuthorId, higher.CanonicalName),
                 Dismissed: LookupDismissal(ignored, key.Item1, key.Item2),
                 MatchReason: reason));
         }
@@ -251,8 +251,8 @@ public class DuplicateDetectionService(IDbContextFactory<BookTrackerDbContext> d
                 {
                     var a = members[i];
                     var b = members[j];
-                    var snapA = new WorkSnapshot(a.Id, a.Title, a.Subtitle, a.AuthorNames, a.BookCount, a.FirstPublishedYear);
-                    var snapB = new WorkSnapshot(b.Id, b.Title, b.Subtitle, b.AuthorNames, b.BookCount, b.FirstPublishedYear);
+                    var snapA = new DuplicateWorkView(a.Id, a.Title, a.Subtitle, a.AuthorNames, a.BookCount, a.FirstPublishedYear);
+                    var snapB = new DuplicateWorkView(b.Id, b.Title, b.Subtitle, b.AuthorNames, b.BookCount, b.FirstPublishedYear);
                     pairs.Add(new WorkDuplicatePair(
                         Lower: snapA,
                         Higher: snapB,
@@ -303,8 +303,8 @@ public class DuplicateDetectionService(IDbContextFactory<BookTrackerDbContext> d
             if (!seen.Add((lowerId, higherId))) return;
             var l = get(lowerId);
             var h = get(higherId);
-            var snapL = new BookSnapshot(l.Item1, l.Item2, l.Item3, l.Item4, l.Item5, l.Item6);
-            var snapH = new BookSnapshot(h.Item1, h.Item2, h.Item3, h.Item4, h.Item5, h.Item6);
+            var snapL = new DuplicateBookView(l.Item1, l.Item2, l.Item3, l.Item4, l.Item5, l.Item6);
+            var snapH = new DuplicateBookView(h.Item1, h.Item2, h.Item3, h.Item4, h.Item5, h.Item6);
             pairs.Add(new BookDuplicatePair(snapL, snapH, LookupDismissal(ignored, lowerId, higherId), reason));
         }
 
@@ -417,7 +417,7 @@ public class DuplicateDetectionService(IDbContextFactory<BookTrackerDbContext> d
             }
         }
 
-        static EditionSnapshot ToSnapshot(EditionProjection e) => new(
+        static DuplicateEditionView ToSnapshot(EditionProjection e) => new(
             e.Id, e.Isbn, e.Format, e.PublisherName, e.DatePrinted, e.CopyCount, e.BookId, e.BookTitle);
     }
 

--- a/BookTracker.Web/Services/Wishlist/WishlistSnapshotService.cs
+++ b/BookTracker.Web/Services/Wishlist/WishlistSnapshotService.cs
@@ -1,0 +1,50 @@
+using BookTracker.Data;
+using BookTracker.Shared.Wishlist;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookTracker.Web.Services.Wishlist;
+
+// Wishlist projection consumed by the /api/wishlist-snapshot endpoint.
+// Same shape as CatalogSnapshotService — slim, read-only, JSON-on-the-
+// wire, populated by a single query. See docs/mobile-app-design.md
+// for the consumer-side picture (BookTracker.Mobile MAUI app).
+//
+// Wishlist mutations (add / remove / "bought") stay online-only on the
+// Web app; the mobile companion is read-only in v1.
+public interface IWishlistSnapshotService
+{
+    Task<WishlistSnapshot> GetSnapshotAsync(CancellationToken ct = default);
+}
+
+public class WishlistSnapshotService(
+    IDbContextFactory<BookTrackerDbContext> dbFactory) : IWishlistSnapshotService
+{
+    public async Task<WishlistSnapshot> GetSnapshotAsync(CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+
+        // Order: priority desc (High first), then DateAdded asc. Matches
+        // "what to buy next" semantics — high-priority items the user
+        // added a while ago bubble to the top. Mobile UI can re-sort
+        // client-side if it wants other orderings.
+        var items = await db.WishlistItems
+            .AsNoTracking()
+            .OrderByDescending(w => w.Priority)
+            .ThenBy(w => w.DateAdded)
+            .Select(w => new WishlistItemSnapshot(
+                w.Id,
+                w.Title,
+                w.Author,
+                w.Priority.ToString(),
+                w.Isbn,
+                w.SeriesId,
+                w.SeriesOrder,
+                w.DateAdded))
+            .ToListAsync(ct);
+
+        return new WishlistSnapshot(
+            BuildInfo.ShortSha ?? "dev",
+            DateTime.UtcNow,
+            items);
+    }
+}

--- a/BookTracker.slnx
+++ b/BookTracker.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Project Path="BookTracker.Data/BookTracker.Data.csproj" />
+  <Project Path="BookTracker.Shared/BookTracker.Shared.csproj" />
   <Project Path="BookTracker.Tests/BookTracker.Tests.csproj" />
   <Project Path="BookTracker.Web/BookTracker.Web.csproj" />
 </Solution>


### PR DESCRIPTION
Mobile PR 1 of the .NET MAUI companion arc per
docs/mobile-app-design.md. The mobile app will reference this
contract directly. Web-only PR — no MAUI tooling needed yet.

New BookTracker.Shared class library (net10.0, no EF dep). DTOs:
- Catalog/CatalogSnapshot.cs — relocated CatalogSnapshot /
  BookSnapshot / AuthorSnapshot from
  BookTracker.Web.Services.Catalog. New SeriesSnapshot type and
  Series array on CatalogSnapshot. New SeriesId / SeriesOrder
  fields on BookSnapshot. Status field is now `string` instead of
  the BookStatus enum — keeps Shared free of the BookTracker.Data
  dependency. JsonStringEnumConverter on the Web side already
  serialises that way, so the wire format is unchanged.
- Wishlist/WishlistSnapshot.cs — new WishlistSnapshot wrapper +
  WishlistItemSnapshot. Priority is `string` for the same reason
  Status is.

CatalogSnapshotService:
- Uses the relocated DTOs from BookTracker.Shared.Catalog.
- Status now projected via .ToString() at the boundary.
- BookSnapshot.SeriesId / SeriesOrder come from the first Work
  by Work.Id — same convention as PrimaryAuthor for compendiums.
- Series list derived from the already-materialised booksRaw +
  IDs-Contains query, rather than chained
  Series.Where(s => s.Works.Any(w => w.Books.Any())) which EF
  Core 10.x can't translate cleanly through the M:N BookWork
  join table. Side effect: a series only attached via a non-first
  Work of a compendium won't surface here, acceptable v1 limit.

New WishlistSnapshotService + GET /api/wishlist-snapshot:
- Same shape as CatalogSnapshotService — slim, read-only,
  AsNoTracking. No current Web caller; ships as the contract MAUI
  will code against.
- Items ordered Priority desc then DateAdded asc ("what to buy
  next" semantics).

Naming-collision pre-fix: BookTracker.Web.Services.DuplicateDetectionService
declared its own BookSnapshot / AuthorSnapshot / WorkSnapshot /
EditionSnapshot records (different shapes — duplicate-candidate
views, not snapshots). Inside CatalogSnapshotService (in the
child namespace), C#'s namespace-walk resolution shadowed the
Shared types via these. Renamed to DuplicateBookView /
DuplicateAuthorView / DuplicateWorkView / DuplicateEditionView
across DuplicateDetectionService, the 4 *Side.razor consumers,
and DuplicatesViewModelTests. Names read better anyway.

Tests (404 total, +6):
- CatalogSnapshotServiceTests: existing BookStatus.Read assertion
  switched to "Read" string; two new tests for SeriesId/Order
  projection and Series-list filtering.
- New WishlistSnapshotServiceTests with 4 cases (empty wishlist,
  field projection + string priority, ordering, series link).

Auth gating: same Easy Auth platform-layer gate as every other
route in the app (SECURITY-AUDIT.md §SEC-006). Both endpoints
inherit it without code change.

Manual smoke (post-merge):
- curl /api/catalog-snapshot — should now include `series` array
  and per-book seriesId/seriesOrder, plus Status as
  "Read"/"Reading"/"Unread" string.
- curl /api/wishlist-snapshot — new endpoint, slim wishlist JSON.
