### PR TITLE
feat(mobile): home page polish — leather palette + state visibility (TODO #32)

### DIFF
--- a/BookTracker.Mobile/MainPage.xaml
+++ b/BookTracker.Mobile/MainPage.xaml
@@ -2,63 +2,152 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="BookTracker.Mobile.MainPage"
-             Title="BookTracker">
+             NavigationPage.HasNavigationBar="False"
+             BackgroundColor="#FAF6EC">
 
-    <!-- PR 3 minimal proof-of-life UI: sign in, call the API, render
-         the result. Subsequent PRs swap this for the real Scan +
-         Author lookup pages. -->
-    <ScrollView>
-        <VerticalStackLayout Padding="30,30" Spacing="20">
+    <!-- BookTracker library palette — mirrored from
+         BookTracker.Web/Theme/BookTrackerTheme.cs so the mobile companion
+         reads as the same product as the Web app.
 
-            <Label
-                Text="BookTracker mobile"
-                Style="{StaticResource Headline}"
-                HorizontalOptions="Center" />
+           leather   #6B2737  primary actions
+           brass     #A67B3A  accent borders + primary in-bookshop CTA
+           parchment #FAF6EC  page background
+           surface   #F2EADB  card / panel background
+           espresso  #3E2723  header banner
+           ink       #2C2416  primary text
+           faded ink #6B5D4A  secondary text
 
-            <Label
-                Text="Offline-capable companion app"
-                Style="{StaticResource SubHeadline}"
-                HorizontalOptions="Center" />
+         Root page hides the system nav bar (NavigationPage.HasNavigationBar)
+         because this is the entry surface — nothing to navigate back from.
+         ScanPage keeps its nav bar so the back button is visible there. -->
 
-            <Button
-                x:Name="SignInButton"
-                Text="Sign in"
-                Clicked="OnSignInClicked"
-                HorizontalOptions="Fill" />
+    <Grid RowDefinitions="Auto,*">
 
-            <Button
-                x:Name="LoadCatalogButton"
-                Text="Load catalog snapshot"
-                Clicked="OnLoadCatalogClicked"
-                HorizontalOptions="Fill"
-                IsEnabled="False" />
-
-            <Button
-                x:Name="ScanButton"
-                Text="📷 Scan ISBN"
-                Clicked="OnScanClicked"
-                HorizontalOptions="Fill"
-                IsEnabled="False" />
-
-            <ActivityIndicator
-                x:Name="Busy"
-                IsRunning="False"
-                HorizontalOptions="Center" />
-
-            <Label
-                x:Name="StatusLabel"
-                Text="Not signed in."
-                HorizontalOptions="Center"
-                LineBreakMode="WordWrap" />
-
-            <Button
-                x:Name="SignOutButton"
-                Text="Sign out"
-                Clicked="OnSignOutClicked"
-                HorizontalOptions="Fill"
-                IsEnabled="False" />
-
+        <!-- Espresso header banner. Replaces the previous in-content
+             Headline/SubHeadline pair so the brand chrome is anchored to
+             a fixed bar rather than flowing inside the scroll view. -->
+        <VerticalStackLayout Grid.Row="0"
+                             BackgroundColor="#3E2723"
+                             Padding="24,20,24,18"
+                             Spacing="2">
+            <Label Text="BookTracker"
+                   FontSize="24"
+                   FontAttributes="Bold"
+                   TextColor="#F2EADB" />
+            <Label Text="Offline-capable companion"
+                   FontSize="13"
+                   TextColor="#A67B3A" />
         </VerticalStackLayout>
-    </ScrollView>
+
+        <ScrollView Grid.Row="1">
+            <VerticalStackLayout Padding="20,24" Spacing="14">
+
+                <!-- Sign in — primary CTA when signed out. -->
+                <Button x:Name="SignInButton"
+                        Text="Sign in"
+                        Clicked="OnSignInClicked"
+                        HeightRequest="56"
+                        BackgroundColor="#6B2737"
+                        TextColor="#FAF6EC"
+                        FontSize="16"
+                        FontAttributes="Bold"
+                        CornerRadius="8"
+                        HorizontalOptions="Fill" />
+
+                <!-- Load / refresh catalog snapshot. Visible only when
+                     signed in; doubles as Refresh once the cache is
+                     populated. -->
+                <Button x:Name="LoadCatalogButton"
+                        Text="📚  Load catalog snapshot"
+                        Clicked="OnLoadCatalogClicked"
+                        HeightRequest="56"
+                        BackgroundColor="#6B2737"
+                        TextColor="#FAF6EC"
+                        FontSize="16"
+                        CornerRadius="8"
+                        HorizontalOptions="Fill"
+                        IsVisible="False" />
+
+                <!-- Scan ISBN — the in-bookshop killer action. Brass
+                     accent + slightly larger height makes it stand out
+                     over the leather-coloured CTAs above. -->
+                <Button x:Name="ScanButton"
+                        Text="📷  Scan ISBN"
+                        Clicked="OnScanClicked"
+                        HeightRequest="64"
+                        BackgroundColor="#A67B3A"
+                        TextColor="#2C2416"
+                        FontSize="18"
+                        FontAttributes="Bold"
+                        CornerRadius="8"
+                        HorizontalOptions="Fill"
+                        IsVisible="False" />
+
+                <!-- Cache stats panel — passive info card that surfaces
+                     "what's stashed locally" so it isn't buried in
+                     StatusLabel text. Brass border on aged-parchment
+                     surface mirrors the Library list card treatment on
+                     Web. Visible whenever the cache has data, even
+                     when signed out (data persists across sign-out). -->
+                <Border x:Name="CacheStatsPanel"
+                        IsVisible="False"
+                        Stroke="#A67B3A"
+                        StrokeThickness="1"
+                        BackgroundColor="#F2EADB"
+                        Padding="16,12">
+                    <Border.StrokeShape>
+                        <RoundRectangle CornerRadius="8" />
+                    </Border.StrokeShape>
+                    <VerticalStackLayout Spacing="4">
+                        <Label Text="Cached catalog"
+                               FontSize="12"
+                               FontAttributes="Bold"
+                               TextColor="#6B2737" />
+                        <Label x:Name="CacheStatsLabel"
+                               FontSize="15"
+                               TextColor="#2C2416" />
+                        <Label x:Name="CacheSyncedAtLabel"
+                               FontSize="12"
+                               TextColor="#6B5D4A" />
+                    </VerticalStackLayout>
+                </Border>
+
+                <ActivityIndicator x:Name="Busy"
+                                   IsRunning="False"
+                                   Color="#6B2737"
+                                   HorizontalOptions="Center"
+                                   Margin="0,4,0,0" />
+
+                <!-- Status / error label. Centred, faded-ink for low
+                     emphasis; the panel above carries the real
+                     "what's true" info. -->
+                <Label x:Name="StatusLabel"
+                       Text="Not signed in. Tap Sign in to begin."
+                       FontSize="14"
+                       TextColor="#6B5D4A"
+                       HorizontalTextAlignment="Center"
+                       LineBreakMode="WordWrap" />
+
+                <!-- Sign out — outlined low-emphasis. Pushed down with
+                     margin so it's visually separated from primary
+                     actions. -->
+                <Button x:Name="SignOutButton"
+                        Text="Sign out"
+                        Clicked="OnSignOutClicked"
+                        HeightRequest="44"
+                        BackgroundColor="Transparent"
+                        TextColor="#6B5D4A"
+                        BorderColor="#A67B3A"
+                        BorderWidth="1"
+                        FontSize="14"
+                        CornerRadius="8"
+                        HorizontalOptions="Center"
+                        WidthRequest="160"
+                        Margin="0,32,0,0"
+                        IsVisible="False" />
+
+            </VerticalStackLayout>
+        </ScrollView>
+    </Grid>
 
 </ContentPage>

--- a/BookTracker.Mobile/MainPage.xaml.cs
+++ b/BookTracker.Mobile/MainPage.xaml.cs
@@ -12,6 +12,11 @@ public partial class MainPage : ContentPage
 
     private bool _signedIn;
     private bool _busy;
+    // Last-known cache metadata. Refreshed on app appearing, after
+    // sign-in, and after Load catalog. RefreshUi() reads from this
+    // (sync) rather than touching the cache directly so the render
+    // path stays cheap.
+    private CacheMeta? _meta;
 
     public MainPage(IAuthService auth, IApiClient api, ICatalogCache cache)
     {
@@ -42,19 +47,20 @@ public partial class MainPage : ContentPage
             StatusLabel.Text = $"Cache init failed: {ex.Message}";
         }
 
-        // If a cached account already exists, surface the signed-in
-        // state on first render so the user doesn't have to tap
-        // Sign in just to find out they're already signed in. If
-        // we have catalog meta from a previous run, surface that too.
+        // Refresh the meta panel regardless of sign-in state — cached
+        // catalog data outlives sign-out, so the panel should show what
+        // we actually have locally.
+        await RefreshMetaAsync();
+
         if (await _auth.IsSignedInAsync())
         {
             _signedIn = true;
-            var meta = await _cache.GetMetaAsync();
-            StatusLabel.Text = meta is null
-                ? "Signed in. Tap to load the catalog."
-                : $"Signed in. Cached catalog: {meta.BookCount} books, {meta.AuthorCount} authors (synced {meta.SyncedAt:u}).";
-            RefreshUi();
+            StatusLabel.Text = _meta is null
+                ? "Signed in. Tap Load catalog snapshot to begin."
+                : "Signed in.";
         }
+
+        RefreshUi();
     }
 
     private async void OnSignInClicked(object? sender, EventArgs e)
