### PR TITLE
docs(mobile): AAD setup runbook for the mobile client (Mobile PR 2)

### DIFF
--- a/docs/mobile-app-design.md
+++ b/docs/mobile-app-design.md
@@ -56,12 +56,17 @@ API stays put. The mobile app is a pure consumer.
 
 ## Authentication
 
-App Service Easy Auth currently runs in cookie mode (browser flow, redirect to `/.auth/login/aad`). For the mobile client, switch the relevant API endpoints to **token-audience acceptance** so a bearer token from MSAL works:
+App Service Easy Auth runs in v2 mode and already accepts both browser cookie flows AND bearer-token API calls — the existing `validation.allowedAudiences` array (`['api://${authClientId}', authClientId]` in `infra/modules/app-config.bicep`) is what gates token validation. When MAUI's MSAL acquires a token for scope `api://<authClientId>/access_as_user`, the token's `aud` claim is `api://<authClientId>` — already in the allowed list. **No Bicep change is needed**, despite the original design's claim that `aadAcceptedTokenAudiences` had to be wired up — the existing config covers the mobile flow.
 
-1. **Register a new AAD app** for the mobile client (native / public client type) in the same tenant. Custom URI scheme redirect (`msauth.com.thelibrary.mobile://auth`) for iOS / Android.
-2. **Expose an API audience** on the existing BookTracker.Web AAD app registration (e.g. `api://<web-app-client-id>/access_as_user`).
-3. **Wire `aadAcceptedTokenAudiences`** in App Service Auth config so the API endpoints accept tokens issued for that audience.
-4. **MAUI uses MSAL.NET** (`Microsoft.Identity.Client` + `Microsoft.Maui.Authentication`) to do the interactive sign-in once, refresh-token from then on. Token cached in `SecureStorage` (Keychain / Keystore).
+What IS needed is one-time AAD-side setup (manual Azure Portal click-ops; runbook in [`infra/README.md`](../infra/README.md) under "Mobile companion — AAD setup"):
+
+1. **Expose the API scope** on the existing `Library-Patrons` Web app registration: Expose an API → confirm Application ID URI = `api://<authClientId>` → Add scope `access_as_user`.
+2. **Register a new AAD app** for the mobile client (Mobile and desktop applications, public client / native) in the same tenant. Redirect URI uses Android's custom URI scheme `msauth://com.thelibrary.mobile/<base64-signature-hash>` (signature hash is derived during PR 3 from the dev keystore).
+3. **Grant the mobile app reg API permission** to the Web app's `access_as_user` scope (delegated, with admin consent if the tenant requires it).
+
+Then in MAUI (PR 3+):
+
+4. **MSAL.NET** (`Microsoft.Identity.Client` + `Microsoft.Maui.Authentication`) does the interactive sign-in once via Chrome Custom Tabs, refresh-token from then on. Token cached in `SecureStorage` (Keystore on Android).
 5. **HttpClient** attaches `Authorization: Bearer <token>` per request; intercept 401 and re-trigger interactive sign-in.
 
 The browser flow on `/bookshop` keeps working through the same cookie-mode Easy Auth until that route is retired.
@@ -112,12 +117,12 @@ Sized for the work, not the calendar. Ship-as-you-go.
 - **Web-only PR.** No MAUI yet. The DTOs become the contract the mobile app codes against.
 - Size: M.
 
-### PR 2 — Easy Auth token-audience mode + AAD app reg for mobile
-- Bicep change to add `aadAcceptedTokenAudiences` for the mobile audience.
-- New AAD native-client app registration (manual one-time setup, document in `infra/README.md`).
-- Validate end-to-end: get a token via `az account get-access-token --resource <audience>` on the dev box, hit the API with it, see the response.
-- **Web-only PR.** No MAUI yet.
-- Size: S.
+### PR 2 — AAD setup runbook for the mobile client
+- Documentation-only PR. The Bicep work originally listed turned out to be unnecessary: the existing `validation.allowedAudiences` in `app-config.bicep` already accepts the audience MSAL produces for the API scope.
+- New "Mobile companion — AAD setup" section in `infra/README.md`: expose `access_as_user` scope on the Web app reg; register a new mobile-native-client app reg; wire delegated API permission; record the resulting clientIds.
+- Validate end-to-end: get a token via `az account get-access-token --resource api://<authClientId>` on the dev box, hit `/api/catalog-snapshot` with it, see the response.
+- **Web-only PR.** No MAUI, no infra change.
+- Size: XS (was S — scope shrank when the Bicep claim was disproven).
 
 ### PR 3 — `BookTracker.Mobile` MAUI project skeleton + auth flow
 - New project at repo root, **`net10.0-android` target only** (iOS deferred until / unless an Apple Developer account materialises).

--- a/infra/README.md
+++ b/infra/README.md
@@ -272,3 +272,66 @@ Not provisioned. See "Why eastus2" above and `TODO.md`.
 ### Local development
 
 For local dev, copy `appsettings.Example.json` → `appsettings.Development.json` and fill in the `AI:` section with the providers you want to test (using `:` instead of `__` as the separator). Local dev hits the Azure resources only if you supply real endpoints/keys; otherwise stub or skip.
