### PR TITLE
feat/collection genre toggle

### DIFF
--- a/BookTracker.Tests/ViewModels/BookAddViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/BookAddViewModelTests.cs
@@ -142,6 +142,161 @@ public class BookAddViewModelTests
     }
 
     [Fact]
+    public void AddCollectionWorkRow_InheritsGenresFromMostRecentPopulatedRow()
+    {
+        // Same shape as the author inheritance, but for genres: typing a
+        // genre on row 1 (SF say) propagates to subsequently-added rows so
+        // a 20-work "mostly SF" anthology only needs the genre picked once.
+        // The one outlier row can clear / replace per row.
+        var vm = CreateVm();
+        vm.IsCollection = true;
+        vm.CollectionWorks[0].GenreIds = new List<int> { 7 };
+
+        vm.AddCollectionWorkRow();
+
+        Assert.Equal(new[] { 7 }, vm.CollectionWorks[1].GenreIds);
+    }
+
+    [Fact]
+    public void AddCollectionWorkRow_GenreInheritanceIsACopyNotAReference()
+    {
+        // Each row owns its genre list — editing one row's GenreIds must
+        // not mutate another row's list (same hazard as authors when the
+        // bound list is mutated by the picker).
+        var vm = CreateVm();
+        vm.IsCollection = true;
+        vm.CollectionWorks[0].GenreIds = new List<int> { 7 };
+
+        vm.AddCollectionWorkRow();
+
+        var newRow = vm.CollectionWorks[^1];
+        newRow.GenreIds.Add(9);
+
+        Assert.Single(vm.CollectionWorks[0].GenreIds);
+        Assert.Equal(7, vm.CollectionWorks[0].GenreIds[0]);
+    }
+
+    [Fact]
+    public async Task SaveAsync_SingleGenreMode_AppliesSharedGenresToEveryWork()
+    {
+        // Single-Genre mode is Drew's order-of-magnitude case — pick the
+        // genre once at the top; save applies it to every Work row.
+        int sfId;
+        using (var db = _factory.CreateDbContext())
+        {
+            var sf = new Genre { Name = "Science Fiction" };
+            db.Genres.Add(sf);
+            await db.SaveChangesAsync();
+            sfId = sf.Id;
+        }
+
+        var vm = CreateVm();
+        vm.BookInput.Title = "The Mammoth Book of SF";
+        vm.EditionInput.Format = BookFormat.TradePaperback;
+        vm.IsCollection = true;
+        vm.SingleAuthor = true;
+        vm.SharedAuthors = new List<string> { "Various" };
+        vm.SingleGenre = true;
+        vm.SharedGenreIds = new List<int> { sfId };
+        vm.CollectionWorks =
+        [
+            new() { Title = "Story A" },
+            new() { Title = "Story B" },
+            new() { Title = "Story C" },
+        ];
+
+        var bookId = await vm.SaveAsync(selectedGenreIds: []);
+
+        Assert.NotNull(bookId);
+        await using var db2 = _factory.CreateDbContext();
+        var saved = await db2.Books
+            .Include(b => b.Works).ThenInclude(w => w.Genres)
+            .FirstAsync(b => b.Id == bookId);
+
+        Assert.Equal(3, saved.Works.Count);
+        Assert.All(saved.Works, w =>
+        {
+            var genre = Assert.Single(w.Genres);
+            Assert.Equal(sfId, genre.Id);
+        });
+    }
+
+    [Fact]
+    public async Task SaveAsync_PerRowGenres_AttachesEachWorksOwnList()
+    {
+        // Single-Genre OFF: each row carries its own GenreIds. The save
+        // path applies them per Work. This is the "mostly SF + one
+        // outlier" shape after the user has overridden the inherited
+        // genre on the odd row.
+        int sfId, horrorId;
+        using (var db = _factory.CreateDbContext())
+        {
+            var sf = new Genre { Name = "Science Fiction" };
+            var horror = new Genre { Name = "Horror" };
+            db.Genres.AddRange(sf, horror);
+            await db.SaveChangesAsync();
+            sfId = sf.Id;
+            horrorId = horror.Id;
+        }
+
+        var vm = CreateVm();
+        vm.BookInput.Title = "Mostly SF, One Horror";
+        vm.EditionInput.Format = BookFormat.TradePaperback;
+        vm.IsCollection = true;
+        vm.SingleGenre = false;
+        vm.CollectionWorks =
+        [
+            new() { Title = "SF One", Authors = ["Author A"], GenreIds = [sfId] },
+            new() { Title = "SF Two", Authors = ["Author A"], GenreIds = [sfId] },
+            new() { Title = "Horror One", Authors = ["Author A"], GenreIds = [horrorId] },
+        ];
+
+        var bookId = await vm.SaveAsync(selectedGenreIds: []);
+
+        Assert.NotNull(bookId);
+        await using var db2 = _factory.CreateDbContext();
+        var saved = await db2.Books
+            .Include(b => b.Works).ThenInclude(w => w.Genres)
+            .FirstAsync(b => b.Id == bookId);
+
+        Assert.Equal(3, saved.Works.Count);
+        var sfOne = saved.Works.Single(w => w.Title == "SF One");
+        Assert.Equal(sfId, Assert.Single(sfOne.Genres).Id);
+        var horrorOne = saved.Works.Single(w => w.Title == "Horror One");
+        Assert.Equal(horrorId, Assert.Single(horrorOne.Genres).Id);
+    }
+
+    [Fact]
+    public async Task SaveAsync_SingleGenreMode_EmptySharedList_LeavesWorksGenreless()
+    {
+        // Single-Genre on but nothing picked — collection still saves; the
+        // works just land with no genres (same shape as a non-collection
+        // save with selectedGenreIds=[]). User can tag genres later.
+        var vm = CreateVm();
+        vm.BookInput.Title = "Untagged Collection";
+        vm.EditionInput.Format = BookFormat.TradePaperback;
+        vm.IsCollection = true;
+        vm.SingleAuthor = true;
+        vm.SharedAuthors = new List<string> { "Various" };
+        vm.SingleGenre = true;
+        vm.SharedGenreIds = [];
+        vm.CollectionWorks =
+        [
+            new() { Title = "Story A" },
+            new() { Title = "Story B" },
+        ];
+
+        var bookId = await vm.SaveAsync(selectedGenreIds: []);
+
+        Assert.NotNull(bookId);
+        await using var db = _factory.CreateDbContext();
+        var saved = await db.Books
+            .Include(b => b.Works).ThenInclude(w => w.Genres)
+            .FirstAsync(b => b.Id == bookId);
+        Assert.All(saved.Works, w => Assert.Empty(w.Genres));
+    }
+
+    [Fact]
     public async Task SearchAsync_EmptyInputs_ReportsMessageAndDoesNotCallLookup()
     {
         var vm = CreateVm();

--- a/BookTracker.Tests/ViewModels/BookAddViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/BookAddViewModelTests.cs
@@ -85,6 +85,139 @@ public class BookAddViewModelTests
     }
 
     [Fact]