@@ -63,7 +69,10 @@ public partial class MainPage : ContentPage
         {
             await _auth.SignInAsync();
             _signedIn = true;
-            return "Signed in. Tap to load the catalog.";
+            await RefreshMetaAsync();
+            return _meta is null
+                ? "Signed in. Tap Load catalog snapshot to begin."
+                : "Signed in.";
         });
     }
 
@@ -72,25 +81,19 @@ public partial class MainPage : ContentPage
         await RunBusyAsync("Loading catalog…", async () =>
         {
             var snapshot = await _api.GetCatalogSnapshotAsync();
-            // Fetch + populate the SQLite cache in the same tap so we
-            // can confirm the cache plumbing works end-to-end on a
-            // real device. The cache populate is atomic so a partial
-            // populate can't leave the DB half-shrunken.
+            // Atomic populate — a partial fill can't leave the DB
+            // half-shrunken. PR 4's defensive null coalesces inside
+            // PopulateAsync mean a server that hasn't shipped /series
+            // yet still hydrates Books + Authors without throwing.
             await _cache.PopulateAsync(snapshot);
+            await RefreshMetaAsync();
 
-            // ?? 0 on each Count — a server that hasn't been redeployed
-            // since Mobile PR 1 merged won't include the `series` array
-            // in the response, so snapshot.Series deserialises as null
-            // (which was the original NRE). Once prod catches up these
-            // all stay non-null.
-            return
-                $"Catalog loaded + cached ✓\n" +
-                $"Version: {snapshot.Version ?? "(none)"}\n" +
-                $"Synced at: {snapshot.SyncedAt:u}\n" +
-                $"Books: {snapshot.Books?.Count ?? 0}\n" +
-                $"Authors: {snapshot.Authors?.Count ?? 0}\n" +
-                $"Series: {snapshot.Series?.Count ?? 0}" +
-                (snapshot.Series is null ? " (server lacks /series field — redeploy Web)" : "");
+            // Surface the redeploy hint only when the server is
+            // genuinely lagging on the /series field — the original
+            // PR 4 NRE diagnostic kept around as a passive warning.
+            return snapshot.Series is null
+                ? "Catalog loaded ✓ (server lacks /series field — redeploy Web)"
+                : "Catalog loaded ✓";
         });
     }
 
