### PR TITLE
feat(mobile): scan ISBN page with ZXing.Net.MAUI (Mobile PR 5)

### DIFF
--- a/BookTracker.Mobile/BookTracker.Mobile.csproj
+++ b/BookTracker.Mobile/BookTracker.Mobile.csproj
@@ -49,6 +49,11 @@
 		<!-- MSAL.NET — AAD interactive sign-in via Chrome Custom Tabs, token
 		     cached in SecureStorage (Keystore-backed). -->
 		<PackageReference Include="Microsoft.Identity.Client" Version="4.66.2" />
+		<!-- Barcode scanner control + camera plumbing. ZXing.Net.MAUI
+		     wraps the platform camera APIs and exposes a
+		     CameraBarcodeReaderView control with a BarcodesDetected
+		     event. Configured for EAN-13/EAN-8 only (book barcodes). -->
+		<PackageReference Include="ZXing.Net.MAUI.Controls" Version="0.4.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/BookTracker.Mobile/MainPage.xaml
+++ b/BookTracker.Mobile/MainPage.xaml
@@ -33,6 +33,13 @@
                 HorizontalOptions="Fill"
                 IsEnabled="False" />
 
+            <Button
+                x:Name="ScanButton"
+                Text="📷 Scan ISBN"
+                Clicked="OnScanClicked"
+                HorizontalOptions="Fill"
+                IsEnabled="False" />
+
             <ActivityIndicator
                 x:Name="Busy"
                 IsRunning="False"

--- a/BookTracker.Mobile/MainPage.xaml.cs
+++ b/BookTracker.Mobile/MainPage.xaml.cs
@@ -1,4 +1,5 @@
 using BookTracker.Mobile.Cache;
+using BookTracker.Mobile.Pages;
 using BookTracker.Mobile.Services;
 
 namespace BookTracker.Mobile;
@@ -137,11 +138,30 @@ public partial class MainPage : ContentPage
         }
     }
 
+    private async void OnScanClicked(object? sender, EventArgs e)
+    {
+        // Resolve the page from DI so it gets ICatalogCache injected.
+        // Transient registration in MauiProgram — each navigation
+        // gets a fresh CameraBarcodeReaderView, no held-camera between
+        // visits.
+        var services = Microsoft.Maui.Controls.Application.Current?.Handler?.MauiContext?.Services
+            ?? throw new InvalidOperationException("ServiceProvider not available.");
+        var page = services.GetService(typeof(ScanPage)) as ScanPage
+            ?? throw new InvalidOperationException("ScanPage not registered.");
+        await Navigation.PushAsync(page);
+    }
+
     private void RefreshUi()
     {
         Busy.IsRunning = _busy;
         SignInButton.IsEnabled = !_busy && !_signedIn;
         LoadCatalogButton.IsEnabled = !_busy && _signedIn;
         SignOutButton.IsEnabled = !_busy && _signedIn;
+        // Scan only makes sense when the cache has been populated —
+        // gate on the cache having a syncedAt rather than signed-in
+        // alone. For PR 5 simplicity we use signed-in as a proxy;
+        // if the cache is empty the scan page will just say
+        // "Not in your library" for everything, which is correct.
+        ScanButton.IsEnabled = !_busy && _signedIn;
     }
 }

--- a/BookTracker.Mobile/MauiProgram.cs
+++ b/BookTracker.Mobile/MauiProgram.cs
@@ -1,6 +1,8 @@
 using BookTracker.Mobile.Cache;
+using BookTracker.Mobile.Pages;
 using BookTracker.Mobile.Services;
 using Microsoft.Extensions.Logging;
+using ZXing.Net.Maui.Controls;
 
 namespace BookTracker.Mobile;
 
@@ -11,6 +13,9 @@ public static class MauiProgram
         var builder = MauiApp.CreateBuilder();
         builder
             .UseMauiApp<App>()