+    public void SingleAuthorToggle_On_SeedsSharedAuthorsFromUnionOfRows()
+    {
+        // OFF → ON: the user has been entering per-row authors, then
+        // decides "actually let's set a default". Shared should capture
+        // the union of what was already on the rows so toggling isn't
+        // destructive.
+        var vm = CreateVm();
+        vm.IsCollection = true;
+        vm.CollectionWorks =
+        [
+            new() { Authors = ["Stephen King"] },
+            new() { Authors = ["Stephen King", "Peter Straub"] },
+            new() { Authors = [] },
+        ];
+
+        vm.SingleAuthor = true;
+
+        Assert.Equal(new[] { "Stephen King", "Peter Straub" }, vm.SharedAuthors);
+    }
+
+    [Fact]
+    public void SingleAuthorToggle_Off_BroadcastsSharedToEveryRow()
+    {
+        // ON → OFF: the user picked a default in shared mode and now wants
+        // to tweak one row. Each row should start with the shared list as
+        // its starting point so the user only edits the outlier rows.
+        var vm = CreateVm();
+        vm.IsCollection = true;
+        vm.CollectionWorks =
+        [
+            new() { Title = "A" },
+            new() { Title = "B" },
+            new() { Title = "C" },
+        ];
+        vm.SingleAuthor = true;
+        vm.SharedAuthors = ["Stephen King"];
+
+        vm.SingleAuthor = false;
+
+        Assert.All(vm.CollectionWorks, w => Assert.Equal(new[] { "Stephen King" }, w.Authors));
+    }
+
+    [Fact]
+    public void SingleAuthorToggle_Off_GivesEachRowAnIndependentList()
+    {
+        // The broadcast must copy the list, not share a reference — picker
+        // mutations on one row would otherwise leak into every other row.
+        var vm = CreateVm();
+        vm.IsCollection = true;
+        vm.CollectionWorks = [new() { Title = "A" }, new() { Title = "B" }];
+        vm.SingleAuthor = true;
+        vm.SharedAuthors = ["Stephen King"];
+
+        vm.SingleAuthor = false;
+
+        vm.CollectionWorks[0].Authors.Add("Co-author");
+        Assert.Single(vm.CollectionWorks[1].Authors);
+        Assert.Equal("Stephen King", vm.CollectionWorks[1].Authors[0]);
+    }
+
+    [Fact]
+    public void SingleGenreToggle_On_SeedsSharedGenresFromUnionOfRows()
+    {
+        var vm = CreateVm();
+        vm.IsCollection = true;
+        vm.CollectionWorks =
+        [
+            new() { GenreIds = [1, 2] },
+            new() { GenreIds = [2, 3] },
+            new() { GenreIds = [] },
+        ];
+
+        vm.SingleGenre = true;
+
+        Assert.Equal(new[] { 1, 2, 3 }, vm.SharedGenreIds);
+    }
+
+    [Fact]
+    public void SingleGenreToggle_Off_BroadcastsSharedToEveryRow()
+    {
+        var vm = CreateVm();
+        vm.IsCollection = true;
+        vm.CollectionWorks = [new() { Title = "A" }, new() { Title = "B" }, new() { Title = "C" }];
+        vm.SingleGenre = true;
+        vm.SharedGenreIds = [7];
+
+        vm.SingleGenre = false;
+
+        Assert.All(vm.CollectionWorks, w => Assert.Equal(new[] { 7 }, w.GenreIds));
+    }
+
+    [Fact]
+    public void SingleGenreToggle_Off_GivesEachRowAnIndependentList()
+    {
+        var vm = CreateVm();
+        vm.IsCollection = true;
+        vm.CollectionWorks = [new() { Title = "A" }, new() { Title = "B" }];
+        vm.SingleGenre = true;
+        vm.SharedGenreIds = [7];
+
+        vm.SingleGenre = false;
+
+        vm.CollectionWorks[0].GenreIds.Add(9);
+        Assert.Single(vm.CollectionWorks[1].GenreIds);
+        Assert.Equal(7, vm.CollectionWorks[1].GenreIds[0]);
+    }
+
+    [Fact]
+    public void Reset_DoesNotBroadcastStaleSharedStateToFreshRow()
+    {
+        // Regression: Reset() flips SingleAuthor / SingleGenre back to false.
+        // If those setters propagated, the freshly-rebuilt empty starter
+        // row would be re-populated with whatever shared state the previous
+        // capture had.
+        var vm = CreateVm();
+        vm.IsCollection = true;
+        vm.SingleAuthor = true;
+        vm.SharedAuthors = ["Stephen King"];
+        vm.SingleGenre = true;
+        vm.SharedGenreIds = [7];
+
+        vm.Reset();
+
+        Assert.False(vm.SingleAuthor);
+        Assert.False(vm.SingleGenre);
+        Assert.Empty(vm.SharedAuthors);
+        Assert.Empty(vm.SharedGenreIds);
+        Assert.Single(vm.CollectionWorks);
+        Assert.Empty(vm.CollectionWorks[0].Authors);
+        Assert.Empty(vm.CollectionWorks[0].GenreIds);
+    }
+
+    [Fact]
     public async Task SaveAsync_SingleAuthorMode_AppliesSharedAuthorsToEveryWork()
     {
         // Single-Author mode is the "King's Different Seasons" shape —

--- a/BookTracker.Web/Components/Pages/Books/Add.razor
+++ b/BookTracker.Web/Components/Pages/Books/Add.razor
@@ -210,18 +210,29 @@
                 <div class="card">
                     <div class="card-header bg-white"><h2 class="h5 mb-0">Works in this collection</h2></div>
                     <div class="card-body">
-                        @* Single-Author mode — when on, render one shared
-                           MudAuthorPicker; the per-row author pickers are
-                           hidden and save applies the shared authors to
-                           every Work. Common case (~50%) is a single-
-                           author compendium where typing the author once
-                           is the desired flow. *@
-                        <div class="form-check form-switch mb-3">
+                        @* Single-Author + Single-Genre modes — when on,
+                           render a shared picker at the top; per-row
+                           pickers are hidden and save applies the shared
+                           list to every Work. Common case (Drew's order-
+                           of-magnitude driver for genres: a 20-work
+                           anthology where 19 share a single genre); same
+                           shape for authors. State is sticky across
+                           toggle flips — per-row entries don't get
+                           clobbered if the user toggles on then off. *@
+                        <div class="form-check form-switch mb-2">
                             <input type="checkbox" id="singleAuthorToggle"
                                    class="form-check-input"
                                    @bind="VM.SingleAuthor" />
                             <label for="singleAuthorToggle" class="form-check-label">
                                 Same author(s) for all works
+                            </label>
+                        </div>
+                        <div class="form-check form-switch mb-3">
+                            <input type="checkbox" id="singleGenreToggle"
+                                   class="form-check-input"
+                                   @bind="VM.SingleGenre" />
+                            <label for="singleGenreToggle" class="form-check-label">
+                                Same genre(s) for all works
                             </label>
                         </div>
 
@@ -232,6 +243,15 @@
                                 <MudAuthorPicker Authors="VM.SharedAuthors"
                                                  AuthorsChanged="list => VM.SharedAuthors = list"
                                                  Label="Add author" />
+                            </div>
+                        }
+
+                        @if (VM.SingleGenre)
+                        {
+                            <div class="mb-3">
+                                <label class="form-label small">Genre(s) for all works in this collection</label>
+                                <MudGenrePicker SelectedGenreIds="VM.SharedGenreIds"
+                                                SelectedGenreIdsChanged="ids => VM.SharedGenreIds = ids" />
                             </div>
                         }
 