@@ -100,6 +103,8 @@ public partial class MainPage : ContentPage
         {
             await _auth.SignOutAsync();
             _signedIn = false;
+            // Note: cache data is intentionally not wiped on sign-out.
+            // The stats panel keeps showing what's locally stashed.
             return "Signed out.";
         });
     }
@@ -151,17 +156,67 @@ public partial class MainPage : ContentPage
         await Navigation.PushAsync(page);
     }
 
+    private async Task RefreshMetaAsync()
+    {
+        try
+        {
+            _meta = await _cache.GetMetaAsync();
+        }
+        catch
+        {
+            // GetMetaAsync only throws if the cache file is corrupt
+            // or InitAsync wasn't called — both already surfaced
+            // upstream. Treat as "no cache" here so RefreshUi keeps
+            // rendering something sensible.
+            _meta = null;
+        }
+    }
+
     private void RefreshUi()
     {
         Busy.IsRunning = _busy;
+        var hasCache = _meta is not null;
+
+        // Signed-out flow: only Sign in is visible / enabled.
+        SignInButton.IsVisible = !_signedIn;
         SignInButton.IsEnabled = !_busy && !_signedIn;
+
+        // Signed-in flow: Load catalog + Scan visible. Load stays
+        // visible after first load so the user can tap to refresh.
+        // Scan needs both signed-in AND cached data (otherwise every
+        // scan would say "not in your library").
+        LoadCatalogButton.IsVisible = _signedIn;
         LoadCatalogButton.IsEnabled = !_busy && _signedIn;
+        ScanButton.IsVisible = _signedIn;
+        ScanButton.IsEnabled = !_busy && _signedIn && hasCache;
+
+        // Cache stats panel: passive info, only when we have data.
+        // Renders independently of signed-in state — cached data
+        // outlives sign-out.
+        CacheStatsPanel.IsVisible = hasCache;
+        if (hasCache && _meta is not null)
+        {
+            CacheStatsLabel.Text =
+                $"{_meta.BookCount:N0} books · {_meta.AuthorCount:N0} authors";
+            CacheSyncedAtLabel.Text = _meta.SyncedAt is { } syncedAt
+                ? $"Last synced {FormatSyncedAt(syncedAt)}"
+                : "Last synced (unknown)";
+        }
+
+        SignOutButton.IsVisible = _signedIn;
         SignOutButton.IsEnabled = !_busy && _signedIn;
-        // Scan only makes sense when the cache has been populated —
-        // gate on the cache having a syncedAt rather than signed-in
-        // alone. For PR 5 simplicity we use signed-in as a proxy;
-        // if the cache is empty the scan page will just say
-        // "Not in your library" for everything, which is correct.
-        ScanButton.IsEnabled = !_busy && _signedIn;
+    }
+
+    // Relative-time formatter for the cache stats panel.
+    // "just now / 5m ago / 2h ago / 2026-05-12 14:23". Kept inline
+    // because it's UI-only with a single use site — promoting it to
+    // a helper class would be over-engineered for one Label binding.
+    private static string FormatSyncedAt(DateTime syncedUtc)
+    {
+        var ago = DateTime.UtcNow - syncedUtc;
+        if (ago.TotalMinutes < 1) return "just now";
+        if (ago.TotalMinutes < 60) return $"{(int)ago.TotalMinutes}m ago";
+        if (ago.TotalHours < 24) return $"{(int)ago.TotalHours}h ago";
+        return syncedUtc.ToLocalTime().ToString("yyyy-MM-dd HH:mm");
     }
 }