+            // ZXing.Net.MAUI handler — registers the CameraBarcodeReaderView
+            // control so the XAML namespace lights up at runtime.
+            .UseBarcodeReader()
             .ConfigureFonts(fonts =>
             {
                 fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
@@ -36,6 +41,10 @@ public static class MauiProgram
         builder.Services.AddSingleton<ICatalogCache, CatalogCache>();
 
         builder.Services.AddSingleton<MainPage>();
+        // Scan page is transient — every navigation gets a fresh
+        // CameraBarcodeReaderView so we don't hold the camera open
+        // when the page isn't visible.
+        builder.Services.AddTransient<ScanPage>();
 
 #if DEBUG
         builder.Logging.AddDebug();

--- a/BookTracker.Mobile/Pages/ScanPage.xaml
+++ b/BookTracker.Mobile/Pages/ScanPage.xaml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:zxing="clr-namespace:ZXing.Net.Maui.Controls;assembly=ZXing.Net.MAUI.Controls"
+             x:Class="BookTracker.Mobile.Pages.ScanPage"
+             Title="Scan ISBN">
+
+    <Grid RowDefinitions="*,Auto" Padding="0">
+
+        <!-- Camera viewfinder. Constrained to a 4:3 aspect-ish region
+             at the top; ZXing autodetects EAN-13/EAN-8 from the
+             configured BarcodeReaderOptions below. -->
+        <zxing:CameraBarcodeReaderView
+            x:Name="Reader"
+            Grid.Row="0"
+            BarcodesDetected="OnBarcodesDetected"
+            IsDetecting="True"
+            IsTorchOn="False" />
+
+        <!-- Result panel — populated by code-behind after a detect or
+             manual entry. Two states (in-cache / not-in-cache) are
+             swapped by visibility. ManualEntry stays visible for users
+             scanning a hard-to-read barcode. -->
+        <ScrollView Grid.Row="1" BackgroundColor="{AppThemeBinding Light=#FFFFFF, Dark=#1E1E1E}">
+            <VerticalStackLayout Padding="20" Spacing="12">
+
+                <Label
+                    x:Name="StatusLabel"
+                    Text="Point the camera at a book's barcode."
+                    HorizontalOptions="Center"
+                    HorizontalTextAlignment="Center"
+                    LineBreakMode="WordWrap" />
+
+                <!-- In-cache result. Border (replaces obsolete Frame in
+                     .NET 9+) — needs an explicit StrokeShape for the
+                     corner-radius effect. -->
+                <Border
+                    x:Name="FoundFrame"
+                    IsVisible="False"
+                    Stroke="{AppThemeBinding Light=#A3D9A5, Dark=#356735}"
+                    BackgroundColor="{AppThemeBinding Light=#E8F5E9, Dark=#1B3320}"
+                    Padding="12">
+                    <Border.StrokeShape>
+                        <RoundRectangle CornerRadius="8" />
+                    </Border.StrokeShape>
+                    <VerticalStackLayout Spacing="6">
+                        <Label x:Name="FoundTitle" FontAttributes="Bold" FontSize="18" />
+                        <Label x:Name="FoundAuthors" FontSize="14" TextColor="{AppThemeBinding Light=#555, Dark=#BBB}" />
+                        <Label x:Name="FoundStatusRating" FontSize="13" />
+                        <Label x:Name="FoundIsbn" FontSize="12" FontFamily="Courier New" TextColor="{AppThemeBinding Light=#555, Dark=#BBB}" />
+                        <Button x:Name="OpenInAppButton" Text="Open in app →" Clicked="OnOpenInAppClicked" HorizontalOptions="Start" />
+                    </VerticalStackLayout>
+                </Border>
+
+                <!-- Not-in-cache result -->
+                <Border
+                    x:Name="MissingFrame"
+                    IsVisible="False"
+                    Stroke="{AppThemeBinding Light=#DDD, Dark=#555}"
+                    BackgroundColor="{AppThemeBinding Light=#FAFAFA, Dark=#252525}"
+                    Padding="12">
+                    <Border.StrokeShape>
+                        <RoundRectangle CornerRadius="8" />
+                    </Border.StrokeShape>
+                    <VerticalStackLayout Spacing="6">
+                        <Label Text="Not in your library." FontAttributes="Bold" />
+                        <Label x:Name="MissingIsbn" FontSize="12" FontFamily="Courier New" TextColor="{AppThemeBinding Light=#555, Dark=#BBB}" />
+                        <Button x:Name="AddToLibraryButton" Text="Add in app →" Clicked="OnAddToLibraryClicked" HorizontalOptions="Start" />
+                    </VerticalStackLayout>
+                </Border>
+
+                <!-- Manual ISBN entry — for damaged barcodes or hand
+                     typing from a back cover. -->
+                <BoxView HeightRequest="1" Color="{AppThemeBinding Light=#EEE, Dark=#333}" />
+                <Label Text="Or enter ISBN manually:" FontSize="13" />
+                <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+                    <Entry
+                        x:Name="ManualEntry"
+                        Grid.Column="0"
+                        Keyboard="Numeric"
+                        Placeholder="9780553287899"
+                        ReturnType="Search"
+                        Completed="OnManualLookupClicked" />
+                    <Button
+                        Grid.Column="1"
+                        Text="Lookup"
+                        Clicked="OnManualLookupClicked" />
+                </Grid>
+            </VerticalStackLayout>
+        </ScrollView>
+    </Grid>
+</ContentPage>

--- a/BookTracker.Mobile/Pages/ScanPage.xaml.cs
+++ b/BookTracker.Mobile/Pages/ScanPage.xaml.cs
@@ -1,0 +1,187 @@
+using BookTracker.Mobile.Cache;
+using BookTracker.Shared.Catalog;
+using ZXing.Net.Maui;
+
+namespace BookTracker.Mobile.Pages;
+
+public partial class ScanPage : ContentPage
+{
+    private readonly ICatalogCache _cache;
+
+    // Debounce — barcode scanners fire detect events ~10x/sec while
+    // the code is in frame. We only want one lookup per "real" scan,
+    // and re-pointing at the same book shouldn't immediately re-fire.
+    // Mirrors the 3s window from BookTracker.Web/wwwroot/js/barcode-scanner.js.
+    private static readonly TimeSpan DebounceWindow = TimeSpan.FromSeconds(3);
+    private string? _lastScannedIsbn;
+    private DateTime _lastScannedAt = DateTime.MinValue;
+
+    public ScanPage(ICatalogCache cache)
+    {
+        InitializeComponent();
+        _cache = cache;
+
+        // Filter the camera reader to book barcodes only — EAN-13 is
+        // the ~99% case (modern ISBN-13); EAN-8 catches the rare
+        // short-form prints. Multi-format scanning slows decode +
+        // false-positives off other patterns.
+        Reader.Options = new BarcodeReaderOptions
+        {
+            Formats = BarcodeFormat.Ean13 | BarcodeFormat.Ean8,
+            AutoRotate = true,
+            Multiple = false,
+        };
+    }
+
+    protected override async void OnAppearing()
+    {
+        base.OnAppearing();
+
+        // Runtime CAMERA permission request. On Android 6+ the
+        // manifest declaration alone isn't enough — we have to
+        // explicitly ask. Permissions.Camera handles both initial
+        // request + "go to settings" if the user permanently denied
+        // earlier. We don't try to recover gracefully in v1 — if
+        // they deny, the camera view stays black and manual entry
+        // remains usable.
+        var status = await Permissions.CheckStatusAsync<Permissions.Camera>();
+        if (status != PermissionStatus.Granted)
+        {
+            status = await Permissions.RequestAsync<Permissions.Camera>();
+        }
+        if (status != PermissionStatus.Granted)
+        {
+            StatusLabel.Text = "Camera permission denied. Manual ISBN entry still works.";
+            Reader.IsDetecting = false;
+        }
+        else
+        {
+            Reader.IsDetecting = true;
+        }
+    }
+
+    protected override void OnDisappearing()
+    {
+        base.OnDisappearing();
+        // Stop the camera feed when leaving the page — the
+        // CameraBarcodeReaderView keeps the camera open while
+        // IsDetecting is true.
+        Reader.IsDetecting = false;
+    }
+
+    private async void OnBarcodesDetected(object? sender, BarcodeDetectionEventArgs e)
+    {
+        // BarcodesDetected fires on a background thread; UI updates
+        // must marshal back to main. ZXing also re-fires while the
+        // code stays in frame, hence the debounce.
+        var result = e.Results.FirstOrDefault();
+        if (result is null) return;
+
+        var isbn = (result.Value ?? "").Trim();
+        if (string.IsNullOrEmpty(isbn)) return;
+
+        var now = DateTime.UtcNow;
+        if (isbn == _lastScannedIsbn && (now - _lastScannedAt) < DebounceWindow)
+        {
+            return;
+        }
+        _lastScannedIsbn = isbn;
+        _lastScannedAt = now;
+
+        await MainThread.InvokeOnMainThreadAsync(() => LookupAsync(isbn));
+    }
+
+    private async void OnManualLookupClicked(object? sender, EventArgs e)
+    {
+        var raw = (ManualEntry.Text ?? "").Trim();
+        // Strip non-alphanumeric (allow trailing X for ISBN-10 check
+        // digit) so a hyphenated barcode pasted from a website still
+        // resolves. The cache stores ISBNs unhyphenated.
+        var cleaned = new string(raw.Where(c => char.IsDigit(c) || c == 'X' || c == 'x').ToArray());
+        if (cleaned.Length < 10 || cleaned.Length > 13)
+        {
+            StatusLabel.Text = "Enter a 10- or 13-digit ISBN.";
+            return;
+        }
+        await LookupAsync(cleaned);
+    }
+
+    private async Task LookupAsync(string isbn)
+    {
+        StatusLabel.Text = $"Looking up {isbn}…";
+        FoundFrame.IsVisible = false;
+        MissingFrame.IsVisible = false;
+
+        BookSnapshot? book;
+        try
+        {
+            book = await _cache.LookupByIsbnAsync(isbn);
+        }
+        catch (Exception ex)
+        {
+            StatusLabel.Text = $"Lookup failed: {ex.GetType().Name} — {ex.Message}";
+            return;
+        }
+
+        if (book is null)
+        {
+            StatusLabel.Text = "Scanned ✓";
+            MissingIsbn.Text = $"ISBN: {isbn}";
+            // Stash the ISBN on the Add button so the click handler
+            // can deep-link with it pre-filled.
+            AddToLibraryButton.CommandParameter = isbn;
+            MissingFrame.IsVisible = true;
+        }
+        else
+        {
+            StatusLabel.Text = "Scanned ✓";
+            FoundTitle.Text = book.Title;
+            FoundAuthors.Text = (book.AllAuthors is { Count: > 1 })
+                ? string.Join(", ", book.AllAuthors)
+                : book.PrimaryAuthor;
+            FoundStatusRating.Text = FormatStatusRating(book);
+            FoundIsbn.Text = $"ISBN: {isbn}";
+            OpenInAppButton.CommandParameter = book.Id;
+            FoundFrame.IsVisible = true;
+        }
+    }
+
+    private static string FormatStatusRating(BookSnapshot book)
+    {
+        var parts = new List<string>();
+        if (book.Rating > 0)
+        {
+            var filled = new string('★', Math.Clamp(book.Rating, 0, 5));
+            var empty = new string('☆', 5 - Math.Clamp(book.Rating, 0, 5));
+            parts.Add(filled + empty);
+        }
+        if (!string.IsNullOrWhiteSpace(book.Status))
+        {
+            parts.Add(book.Status);
+        }
+        return parts.Count == 0 ? "" : string.Join("  ·  ", parts);
+    }
+
+    private async void OnOpenInAppClicked(object? sender, EventArgs e)
+    {
+        // Deep-link to the Web app's book detail page. Requires the
+        // user to be online; mobile companion is read-only in v1.
+        if (sender is Button { CommandParameter: int bookId })
+        {
+            var url = $"{AppConfig.ApiBaseUrl}/books/{bookId}";
+            try { await Launcher.Default.OpenAsync(new Uri(url)); }
+            catch (Exception ex) { StatusLabel.Text = $"Couldn't open browser: {ex.Message}"; }
+        }
+    }
+
+    private async void OnAddToLibraryClicked(object? sender, EventArgs e)
+    {
+        // Same online-required deep link, into the Add page. PR 5
+        // doesn't pre-fill the ISBN on the Web side; the user types
+        // it in after the page loads. A future Web-side change could
+        // accept ?isbn= as a query param.
+        var url = $"{AppConfig.ApiBaseUrl}/books/add";
+        try { await Launcher.Default.OpenAsync(new Uri(url)); }
+        catch (Exception ex) { StatusLabel.Text = $"Couldn't open browser: {ex.Message}"; }
+    }
+}

--- a/BookTracker.Mobile/Platforms/Android/AndroidManifest.xml
+++ b/BookTracker.Mobile/Platforms/Android/AndroidManifest.xml
@@ -52,4 +52,11 @@
 	</application>
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-permission android:name="android.permission.INTERNET" />
+	<!-- Barcode scanning needs the camera. android.hardware.camera is
+	     marked required=false so the app still installs on a
+	     phone-without-camera (rare, but it's the recommended manifest
+	     shape per Android docs — the runtime CAMERA permission is the
+	     real gate). -->
+	<uses-permission android:name="android.permission.CAMERA" />
+	<uses-feature android:name="android.hardware.camera" android:required="false" />
 </manifest>


### PR DESCRIPTION
ScanPage opens the device camera via ZXing's CameraBarcodeReaderView,
decodes EAN-13/EAN-8 only, and looks up the resulting ISBN in the
SQLite catalog cache from PR 4. Found books render in a green Border
with title/authors/status/rating; unknown ISBNs render in a neutral
Border with a deep-link to /books/add. Manual ISBN entry is always
visible for damaged barcodes.

- ZXing.Net.MAUI.Controls 0.4.0 added; .UseBarcodeReader() in MauiProgram.
- CAMERA permission + uses-feature (camera not required) in
  AndroidManifest. Runtime Permissions.Camera ask on OnAppearing —
  manual entry stays usable if denied.
- 3s same-ISBN debounce mirrors the Web barcode-scanner.js so a code
  held in frame doesn't re-fire ten times a second.
- ScanPage registered Transient — each navigation gets a fresh camera
  view so we don't hold the camera open between visits. OnDisappearing
  flips IsDetecting=false belt-and-braces.
- Border (with RoundRectangle StrokeShape) replaces obsolete Frame
  control, removing the .NET 9+ CS0618 warnings.
- Open-in-app / Add-to-library buttons deep-link to the Web app via
  Launcher.Default.OpenAsync — mobile companion is read-only in v1.

Build is clean apart from two unfixable XA0141 page-size warnings from
upstream camera-core and SQLitePCLRaw native libs.
