### PR TITLE
feat(mobile): BookTracker app icon + splash (TODO #31)

### DIFF
--- a/BookTracker.Mobile/BookTracker.Mobile.csproj
+++ b/BookTracker.Mobile/BookTracker.Mobile.csproj
@@ -35,8 +35,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<MauiIcon Include="Resources\AppIcon\appicon.svg" ForegroundFile="Resources\AppIcon\appiconfg.svg" Color="#512BD4" />
-		<MauiSplashScreen Include="Resources\Splash\splash.svg" Color="#512BD4" BaseSize="128,128" />
+		<MauiIcon Include="Resources\AppIcon\appicon.svg" ForegroundFile="Resources\AppIcon\appiconfg.svg" Color="#6750A4" />
+		<MauiSplashScreen Include="Resources\Splash\splash.svg" Color="#6750A4" BaseSize="128,128" />
 		<MauiImage Include="Resources\Images\*" />
 		<MauiFont Include="Resources\Fonts\*" />
 		<MauiAsset Include="Resources\Raw\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)" />

--- a/BookTracker.Mobile/Resources/AppIcon/appicon.svg
+++ b/BookTracker.Mobile/Resources/AppIcon/appicon.svg
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg width="456" height="456" viewBox="0 0 456 456" version="1.1" xmlns="http://www.w3.org/2000/svg">
-    <rect x="0" y="0" width="456" height="456" fill="#512BD4" />
+<!--
+  BookTracker app icon — background layer.
+
+  Adaptive-icon background for Android. Solid purple (#6750A4) matching
+  BookTracker.Web's PWA icon (wwwroot/icons/icon.svg) so the install
+  transition from the Web install banner to the native app feels
+  visually continuous. The foreground design (spine + text lines) lives
+  in appiconfg.svg and sits centred in the Android safe zone on top of
+  this background.
+-->
+<svg width="456" height="456" viewBox="0 0 456 456" xmlns="http://www.w3.org/2000/svg">
+    <rect x="0" y="0" width="456" height="456" fill="#6750A4" />
 </svg>

--- a/BookTracker.Mobile/Resources/AppIcon/appiconfg.svg
+++ b/BookTracker.Mobile/Resources/AppIcon/appiconfg.svg
@@ -1,8 +1,24 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg width="456" height="456" viewBox="0 0 456 456" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
-    <path d="m 105.50037,281.60863 c -2.70293,0 -5.00091,-0.90042 -6.893127,-2.70209 -1.892214,-1.84778 -2.837901,-4.04181 -2.837901,-6.58209 0,-2.58722 0.945687,-4.80389 2.837901,-6.65167 1.892217,-1.84778 4.190197,-2.77167 6.893127,-2.77167 2.74819,0 5.06798,0.92389 6.96019,2.77167 1.93749,1.84778 2.90581,4.06445 2.90581,6.65167 0,2.54028 -0.96832,4.73431 -2.90581,6.58209 -1.89221,1.80167 -4.212,2.70209 -6.96019,2.70209 z" style="fill:#ffffff;fill-rule:nonzero;stroke-width:0.838376" />
-    <path d="M 213.56111,280.08446 H 195.99044 L 149.69953,207.0544 c -1.17121,-1.84778 -2.14037,-3.76515 -2.90581,-5.75126 h -0.40578 c 0.36051,2.12528 0.54076,6.67515 0.54076,13.6496 v 65.13172 h -15.54349 v -99.36009 h 18.71925 l 44.7374,71.29798 c 1.89222,2.95695 3.1087,4.98917 3.64945,6.09751 h 0.26996 c -0.45021,-2.6325 -0.67573,-7.09015 -0.67573,-13.37293 v -64.02256 h 15.47557 z" style="fill:#ffffff;fill-rule:nonzero;stroke-width:0.838376" />
-    <path d="m 289.25134,280.08446 h -54.40052 v -99.36009 h 52.23835 v 13.99669 h -36.15411 v 28.13085 h 33.31621 v 13.9271 h -33.31621 v 29.37835 h 38.31628 z" style="fill:#ffffff;fill-rule:nonzero;stroke-width:0.838376" />
-    <path d="M 366.56466,194.72106 H 338.7222 v 85.3634 h -16.08423 v -85.3634 h -27.77455 v -13.99669 h 71.70124 z" style="fill:#ffffff;fill-rule:nonzero;stroke-width:0.838376" />
+<!--
+  BookTracker app icon — foreground layer.
+
+  Mirrors the PWA's BookTracker.Web/wwwroot/icons/icon.svg design:
+  a darker-purple book spine block on the left, three white "text
+  line" stripes representing book pages. Sits on top of the solid
+  purple background in appicon.svg.
+
+  The original PWA design fills a 512x512 viewBox edge-to-edge. For
+  Android adaptive icons we need the visible content to live within
+  the inner ~66% safe zone (otherwise launcher masks crop it on round
+  / squircle shapes). The nested 0-512 viewBox is mapped into a
+  300x300 region centred at (78,78)..(378,378), scaling the design
+  down to ~58% so it sits comfortably inside the safe zone.
+-->
+<svg width="456" height="456" viewBox="0 0 456 456" xmlns="http://www.w3.org/2000/svg">
+    <svg x="78" y="78" width="300" height="300" viewBox="0 0 512 512">
+        <rect x="96" y="72" width="96" height="368" fill="#4F378B" />
+        <line x1="208" y1="170" x2="400" y2="170" stroke="#ffffff" stroke-width="14" stroke-linecap="round" />
+        <line x1="208" y1="250" x2="400" y2="250" stroke="#ffffff" stroke-width="14" stroke-linecap="round" />
+        <line x1="208" y1="330" x2="348" y2="330" stroke="#ffffff" stroke-width="14" stroke-linecap="round" />
+    </svg>
 </svg>

--- a/BookTracker.Mobile/Resources/Splash/splash.svg
+++ b/BookTracker.Mobile/Resources/Splash/splash.svg
@@ -1,8 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg width="456" height="456" viewBox="0 0 456 456" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
-    <path d="m 105.50037,281.60863 c -2.70293,0 -5.00091,-0.90042 -6.893127,-2.70209 -1.892214,-1.84778 -2.837901,-4.04181 -2.837901,-6.58209 0,-2.58722 0.945687,-4.80389 2.837901,-6.65167 1.892217,-1.84778 4.190197,-2.77167 6.893127,-2.77167 2.74819,0 5.06798,0.92389 6.96019,2.77167 1.93749,1.84778 2.90581,4.06445 2.90581,6.65167 0,2.54028 -0.96832,4.73431 -2.90581,6.58209 -1.89221,1.80167 -4.212,2.70209 -6.96019,2.70209 z" style="fill:#ffffff;fill-rule:nonzero;stroke-width:0.838376" />
-    <path d="M 213.56111,280.08446 H 195.99044 L 149.69953,207.0544 c -1.17121,-1.84778 -2.14037,-3.76515 -2.90581,-5.75126 h -0.40578 c 0.36051,2.12528 0.54076,6.67515 0.54076,13.6496 v 65.13172 h -15.54349 v -99.36009 h 18.71925 l 44.7374,71.29798 c 1.89222,2.95695 3.1087,4.98917 3.64945,6.09751 h 0.26996 c -0.45021,-2.6325 -0.67573,-7.09015 -0.67573,-13.37293 v -64.02256 h 15.47557 z" style="fill:#ffffff;fill-rule:nonzero;stroke-width:0.838376" />
-    <path d="m 289.25134,280.08446 h -54.40052 v -99.36009 h 52.23835 v 13.99669 h -36.15411 v 28.13085 h 33.31621 v 13.9271 h -33.31621 v 29.37835 h 38.31628 z" style="fill:#ffffff;fill-rule:nonzero;stroke-width:0.838376" />
-    <path d="M 366.56466,194.72106 H 338.7222 v 85.3634 h -16.08423 v -85.3634 h -27.77455 v -13.99669 h 71.70124 z" style="fill:#ffffff;fill-rule:nonzero;stroke-width:0.838376" />
+<!--
+  BookTracker splash screen.
+
+  The same icon design used in the AppIcon foreground (book spine +
+  text lines), rendered at original 512x512 scale. The MauiSplashScreen
+  element in the csproj sets Color="#6750A4" so the surrounding screen
+  fill matches the icon background — the splash visually echoes the
+  launcher icon while the app starts up. Splash isn't safe-zone
+  constrained, so the content can use the full canvas.
+-->
+<svg width="512" height="512" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+    <rect x="96" y="72" width="96" height="368" fill="#4F378B" />
+    <line x1="208" y1="170" x2="400" y2="170" stroke="#ffffff" stroke-width="14" stroke-linecap="round" />
+    <line x1="208" y1="250" x2="400" y2="250" stroke="#ffffff" stroke-width="14" stroke-linecap="round" />
+    <line x1="208" y1="330" x2="348" y2="330" stroke="#ffffff" stroke-width="14" stroke-linecap="round" />
 </svg>


### PR DESCRIPTION
Replaces the default MAUI placeholder icon ("NET" on solid #512BD4)
with the BookTracker design from the PWA (BookTracker.Web/wwwroot/
icons/icon.svg): purple book with darker spine + three white text
lines. Visual continuity with the PWA install for users who have
both.

- appicon.svg (background): solid #6750A4 matching the PWA primary.
- appiconfg.svg (foreground): spine + text lines from the PWA design,
  scaled to ~58% and centred in the Android adaptive-icon safe zone
  (inner 300x300 of the 456x456 canvas) via a nested viewBox. Keeps
  the content inside the round/squircle launcher masks without
  redesigning the glyph.
- splash.svg: same spine + lines at full 512 scale; MauiSplashScreen
  Color matches the icon background so the loading screen reads as
  the icon enlarged.
- csproj MauiIcon + MauiSplashScreen Color updated to #6750A4.

A future redesign for tighter brand alignment (leather/brass/parchment
palette from MudBlazor theme) is captured in the TODO; this PR is
visual-continuity-with-PWA, not full rebrand.