### PR DESCRIPTION
Replaces the engineer's-first-MAUI-page flat stack with a themed
layout that reads as the same product as BookTracker.Web. Palette
mirrored from BookTrackerTheme.cs (leather/brass/parchment/espresso/
ink/faded-ink), structure split into header + scrollable content.

Key changes:

- Espresso (#3E2723) header banner replaces in-content Headline /
  SubHeadline labels. System nav bar hidden on MainPage only
  (NavigationPage.HasNavigationBar=False) because this is the root
  surface; ScanPage still gets its nav bar with the back button.
- Action buttons themed: leather (#6B2737) for Sign in + Load
  catalog; brass (#A67B3A) accent for Scan ISBN so the in-bookshop
  killer action stands out from the management actions above it.
  Larger height (64dp) on Scan for thumb-reach.
- Cache stats panel — passive Border-with-brass-stroke card that
  surfaces "books · authors · last synced" once the cache has
  data. Replaces burying that info inside StatusLabel. Stays
  visible even when signed out because cached data outlives sign-
  out (intentional — user can see what's stashed locally).
- Visibility-based state model replaces enable/disable-only. Signed
  out shows only Sign in; signed in shows Load catalog + Scan +
  Sign out + (when populated) stats panel. Cleaner than rendering
  greyed-out controls users can't tap.
- Sign out demoted to outlined low-emphasis button at bottom with
  32dp top margin.
- Relative-time formatter (just now / 5m ago / 2h ago / yyyy-MM-dd
  HH:mm) on the synced-at label so the panel is glanceable.

Code-behind refactor: added _meta field cached from GetMetaAsync()
via RefreshMetaAsync(); RefreshUi() stays sync and reads from it.
Each state-change site (OnAppearing, OnSignInClicked, OnLoad-
CatalogClicked) awaits RefreshMetaAsync before calling RefreshUi.
Keeps the render path off the DB; meta only re-fetched when it
might have changed.

Scan button now correctly gated on (signed-in AND has-cache) rather
than the PR 5 signed-in-as-proxy comment promised — empty cache
won't render "not in your library" for every scan now.