@@ -286,11 +306,19 @@
                                         <label class="form-label small">First published <span class="text-muted">(optional)</span></label>
                                         <InputText @bind-Value="work.FirstPublishedDate" class="form-control" placeholder="e.g. 1934" />
                                     </div>
+                                    @if (!VM.SingleGenre)
+                                    {
+                                        <div class="col-12">
+                                            <label class="form-label small">Genre(s)</label>
+                                            <MudGenrePicker SelectedGenreIds="work.GenreIds"
+                                                            SelectedGenreIdsChanged="ids => work.GenreIds = ids" />
+                                        </div>
+                                    }
                                 </div>
                             </div>
                         }
                         <button type="button" class="btn btn-outline-primary btn-sm" @onclick="VM.AddCollectionWorkRow">+ Add another work</button>
-                        <div class="form-text mt-2">Genres and series are set per-work after saving — open each work from the book detail page to tag.</div>
+                        <div class="form-text mt-2">Series suggestions are set per-work after saving — open each work from the book detail page to tag.</div>
                     </div>
                 </div>
             </div>

--- a/BookTracker.Web/Components/Shared/MudGenrePicker.razor
+++ b/BookTracker.Web/Components/Shared/MudGenrePicker.razor
@@ -27,7 +27,8 @@
                 var label = VM.ChipLabel(id);
                 <MudChip T="string"
                          Size="Size.Small"
