### PR TITLE
chore(memory): capture Blazor dialog VM lifetime trap from PR 4

### DIFF
--- a/.claude-memory/MEMORY.md
+++ b/.claude-memory/MEMORY.md
@@ -21,3 +21,4 @@
 - [Optimise for the common path, not the visible edge](feedback_common_path_over_visible_edge.md) — when fixing a reported edge-case, name what the fix changes for the silent majority before applying; reflex fixes often satisfy the visible bug at the cost of the unmeasured everyday flow.
 - [Runbook: SQL DB restart for SqlClient pool zombies](runbook_sqlclient_pool_zombies.md) — when both slots Running but won't serve and Stop+Start doesn't help, restart the SQL DB to break stuck connection state.
 - [Runbook: container warmup timeout calibration](runbook_container_warmup_calibration.md) — Linux App Service default 230s probe is too tight under AAD-auth + cold cert update; `WEBSITES_CONTAINER_START_TIME_LIMIT=600` now in Bicep.
+- [Blazor dialog VM lifetime trap](feedback_dialog_vm_lifetime.md) — `@inject` inside a MudDialog hands a fresh Transient VM, not the page's; pass the page's VM via `DialogParameters` when shared state matters.

--- a/.claude-memory/feedback_dialog_vm_lifetime.md
+++ b/.claude-memory/feedback_dialog_vm_lifetime.md
@@ -1,0 +1,11 @@
+---
+name: Blazor dialog VM lifetime trap
+description: Transient ViewModels @injected inside a MudDialog get a fresh instance, not the page's — pass the page's VM via DialogParameters when shared state is needed.
+type: feedback
+originSessionId: 06e95d36-5868-496f-9999-8b65f480b83c
+---
+When a MudBlazor dialog needs the page's initialised state (e.g. `VM.Book`), do NOT `@inject` the same VM type inside the dialog. BookTracker registers ViewModels as Transient, so `@inject` hands the dialog a brand-new instance whose state (Book, snapshot, etc.) is empty — the dialog calls VM methods that silently no-op or return empty.
+
+**Why:** caught in PR 4 of the Add/View/Edit polish arc (2026-05-12). The "Add existing work" dialog @injected `BookDetailViewModel` and called `VM.SearchAttachableWorksAsync` — which short-circuits when `Book is null`. The full edit page worked because it has a different VM and didn't hit this code path. Drew's repro: "in the view page I get no works found for a work that the full edit page finds."
+
+**How to apply:** when a dialog needs the page's VM state, follow the EditionCoverUploadDialog pattern — declare a `[Parameter, EditorRequired] public TheVM VM { get; set; }` on the dialog and pass it through from the page via `DialogParameters<TheDialog> { { x => x.VM, VM } }`. Dialogs that only need stateless services (IBookLookupService, IWorkSearchService, IDbContextFactory) can still `@inject` them — the rule is specifically about VMs that hold initialised page state.


### PR DESCRIPTION
PR 4 fix surfaced a recurring shape: @inject of a Transient VM inside
a MudDialog hands a fresh instance, not the page's. Pass the page's
VM via DialogParameters when shared state matters.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