+
+## Mobile companion — AAD setup
+
+Required before the BookTracker.Mobile (.NET MAUI) app can sign users in and call the API. See [`docs/mobile-app-design.md`](../docs/mobile-app-design.md) for the bigger picture; this section is the click-ops runbook.
+
+**Why this isn't fully automated by `deploy.ps1`:** native / public client app registrations have a couple of properties (the redirect URI scheme, the API permission grant) that need values which only exist later in the build pipeline — the Android signing-key SHA-1 hash for the `msauth://` redirect URI is derived from the dev keystore, which doesn't exist yet at infra-deploy time. Could automate the *initial* app reg, but you'd still come back to the portal once for the redirect URI. One trip is fine.
+
+**Note on Bicep:** the existing `validation.allowedAudiences` in `app-config.bicep` (`['api://${authClientId}', authClientId]`) already accepts the audience MSAL produces when acquiring tokens for the API scope below. No infra change is needed for this PR.
+
+### Step 1 — Expose the API scope on the existing `Library-Patrons` app reg
+
+Azure Portal → Microsoft Entra ID → App registrations → `Library-Patrons` → **Expose an API**:
+
+1. Confirm the **Application ID URI** is set to `api://<authClientId>` (where `<authClientId>` is the same App (client) ID used for `-authClientId` in `deploy.ps1`). It usually is — `validation.allowedAudiences` references this exact form.
+2. **Add a scope:**
+   - Scope name: `access_as_user`
+   - Who can consent: **Admins and users**
+   - Admin consent display name: `Access BookTracker as the signed-in user`
+   - Admin consent description: `Allows the mobile companion app to call the BookTracker API on behalf of the signed-in user.`
+   - User consent display name: `Access BookTracker on your behalf`
+   - User consent description: `Allows the BookTracker mobile app to call the BookTracker API as you.`
+   - State: **Enabled**
+3. Save. Full scope identifier becomes `api://<authClientId>/access_as_user` — record this; MAUI will request it.
+
+### Step 2 — Register the mobile native-client app
+
+Azure Portal → Microsoft Entra ID → App registrations → **New registration**:
+
+- Name: `BookTracker Mobile`
+- Supported account types: **Single tenant** (matches `Library-Patrons`)
+- Redirect URI: leave blank for now — set it in step 4 once the Android signing-key hash is known.
+
+After creation, record the **Application (client) ID** — this is the `mobileClientId` MAUI's `PublicClientApplicationBuilder.Create(...)` will use.
+
+### Step 3 — Grant API permission
+
+Still on the new `BookTracker Mobile` app reg, **API permissions** → **Add a permission** → **My APIs** → `Library-Patrons` → **Delegated permissions** → tick `access_as_user` → **Add permissions**.
+
+If your tenant requires admin consent for delegated scopes, click **Grant admin consent for `<tenant>`**.
+
+### Step 4 — Redirect URI (deferred to PR 3)
+
+The native redirect URI is `msauth://com.thelibrary.mobile/<base64-signature-hash>`. The signature hash is computed from the Android keystore used to sign the APK during `dotnet build -t:Run -f net10.0-android`, which doesn't exist yet. PR 3 generates the keystore, prints the hash, and Drew adds the URI to the mobile app reg's **Authentication** → **Mobile and desktop applications** platform.
+
+### Step 5 — Validate end-to-end (smoke test)
+
+Once steps 1–3 are done, you can verify the API accepts a bearer token from a non-browser caller without writing any MAUI code yet:
+
+```powershell
+# Acquire an access token for the API scope. The first run prompts
+# for sign-in via az's interactive flow; later runs use cached creds.
+$token = az account get-access-token `
+    --resource "api://<authClientId>" `
+    --query accessToken -o tsv
+
+# Call the API. Easy Auth validates the bearer; if everything is
+# wired correctly you get the JSON snapshot.
+curl -H "Authorization: Bearer $token" `
+    https://<app>.azurewebsites.net/api/catalog-snapshot | ConvertFrom-Json `
+    | Select-Object Version, SyncedAt, @{n='Books';e={$_.Books.Count}}
+```
+
+A 401 means the token's `aud` doesn't match `validation.allowedAudiences` — confirm step 1's Application ID URI matches `api://<authClientId>`. A 200 with valid JSON means the Easy Auth path is ready for MAUI.


### PR DESCRIPTION
Documentation-only — the Bicep change originally listed in the
mobile-app-design doc turned out to be unnecessary. The existing
`validation.allowedAudiences` in `infra/modules/app-config.bicep`
(`['api://${authClientId}', authClientId]`) already accepts the
audience MSAL produces when acquiring tokens for the API scope
the mobile client will request. Re-checking against the App
Service Auth schema and MSAL's audience semantics: when MAUI
acquires a token for `api://<authClientId>/access_as_user`, the
resulting token's `aud` claim is `api://<authClientId>` — already
in the allowed list. No infra change.

What this PR delivers:
- `infra/README.md` new section "Mobile companion — AAD setup":
  - Why this isn't fully automated by deploy.ps1 (Android signing-
    key SHA-1 hash for the redirect URI doesn't exist until
    PR 3 generates the keystore).
  - Step 1 — expose the `access_as_user` scope on the existing
    Library-Patrons app reg.
  - Step 2 — register the mobile native-client app reg.
  - Step 3 — grant delegated API permission.
  - Step 4 — redirect URI (deferred to PR 3 once the dev keystore
    + signature hash are known).
  - Step 5 — end-to-end smoke: az account get-access-token →
    curl /api/catalog-snapshot with the bearer.

- `docs/mobile-app-design.md` corrected:
  - Auth section now reflects that no Bicep change is needed and
    points at the runbook.
  - PR 2 line in the breakdown updated to "AAD setup runbook" +
    sized XS (was S — scope shrank when the Bicep claim was
    disproven).

Caveat: I haven't actually walked the runbook on the live
tenant. Drew will validate the click-ops next time he sits down
to do the AAD work; if any portal labels have drifted or the
admin-consent prompt looks different, fold the corrections back
into infra/README.md before PR 3 starts.