-                         Variant="Variant.Outlined"
+                         Variant="Variant.Filled"
+                         Color="Color.Primary"
                          OnClose="@(() => OnRemoveAsync(id))">@label</MudChip>
             }
         </MudStack>

--- a/BookTracker.Web/ViewModels/BookAddViewModel.cs
+++ b/BookTracker.Web/ViewModels/BookAddViewModel.cs
@@ -43,26 +43,76 @@ public class BookAddViewModel(
     // author inheritance didn't help). Start small, let typing grow it.
     public List<WorkFormViewModel.WorkFormInput> CollectionWorks { get; set; } = [new()];
 
-    // "Same author(s) for all works" mode — when on, a single shared
-    // author chip-list at the top of the collection block applies to
-    // every Work at save time and the per-row author pickers are
-    // hidden. Common case (Drew's ~50% estimate) is a single-author
-    // compendium (King's Different Seasons, Christie crime collections);
-    // this mode avoids both per-row chip-entry friction and the new-row
-    // inheritance race when the first row hasn't been populated yet.
-    // Off (default) keeps the per-row author UI for genuinely mixed-
-    // author anthologies (Dozois year's best, etc.).
-    public bool SingleAuthor { get; set; }
+    // "Same author(s) / genre(s) for all works" modes — when on, a single
+    // shared chip-list at the top of the collection block applies to every
+    // Work at save time and the per-row pickers are hidden. Common cases:
+    //   - Author: single-author compendium (King's Different Seasons,
+    //     Christie crime collections).
+    //   - Genre: Drew's order-of-magnitude case — a 20-work anthology
+    //     where 19 share a single genre and one differs.
+    //
+    // Toggle flips propagate data both ways so the user's picks survive
+    // (no "where did my genres go" moment):
+    //   - OFF → ON: shared = union of every row's per-row list (lossless
+    //     capture; user can prune if the union has stragglers).
+    //   - ON → OFF: every row's list := shared (broadcast; gives the user
+    //     a pre-populated starting point on each row so they only need
+    //     to edit the outliers — the order-of-magnitude flow).
+    // Reset() bypasses these setters and clears via the backing fields so
+    // it can't accidentally re-populate a fresh CollectionWorks row.
+    private bool _singleAuthor;
+    public bool SingleAuthor
+    {
+        get => _singleAuthor;
+        set
+        {
+            if (_singleAuthor == value) return;
+            if (value)
+            {
+                SharedAuthors = CollectionWorks
+                    .SelectMany(r => r.Authors)
+                    .Where(a => !string.IsNullOrWhiteSpace(a))
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToList();
+            }
+            else
+            {
+                // Fresh copy per row so picker mutations on one row don't
+                // leak into another via shared list reference.
+                foreach (var row in CollectionWorks)
+                {
+                    row.Authors = SharedAuthors.ToList();
+                }
+            }
+            _singleAuthor = value;
+        }
+    }
     public List<string> SharedAuthors { get; set; } = [];
 
-    // "Same genre(s) for all works" mode — same shape as SingleAuthor but
-    // for genres. Drew's order-of-magnitude case: a 20-work collection
-    // where 19 share a single genre (e.g. SF) and one differs. On-mode
-    // applies SharedGenreIds to every Work at save time; off-mode reads
-    // each row's own GenreIds. New rows in off-mode inherit genres from
-    // the most recent populated row (same as authors) so a "mostly SF"
-    // anthology only needs the genre picked once.
-    public bool SingleGenre { get; set; }
+    private bool _singleGenre;
+    public bool SingleGenre
+    {
+        get => _singleGenre;
+        set
+        {
+            if (_singleGenre == value) return;
+            if (value)
+            {
+                SharedGenreIds = CollectionWorks
+                    .SelectMany(r => r.GenreIds)
+                    .Distinct()
+                    .ToList();
+            }
+            else
+            {
+                foreach (var row in CollectionWorks)
+                {
+                    row.GenreIds = SharedGenreIds.ToList();
+                }
+            }
+            _singleGenre = value;
+        }
+    }
     public List<int> SharedGenreIds { get; set; } = [];
 
     public void AddCollectionWorkRow()
@@ -308,9 +358,13 @@ public class BookAddViewModel(
         NoIsbnMode = false;
         IsCollection = false;
         CollectionWorks = [new()];
-        SingleAuthor = false;
+        // Bypass the SingleAuthor / SingleGenre setters here — they
+        // propagate shared list state to CollectionWorks rows on flip,
+        // which would re-populate the just-replaced empty starter row
+        // with whatever the previous capture had in shared mode.
+        _singleAuthor = false;
         SharedAuthors = [];
-        SingleGenre = false;
+        _singleGenre = false;
         SharedGenreIds = [];
         // Picker state clears via parameter binding when the page resets
         // its selectedGenreIds + this VM's LookupCandidates above. No

--- a/BookTracker.Web/ViewModels/BookAddViewModel.cs
+++ b/BookTracker.Web/ViewModels/BookAddViewModel.cs
@@ -31,9 +31,10 @@ public class BookAddViewModel(
     // Works (e.g. "The Bachman Books", anthologies). Toggling on swaps the
     // single WorkForm for a repeatable Works builder; lookup fills only the
     // collection's Book.Title + cover and skips the work-specific fields.
-    // Genres and series suggestions are deferred to per-work editing on
-    // /books/{id}/edit — applying them to all works at save time would be
-    // wrong (each work has its own).
+    // Authors and genres are captured at save time via the SingleAuthor /
+    // SingleGenre shared-mode toggles or per-row entry; series suggestions
+    // stay deferred to per-work editing on /books/{id}/edit because the
+    // lookup flow describes the collection, not its constituent works.
     public bool IsCollection { get; set; }
     // Default to a single starter row. The Enter-on-Title affordance
     // grows the list as the user types; pre-seeding a second empty row
@@ -54,6 +55,16 @@ public class BookAddViewModel(
     public bool SingleAuthor { get; set; }
     public List<string> SharedAuthors { get; set; } = [];
 
+    // "Same genre(s) for all works" mode — same shape as SingleAuthor but
+    // for genres. Drew's order-of-magnitude case: a 20-work collection
+    // where 19 share a single genre (e.g. SF) and one differs. On-mode
+    // applies SharedGenreIds to every Work at save time; off-mode reads
+    // each row's own GenreIds. New rows in off-mode inherit genres from
+    // the most recent populated row (same as authors) so a "mostly SF"
+    // anthology only needs the genre picked once.
+    public bool SingleGenre { get; set; }
+    public List<int> SharedGenreIds { get; set; } = [];
+
     public void AddCollectionWorkRow()
     {
         // Inherit authors from the most recent row that has authors so
@@ -61,13 +72,23 @@ public class BookAddViewModel(
         // Seasons", Christie collections) only need authors entered once.
         // User can clear / replace per row. If no row has authors yet —
         // including the first-time case before anything is typed — the
-        // new row starts empty as before.
+        // new row starts empty as before. Genres inherit the same way so
+        // a "mostly SF" anthology only needs the genre picked on row 1.
         var seedAuthors = CollectionWorks
             .AsEnumerable()
             .Reverse()
             .FirstOrDefault(w => w.Authors.Count > 0)?.Authors
             .ToList() ?? [];
-        CollectionWorks.Add(new WorkFormViewModel.WorkFormInput { Authors = seedAuthors });
+        var seedGenres = CollectionWorks
+            .AsEnumerable()
+            .Reverse()
+            .FirstOrDefault(w => w.GenreIds.Count > 0)?.GenreIds
+            .ToList() ?? [];
+        CollectionWorks.Add(new WorkFormViewModel.WorkFormInput
+        {
+            Authors = seedAuthors,
+            GenreIds = seedGenres,
+        });
     }
 
     public void RemoveCollectionWorkRow(int index)
@@ -289,6 +310,8 @@ public class BookAddViewModel(
         CollectionWorks = [new()];
         SingleAuthor = false;
         SharedAuthors = [];
+        SingleGenre = false;
+        SharedGenreIds = [];
         // Picker state clears via parameter binding when the page resets
         // its selectedGenreIds + this VM's LookupCandidates above. No
         // direct picker poke needed.
@@ -377,17 +400,21 @@ public class BookAddViewModel(
             List<Work> works;
             if (IsCollection)
             {
-                // Collection mode: build N Works, one per row. Genres and series
-                // suggestions are deferred to per-work editing on /books/{id}/edit
-                // — the lookup flow can't pick them per-work, and applying to all
-                // would be wrong (each Work has its own).
+                // Collection mode: build N Works, one per row. Series
+                // suggestions are still deferred to per-work editing on
+                // /books/{id}/edit (the lookup flow can't pick per-work, and
+                // applying to all would be wrong). Genres now ride with the
+                // capture flow: shared list when SingleGenre is on, per-row
+                // GenreIds otherwise.
                 //
                 // Author source depends on SingleAuthor mode: when on, the
                 // shared SharedAuthors chip-list applies to every row; when
                 // off, each row carries its own Authors list. Effective list
-                // is selected per row via the local helper.
+                // is selected per row via the local helpers.
                 List<string> AuthorsFor(WorkFormViewModel.WorkFormInput row) =>
                     SingleAuthor ? SharedAuthors : row.Authors;
+                List<int> GenresFor(WorkFormViewModel.WorkFormInput row) =>
+                    SingleGenre ? SharedGenreIds : row.GenreIds;
 
                 var rows = CollectionWorks
                     .Where(w => !string.IsNullOrWhiteSpace(w.Title) && AuthorsFor(w).Count > 0)
@@ -407,6 +434,19 @@ public class BookAddViewModel(
                 var allAuthors = await AuthorResolver.FindOrCreateAllAsync(allNames, db);
                 var byName = allAuthors.ToDictionary(a => a.Name, StringComparer.OrdinalIgnoreCase);
 
+                // Resolve the union of distinct genre ids across all rows in
+                // one query — same reason as authors above, and a single
+                // round-trip beats N row-by-row Genres lookups.
+                var allGenreIds = (SingleGenre
+                    ? SharedGenreIds
+                    : rows.SelectMany(r => r.GenreIds))
+                    .Distinct()
+                    .ToList();
+                var collectionGenres = allGenreIds.Count == 0
+                    ? new List<Genre>()
+                    : await db.Genres.Where(g => allGenreIds.Contains(g.Id)).ToListAsync();
+                var genresById = collectionGenres.ToDictionary(g => g.Id);
+
                 works = new List<Work>(rows.Count);
                 foreach (var row in rows)
                 {
@@ -420,6 +460,11 @@ public class BookAddViewModel(
                     {
                         throw new InvalidOperationException($"Each work in the collection needs at least one author (work \"{row.Title}\" had none).");
                     }
+                    var rowGenres = GenresFor(row)
+                        .Distinct()
+                        .Where(genresById.ContainsKey)
+                        .Select(id => genresById[id])
+                        .ToList();
                     var rowFirstPub = PartialDateParser.TryParse(row.FirstPublishedDate) ?? PartialDate.Empty;
                     var w = new Work
                     {
@@ -427,7 +472,7 @@ public class BookAddViewModel(
                         Subtitle = string.IsNullOrWhiteSpace(row.Subtitle) ? null : row.Subtitle!.Trim(),
                         FirstPublishedDate = rowFirstPub.Date,
                         FirstPublishedDatePrecision = rowFirstPub.Precision,
-                        Genres = [],
+                        Genres = rowGenres,
                     };
                     AuthorResolver.AssignAuthors(w, rowAuthors);
                     works.Add(w);

--- a/BookTracker.Web/ViewModels/WorkFormViewModel.cs
+++ b/BookTracker.Web/ViewModels/WorkFormViewModel.cs
@@ -27,5 +27,11 @@ public class WorkFormViewModel
         // "1973-10", "1973-10-12". Parsed into Work.FirstPublishedDate +
         // Work.FirstPublishedDatePrecision at save time.
         public string? FirstPublishedDate { get; set; }
+
+        // Per-Work genre selection — used by the collection-mode "Single-Genre
+        // off" path so each row can carry its own genre chips. Single-Work
+        // captures still route genre selection through the page's own
+        // selectedGenreIds field rather than this list.
+        public List<int> GenreIds { get; set; } = [];
     }
 }


### PR DESCRIPTION
- **feat(add): collection-mode genre toggle + per-row genre picker**
- **fix(genre-picker): brand chip — match MudAuthorPicker (Filled + Primary)**
- **feat(add): propagate shared/per-row lists on SingleAuthor + SingleGenre toggle flips**
