### PR TITLE
feat/add existing work on collection row

### DIFF
--- a/.claude-memory/MEMORY.md
+++ b/.claude-memory/MEMORY.md
@@ -21,3 +21,4 @@
 - [Optimise for the common path, not the visible edge](feedback_common_path_over_visible_edge.md) — when fixing a reported edge-case, name what the fix changes for the silent majority before applying; reflex fixes often satisfy the visible bug at the cost of the unmeasured everyday flow.
 - [Runbook: SQL DB restart for SqlClient pool zombies](runbook_sqlclient_pool_zombies.md) — when both slots Running but won't serve and Stop+Start doesn't help, restart the SQL DB to break stuck connection state.
 - [Runbook: container warmup timeout calibration](runbook_container_warmup_calibration.md) — Linux App Service default 230s probe is too tight under AAD-auth + cold cert update; `WEBSITES_CONTAINER_START_TIME_LIMIT=600` now in Bicep.
+- [Blazor dialog VM lifetime trap](feedback_dialog_vm_lifetime.md) — `@inject` inside a MudDialog hands a fresh Transient VM, not the page's; pass the page's VM via `DialogParameters` when shared state matters.

--- a/.claude-memory/feedback_dialog_vm_lifetime.md
+++ b/.claude-memory/feedback_dialog_vm_lifetime.md
@@ -1,0 +1,11 @@
+---
+name: Blazor dialog VM lifetime trap
+description: Transient ViewModels @injected inside a MudDialog get a fresh instance, not the page's — pass the page's VM via DialogParameters when shared state is needed.
+type: feedback
+originSessionId: 06e95d36-5868-496f-9999-8b65f480b83c
+---
+When a MudBlazor dialog needs the page's initialised state (e.g. `VM.Book`), do NOT `@inject` the same VM type inside the dialog. BookTracker registers ViewModels as Transient, so `@inject` hands the dialog a brand-new instance whose state (Book, snapshot, etc.) is empty — the dialog calls VM methods that silently no-op or return empty.
+
+**Why:** caught in PR 4 of the Add/View/Edit polish arc (2026-05-12). The "Add existing work" dialog @injected `BookDetailViewModel` and called `VM.SearchAttachableWorksAsync` — which short-circuits when `Book is null`. The full edit page worked because it has a different VM and didn't hit this code path. Drew's repro: "in the view page I get no works found for a work that the full edit page finds."
+
+**How to apply:** when a dialog needs the page's VM state, follow the EditionCoverUploadDialog pattern — declare a `[Parameter, EditorRequired] public TheVM VM { get; set; }` on the dialog and pass it through from the page via `DialogParameters<TheDialog> { { x => x.VM, VM } }`. Dialogs that only need stateless services (IBookLookupService, IWorkSearchService, IDbContextFactory) can still `@inject` them — the rule is specifically about VMs that hold initialised page state.

--- a/BookTracker.Tests/ViewModels/BookAddViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/BookAddViewModelTests.cs
@@ -13,7 +13,7 @@ public class BookAddViewModelTests
     private readonly IBookLookupService _lookup = Substitute.For<IBookLookupService>();
 
     private BookAddViewModel CreateVm() =>
-        new(_factory, _lookup, new SeriesMatchService(_factory));
+        new(_factory, _lookup, new SeriesMatchService(_factory), new WorkSearchService(_factory));
 
     [Fact]
     public void AddCollectionWorkRow_InheritsAuthorsFromMostRecentPopulatedRow()
@@ -782,6 +782,135 @@ public class BookAddViewModelTests
         var work = db.Works.Single();
         Assert.Null(work.SeriesId);
         Assert.Null(work.SeriesOrder);
+    }
+
+    [Fact]
+    public async Task SaveAsync_CollectionMode_MixedNewAndAttachedRows_AttachesExistingAndCreatesNew()
+    {
+        // Drew's Lovecraft "complete works" case during initial capture: a
+        // brand-new anthology where some stories are new and some are
+        // already in the library from previous anthologies. Save creates
+        // the new Works and attaches the existing ones to the same Book,
+        // preserving the user-entered row order.
+        var factory = new TestDbContextFactory();
+        int existingId;
+        using (var db = factory.CreateDbContext())
+        {
+            var author = new Author { Name = "H.P. Lovecraft" };
+            var existing = new Work
+            {
+                Title = "The Call of Cthulhu",
+                WorkAuthors = [new WorkAuthor { Author = author, Order = 0 }],
+            };
+            db.Books.Add(new Book { Title = "Other Anthology", Works = [existing] });
+            await db.SaveChangesAsync();
+            existingId = existing.Id;
+        }
+
+        var vm = new BookAddViewModel(factory, _lookup, new SeriesMatchService(factory), new WorkSearchService(factory));
+        vm.BookInput.Title = "Mixed Anthology";
+        vm.EditionInput.Format = BookFormat.TradePaperback;
+        vm.IsCollection = true;
+        vm.CollectionWorks =
+        [
+            new() { Title = "New Story A", Authors = ["H.P. Lovecraft"] },
+            new() { AttachedWorkId = existingId, Title = "The Call of Cthulhu" },
+            new() { Title = "New Story B", Authors = ["H.P. Lovecraft"] },
+        ];
+
+        var bookId = await vm.SaveAsync(selectedGenreIds: []);
+
+        Assert.NotNull(bookId);
+        await using var db2 = factory.CreateDbContext();
+        var book = await db2.Books
+            .Include(b => b.Works).ThenInclude(w => w.WorkAuthors).ThenInclude(wa => wa.Author)
+            .FirstAsync(b => b.Id == bookId);
+
+        Assert.Equal(3, book.Works.Count);
+        Assert.Contains(book.Works, w => w.Id == existingId);
+        Assert.Contains(book.Works, w => w.Title == "New Story A");
+        Assert.Contains(book.Works, w => w.Title == "New Story B");
+        // Existing Work still has its original anthology attached too — N:N preserved.
+        var cthulhu = await db2.Works.Include(w => w.Books).FirstAsync(w => w.Id == existingId);
+        Assert.Equal(2, cthulhu.Books.Count);
+    }
+
+    [Fact]
+    public async Task SaveAsync_CollectionMode_AttachOnlyRow_DoesNotRequireTitleOrAuthorOnThatRow()
+    {
+        // An attach-existing row carries no editable fields; validation
+        // must skip the "title + at least one author" check for it. A
+        // collection with a single attach-only row should save cleanly.
+        var factory = new TestDbContextFactory();
+        int existingId;
+        using (var db = factory.CreateDbContext())
+        {
+            var author = new Author { Name = "Author" };
+            var existing = new Work
+            {
+                Title = "Existing",
+                WorkAuthors = [new WorkAuthor { Author = author, Order = 0 }],
+            };
+            db.Books.Add(new Book { Title = "Other", Works = [existing] });
+            await db.SaveChangesAsync();
+            existingId = existing.Id;
+        }
+
+        var vm = new BookAddViewModel(factory, _lookup, new SeriesMatchService(factory), new WorkSearchService(factory));
+        vm.BookInput.Title = "Attach-only book";
+        vm.EditionInput.Format = BookFormat.TradePaperback;
+        vm.IsCollection = true;
+        vm.CollectionWorks =
+        [
+            new() { AttachedWorkId = existingId, Title = "Existing" },
+        ];
+
+        var bookId = await vm.SaveAsync(selectedGenreIds: []);
+
+        Assert.NotNull(bookId);
+        using var db2 = factory.CreateDbContext();
+        var book = db2.Books.Include(b => b.Works).Single(b => b.Id == bookId);
+        Assert.Single(book.Works);
+        Assert.Equal(existingId, book.Works[0].Id);
+    }
+
+    [Fact]
+    public void AttachExistingToRow_FlipsRowToAttachMode_AndStashesDisplayFields()
+    {
+        var vm = CreateVm();
+        vm.IsCollection = true;
+        vm.CollectionWorks = [new() { Title = "user-typed" }];
+        var picked = new WorkSearchResult(
+            Id: 42, Title: "The Call of Cthulhu", Subtitle: null,
+            AuthorName: "H.P. Lovecraft", FirstPublishedYear: 1928, BookCount: 3);
+
+        vm.AttachExistingToRow(0, picked);
+
+        Assert.Equal(42, vm.CollectionWorks[0].AttachedWorkId);
+        Assert.Equal("H.P. Lovecraft", vm.CollectionWorks[0].AttachedWorkAuthor);
+        // Title mirrors the existing Work's title so the summary card
+        // and any subsequent save-then-edit round trip render it.
+        Assert.Equal("The Call of Cthulhu", vm.CollectionWorks[0].Title);
+        Assert.True(vm.HasAttachedWorkRows);
+    }
+
+    [Fact]
+    public void DetachRow_ClearsAttachedFields_AndPreservesUserTitle()
+    {
+        // "Edit as new" affordance — user changes their mind after picking.
+        // AttachedWorkId clears so the row returns to editable mode; the
+        // title stays as whatever was last on the row (the picked Work's
+        // title, which the user can edit / replace).
+        var vm = CreateVm();
+        vm.IsCollection = true;
+        vm.CollectionWorks = [new() { Title = "Existing", AttachedWorkId = 42, AttachedWorkAuthor = "Author" }];
+
+        vm.DetachRow(0);
+
+        Assert.Null(vm.CollectionWorks[0].AttachedWorkId);
+        Assert.Null(vm.CollectionWorks[0].AttachedWorkAuthor);
+        Assert.Equal("Existing", vm.CollectionWorks[0].Title);
+        Assert.False(vm.HasAttachedWorkRows);
     }
 
     [Fact]

--- a/BookTracker.Web/Components/Pages/Books/Add.razor
+++ b/BookTracker.Web/Components/Pages/Books/Add.razor
@@ -1,7 +1,9 @@
 @page "/books/add"
+@implements IAsyncDisposable
 @inject BookAddViewModel VM
 @inject NavigationManager Nav
 @inject IJSRuntime JS
+@inject IDialogService DialogService
 
 <PageTitle>Add a book - BookTracker</PageTitle>
 
@@ -19,7 +21,11 @@
                         <label for="noIsbnToggle" class="form-check-label">No ISBN (pre-1974 book)</label>
                     </div>
                     <div class="form-check form-switch mb-3">
-                        <input type="checkbox" id="collectionToggle" class="form-check-input" @bind="VM.IsCollection" />
+                        @* Custom @onchange instead of @bind because flipping the toggle OFF when
+                           any row is an attach-existing reference would silently discard those
+                           attachments — confirm first so a fat-finger flick is recoverable. *@
+                        <input type="checkbox" id="collectionToggle" class="form-check-input"
+                               checked="@VM.IsCollection" @onchange="OnCollectionToggleChangedAsync" />
                         <label for="collectionToggle" class="form-check-label">This is a collection (multiple works in one book)</label>
                     </div>
 
@@ -259,66 +265,117 @@
                         {
                             var index = i;
                             var work = VM.CollectionWorks[i];
-                            <div class="border rounded p-3 mb-3">
-                                <div class="d-flex justify-content-between align-items-center mb-2">
-                                    <strong>Work @(index + 1)</strong>
-                                    @if (VM.CollectionWorks.Count > 1)
-                                    {
-                                        <button type="button" class="btn btn-sm btn-outline-danger" @onclick="() => VM.RemoveCollectionWorkRow(index)">Remove</button>
-                                    }
-                                </div>
-                                <div class="row g-2">
-                                    <div class="col-md-@(VM.SingleAuthor ? 12 : 7)">
-                                        <label class="form-label small">Title</label>
-                                        @* Enter on these title inputs is handled in two layers:
-                                           collection-works.js installs a document-level keydown
-                                           listener that preventDefaults Enter on any element marked
-                                           with data-collection-work-title (stops the surrounding
-                                           form submitting); Blazor's @onkeydown still fires and
-                                           routes to OnCollectionTitleKeyDownAsync — Enter on the
-                                           last row adds a new row (inheriting authors from the
-                                           most recent populated row) and focuses its Title; Enter
-                                           on a non-last row jumps focus to the next row's Title.
-                                           Razor compiler rejects both inline onkeydown + Blazor's
-                                           @onkeydown on the same element (duplicate parameter name),
-                                           so the suppression lives in JS — same shape as the
-                                           chip-picker arc. *@
-                                        <InputText @bind-Value="work.Title"
-                                                   class="form-control"
-                                                   id="@($"collection-work-title-{index}")"
-                                                   data-collection-work-title=""
-                                                   @onkeydown="@(e => OnCollectionTitleKeyDownAsync(e, index))" />
+                            @if (work.AttachedWorkId is int)
+                            {
+                                @* Attach-existing summary card. Editable fields hidden; the existing Work
+                                   carries its own authors / subtitle / first-published / genres. "Edit as new"
+                                   reverts to the new-work shape preserving whatever title was typed. *@
+                                <div class="border rounded p-3 mb-3 bg-body-tertiary">
+                                    <div class="d-flex justify-content-between align-items-start gap-2">
+                                        <div class="flex-grow-1" style="min-width: 0;">
+                                            <div class="d-flex align-items-center gap-2 flex-wrap mb-1">
+                                                <span class="badge bg-secondary">Existing work</span>
+                                                <strong style="word-break: break-word;">@work.Title</strong>
+                                            </div>
+                                            @if (!string.IsNullOrEmpty(work.AttachedWorkAuthor))
+                                            {
+                                                <div class="small text-muted">@work.AttachedWorkAuthor</div>
+                                            }
+                                        </div>
+                                        <div class="d-flex gap-1 flex-shrink-0">
+                                            <button type="button" class="btn btn-sm btn-outline-secondary" @onclick="() => VM.DetachRow(index)">Edit as new</button>
+                                            @if (VM.CollectionWorks.Count > 1)
+                                            {
+                                                <button type="button" class="btn btn-sm btn-outline-danger" @onclick="() => VM.RemoveCollectionWorkRow(index)">Remove</button>
+                                            }
+                                        </div>
                                     </div>
-                                    @if (!VM.SingleAuthor)
-                                    {
+                                </div>
+                            }
+                            else
+                            {
+                                <div class="border rounded p-3 mb-3">
+                                    <div class="d-flex justify-content-between align-items-center mb-2">
+                                        <strong>Work @(index + 1)</strong>
+                                        @if (VM.CollectionWorks.Count > 1)
+                                        {
+                                            <button type="button" class="btn btn-sm btn-outline-danger" @onclick="() => VM.RemoveCollectionWorkRow(index)">Remove</button>
+                                        }
+                                    </div>
+                                    <div class="row g-2">
+                                        <div class="col-md-@(VM.SingleAuthor ? 12 : 7)">
+                                            <label class="form-label small">Title</label>
+                                            @* MudAutocomplete<WorkSearchResult> — as the user types, existing
+                                               Works appear in the dropdown. Picking one fires ValueChanged →
+                                               OnExistingWorkPickedAsync, flipping the row to attach-existing
+                                               mode. Free-text Enter (no dropdown highlight) falls through to
+                                               collection-works.js → page [JSInvokable] OnCollectionTitleEnter,
+                                               which adds a new row / focuses next. The wrapper div carries
+                                               data-collection-work-title="@index" so the JS doc-level keydown
+                                               listener can route the event correctly — MudAutocomplete renders
+                                               its <input> deep inside, so we can't put the data-attribute
+                                               directly on the input. *@
+                                            <div data-collection-work-title="@index">
+                                                <MudAutocomplete T="WorkSearchResult"
+                                                                 Value="null"
+                                                                 ValueChanged="@(picked => OnExistingWorkPickedAsync(picked, index))"
+                                                                 Text="@work.Title"
+                                                                 TextChanged="@(t => work.Title = t ?? string.Empty)"
+                                                                 SearchFunc="@(async (q, ct) => await SearchExistingWorksAsync(q, ct))"
+                                                                 ToStringFunc="@(r => r?.Title ?? string.Empty)"
+                                                                 Placeholder="Type to search existing or capture new..."
+                                                                 Variant="Variant.Outlined"
+                                                                 Margin="Margin.Dense"
+                                                                 MinCharacters="2"
+                                                                 DebounceInterval="250"
+                                                                 CoerceValue="false"
+                                                                 CoerceText="true"
+                                                                 ResetValueOnEmptyText="false"
+                                                                 ShowProgressIndicator="true">
+                                                    <ItemTemplate Context="r">
+                                                        <MudStack Spacing="0" Style="min-width: 0;">
+                                                            <MudText Typo="Typo.body2" Style="word-break: break-word;">
+                                                                @r.Title@(r.FirstPublishedYear is int y ? $" ({y})" : "")
+                                                            </MudText>
+                                                            <MudText Typo="Typo.caption" Color="Color.Secondary">
+                                                                @r.AuthorName · in @r.BookCount @(r.BookCount == 1 ? "book" : "books")
+                                                            </MudText>
+                                                        </MudStack>
+                                                    </ItemTemplate>
+                                                </MudAutocomplete>
+                                            </div>
+                                        </div>
+                                        @if (!VM.SingleAuthor)
+                                        {
+                                            <div class="col-md-5">
+                                                <label class="form-label small">Author(s)</label>
+                                                <MudAuthorPicker Authors="work.Authors"
+                                                                 AuthorsChanged="list => work.Authors = list"
+                                                                 Label="Add author" />
+                                            </div>
+                                        }
+                                        <div class="col-md-7">
+                                            <label class="form-label small">Subtitle <span class="text-muted">(optional)</span></label>
+                                            <InputText @bind-Value="work.Subtitle" class="form-control" />
+                                        </div>
                                         <div class="col-md-5">
-                                            <label class="form-label small">Author(s)</label>
-                                            <MudAuthorPicker Authors="work.Authors"
-                                                             AuthorsChanged="list => work.Authors = list"
-                                                             Label="Add author" />
+                                            <label class="form-label small">First published <span class="text-muted">(optional)</span></label>
+                                            <InputText @bind-Value="work.FirstPublishedDate" class="form-control" placeholder="e.g. 1934" />
                                         </div>
-                                    }
-                                    <div class="col-md-7">
-                                        <label class="form-label small">Subtitle <span class="text-muted">(optional)</span></label>
-                                        <InputText @bind-Value="work.Subtitle" class="form-control" />
+                                        @if (!VM.SingleGenre)
+                                        {
+                                            <div class="col-12">
+                                                <label class="form-label small">Genre(s)</label>
+                                                <MudGenrePicker SelectedGenreIds="work.GenreIds"
+                                                                SelectedGenreIdsChanged="ids => work.GenreIds = ids" />
+                                            </div>
+                                        }
                                     </div>
-                                    <div class="col-md-5">
-                                        <label class="form-label small">First published <span class="text-muted">(optional)</span></label>
-                                        <InputText @bind-Value="work.FirstPublishedDate" class="form-control" placeholder="e.g. 1934" />
-                                    </div>
-                                    @if (!VM.SingleGenre)
-                                    {
-                                        <div class="col-12">
-                                            <label class="form-label small">Genre(s)</label>
-                                            <MudGenrePicker SelectedGenreIds="work.GenreIds"
-                                                            SelectedGenreIdsChanged="ids => work.GenreIds = ids" />
-                                        </div>
-                                    }
                                 </div>
-                            </div>
+                            }
                         }
                         <button type="button" class="btn btn-outline-primary btn-sm" @onclick="VM.AddCollectionWorkRow">+ Add another work</button>
-                        <div class="form-text mt-2">Series suggestions are set per-work after saving — open each work from the book detail page to tag.</div>
+                        <div class="form-text mt-2">Start typing a title and any matching existing Works appear — Enter on a highlighted match attaches it; press Enter on free text to add the next new row.</div>
                     </div>
                 </div>
             </div>
@@ -350,20 +407,26 @@
     private MudGenrePicker? genrePicker;
     private bool addAnother;
 
-    // After OnCollectionTitleKeyDownAsync grows the CollectionWorks list,
-    // the new row's DOM element only exists post-render. Stash the index
-    // here and apply focus in OnAfterRenderAsync so the JS focus call
-    // hits an element that actually exists.
+    // After Enter on a title grows the CollectionWorks list (or an
+    // existing-Work pick advances to the next row), the new row's DOM
+    // element only exists post-render. Stash the index here and apply
+    // focus in OnAfterRenderAsync so the JS focus call hits an element
+    // that actually exists.
     private int? _pendingCollectionFocusIndex;
+
+    // DotNetObjectReference handed to collection-works.js so the JS
+    // keydown listener can call back into Blazor with the row index
+    // when Enter fires on a non-highlighted Title (the "add new row /
+    // focus next" path). Disposed on circuit teardown so the listener
+    // can't call a dead managed object.
+    private DotNetObjectReference<Add>? _pageRef;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (firstRender)
         {
-            // Install the Enter-suppression keydown listener once per
-            // SPA session. Idempotent on the JS side; firstRender
-            // gating here keeps the call count to one per page-load.
-            await JS.InvokeVoidAsync("collectionWorks.bindEnterSuppression");
+            _pageRef = DotNetObjectReference.Create(this);
+            await JS.InvokeVoidAsync("collectionWorks.bindEnterSuppression", _pageRef);
         }
 
         if (_pendingCollectionFocusIndex is int idx)
@@ -373,27 +436,90 @@
         }
     }
 
-    private async Task OnCollectionTitleKeyDownAsync(KeyboardEventArgs e, int index)
+    public ValueTask DisposeAsync()
     {
-        if (e.Key != "Enter") return;
+        _pageRef?.Dispose();
+        return ValueTask.CompletedTask;
+    }
+
+    /// <summary>Invoked by collection-works.js when Enter fires on a
+    /// title input AND no autocomplete suggestion is highlighted —
+    /// equivalent to the old @onkeydown handler's last-row vs mid-list
+    /// behaviour. Existing-Work rows have no input (they render as a
+    /// summary), so the JS listener never targets them.</summary>
+    [JSInvokable]
+    public async Task OnCollectionTitleEnter(int index)
+    {
         if (!VM.IsCollection) return;
         if (index < 0 || index >= VM.CollectionWorks.Count) return;
 
         if (index == VM.CollectionWorks.Count - 1)
         {
-            // Last row: add a new row (inheriting authors per
-            // BookAddViewModel.AddCollectionWorkRow) and queue focus
-            // on it for after the re-render.
             VM.AddCollectionWorkRow();
             _pendingCollectionFocusIndex = VM.CollectionWorks.Count - 1;
+            await InvokeAsync(StateHasChanged);
         }
         else
         {
-            // Mid-list Enter: jump focus to the next row's Title field.
-            // Tab-like behaviour for the typing flow without touching
-            // the surrounding form's tab order.
             await JS.InvokeVoidAsync("collectionWorks.focusTitle", index + 1);
         }
+    }
+
+    /// <summary>Fired when the user picks a suggestion from the row's
+    /// title autocomplete (Enter on a highlighted item, or click).
+    /// Flips the row to attach-existing mode and advances focus to
+    /// the next row's title — same continuation as Enter-on-free-text,
+    /// so the keyboard flow doesn't break stride after a pick.</summary>
+    private async Task OnExistingWorkPickedAsync(WorkSearchResult? picked, int index)
+    {
+        if (picked is null) return;
+        if (!VM.IsCollection) return;
+        if (index < 0 || index >= VM.CollectionWorks.Count) return;
+
+        VM.AttachExistingToRow(index, picked);
+
+        if (index == VM.CollectionWorks.Count - 1)
+        {
+            VM.AddCollectionWorkRow();
+        }
+        _pendingCollectionFocusIndex = index + 1;
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private async Task<IEnumerable<WorkSearchResult>> SearchExistingWorksAsync(string? query, CancellationToken ct)
+    {
+        try { return await VM.SearchExistingWorksAsync(query ?? "", ct); }
+        catch { return []; }
+    }
+
+    /// <summary>Custom toggle handler for the collection switch — confirms
+    /// before flipping OFF when there are existing-Work attachments on
+    /// rows (a fat-finger flick would otherwise silently drop them, since
+    /// the single-Work form has nowhere to put attachments).</summary>
+    private async Task OnCollectionToggleChangedAsync(ChangeEventArgs e)
+    {
+        var newValue = e.Value is bool b && b;
+        if (newValue == VM.IsCollection) return;
+
+        if (!newValue && VM.HasAttachedWorkRows)
+        {
+            var attachedCount = VM.CollectionWorks.Count(r => r.AttachedWorkId is not null);
+            var confirmed = await DialogService.ShowMessageBoxAsync(
+                "Discard attached works?",
+                $"Switching off collection mode will discard {attachedCount} existing-work attachment{(attachedCount == 1 ? "" : "s")}. Continue?",
+                yesText: "Discard",
+                cancelText: "Keep collection mode");
+            if (confirmed != true)
+            {
+                // Confirm cancelled — re-render so the checkbox snaps back
+                // to ON (the DOM updated optimistically when the user clicked).
+                await InvokeAsync(StateHasChanged);
+                return;
+            }
+        }
+
+        VM.IsCollection = newValue;
+        await InvokeAsync(StateHasChanged);
     }
 
     private async Task LookupAsync()

--- a/BookTracker.Web/Components/Pages/Books/Add.razor
+++ b/BookTracker.Web/Components/Pages/Books/Add.razor
@@ -316,6 +316,13 @@
                                                its <input> deep inside, so we can't put the data-attribute
                                                directly on the input. *@
                                             <div data-collection-work-title="@index">
+                                                @* CoerceText="false" so Esc / un-picked dropdown close doesn'\''t
+                                                   revert work.Title to the (null) Value's display string —
+                                                   the typed text needs to survive for the "captured as new"
+                                                   flow. Paired with the collection-works.js capture-phase
+                                                   listener that tracks user navigation (Down/Up) per input
+                                                   and only defers to MudAutocomplete's auto-pick when the
+                                                   user has explicitly arrow-keyed. *@
                                                 <MudAutocomplete T="WorkSearchResult"
                                                                  Value="null"
                                                                  ValueChanged="@(picked => OnExistingWorkPickedAsync(picked, index))"
@@ -329,7 +336,7 @@
                                                                  MinCharacters="2"
                                                                  DebounceInterval="250"
                                                                  CoerceValue="false"
-                                                                 CoerceText="true"
+                                                                 CoerceText="false"
                                                                  ResetValueOnEmptyText="false"
                                                                  ShowProgressIndicator="true">
                                                     <ItemTemplate Context="r">

--- a/BookTracker.Web/ViewModels/BookAddViewModel.cs
+++ b/BookTracker.Web/ViewModels/BookAddViewModel.cs
@@ -8,8 +8,17 @@ namespace BookTracker.Web.ViewModels;
 public class BookAddViewModel(
     IDbContextFactory<BookTrackerDbContext> dbFactory,
     IBookLookupService lookup,
-    SeriesMatchService seriesMatch)
+    SeriesMatchService seriesMatch,
+    IWorkSearchService workSearch)
 {
+    /// <summary>Search existing Works for the collection-row autocomplete.
+    /// Returns matches as the user types so they can attach an already-
+    /// captured Work rather than re-typing it. excludeBookId is null —
+    /// the Book is brand-new so there's nothing to exclude.</summary>
+    public Task<IReadOnlyList<WorkSearchResult>> SearchExistingWorksAsync(string query, CancellationToken ct)
+        => workSearch.SearchAsync(query, excludeBookId: null, ct: ct);
+
+
     public BookFormViewModel.BookFormInput BookInput { get; set; } = new();
     public WorkFormViewModel.WorkFormInput WorkInput { get; set; } = new();
     public EditionFormViewModel.EditionFormInput EditionInput { get; set; } = new();
@@ -146,6 +155,38 @@ public class BookAddViewModel(
         if (index < 0 || index >= CollectionWorks.Count) return;
         CollectionWorks.RemoveAt(index);
         if (CollectionWorks.Count == 0) CollectionWorks.Add(new());
+    }
+
+    /// <summary>True if any collection row is in attach-existing mode —
+    /// used by the page to decide whether to surface a confirm dialog
+    /// when the user flicks IsCollection back off (existing-work
+    /// attachments would be silently discarded otherwise).</summary>
+    public bool HasAttachedWorkRows => CollectionWorks.Any(r => r.AttachedWorkId is not null);
+
+    /// <summary>Marks a collection row as "attach this existing Work to
+    /// the new Book" instead of creating a new one. The row's editable
+    /// fields are kept (so reverting is non-destructive) but ignored at
+    /// save time; the UI hides them in favour of a compact summary.</summary>
+    public void AttachExistingToRow(int rowIndex, WorkSearchResult picked)
+    {
+        if (rowIndex < 0 || rowIndex >= CollectionWorks.Count) return;
+        var row = CollectionWorks[rowIndex];
+        row.AttachedWorkId = picked.Id;
+        row.AttachedWorkAuthor = picked.AuthorName;
+        // Mirror the existing Work's title into the row's title so subsequent
+        // re-opens of the page or save-then-edit flows render the right
+        // string. Title still flows through `row.Title` either way.
+        row.Title = picked.Title;
+    }
+
+    /// <summary>Undo an existing-work attach on a row — clears the
+    /// AttachedWorkId so the row returns to editable new-work mode.
+    /// Preserves whatever title the user had typed before picking.</summary>
+    public void DetachRow(int rowIndex)
+    {
+        if (rowIndex < 0 || rowIndex >= CollectionWorks.Count) return;
+        CollectionWorks[rowIndex].AttachedWorkId = null;
+        CollectionWorks[rowIndex].AttachedWorkAuthor = null;
     }
     public string? SearchTitle { get; set; }
     public string? SearchAuthor { get; set; }
@@ -454,46 +495,61 @@ public class BookAddViewModel(
             List<Work> works;
             if (IsCollection)
             {
-                // Collection mode: build N Works, one per row. Series
-                // suggestions are still deferred to per-work editing on
-                // /books/{id}/edit (the lookup flow can't pick per-work, and
-                // applying to all would be wrong). Genres now ride with the
-                // capture flow: shared list when SingleGenre is on, per-row
-                // GenreIds otherwise.
+                // Collection mode: build N Works, one per row. Rows split
+                // into two flavours:
+                //   - attach-existing rows (AttachedWorkId set): load the
+                //     existing Work from the DB and attach it; the inline
+                //     edit fields are not used.
+                //   - new-work rows (AttachedWorkId null): create a Work
+                //     from the row fields (title, authors, subtitle,
+                //     first-published, per-row or shared genres).
                 //
-                // Author source depends on SingleAuthor mode: when on, the
-                // shared SharedAuthors chip-list applies to every row; when
-                // off, each row carries its own Authors list. Effective list
-                // is selected per row via the local helpers.
+                // Series suggestions stay deferred to per-work editing on
+                // /books/{id}/edit (the lookup flow can't pick per-work, and
+                // applying to all would be wrong). Author source depends on
+                // SingleAuthor mode; genre source on SingleGenre — both
+                // apply only to new-work rows (existing Works bring their
+                // own).
                 List<string> AuthorsFor(WorkFormViewModel.WorkFormInput row) =>
                     SingleAuthor ? SharedAuthors : row.Authors;
                 List<int> GenresFor(WorkFormViewModel.WorkFormInput row) =>
                     SingleGenre ? SharedGenreIds : row.GenreIds;
 
-                var rows = CollectionWorks
-                    .Where(w => !string.IsNullOrWhiteSpace(w.Title) && AuthorsFor(w).Count > 0)
+                // Preserve the user-entered order across both row flavours so
+                // the saved Book.Works reflects the order on screen.
+                var orderedRows = CollectionWorks
+                    .Where(w => w.AttachedWorkId is not null
+                                || (!string.IsNullOrWhiteSpace(w.Title) && AuthorsFor(w).Count > 0))
                     .ToList();
-                if (rows.Count == 0)
+                if (orderedRows.Count == 0)
                 {
                     throw new InvalidOperationException(SingleAuthor
-                        ? "A collection in Single-Author mode needs at least one work with a title, plus at least one shared author."
-                        : "A collection must contain at least one work with a title and an author.");
+                        ? "A collection in Single-Author mode needs at least one work with a title, plus at least one shared author. (Or attach an existing work.)"
+                        : "A collection must contain at least one work with a title and an author. (Or attach an existing work.)");
                 }
-                // Resolve the union of distinct author names across all rows
-                // in one pass — calling FindOrCreate per row would create
-                // duplicate Author entities when the same name appears in
-                // multiple stories (the existence check queries the committed
-                // DB, missing pending entities in the change tracker).
-                var allNames = SingleAuthor ? SharedAuthors : rows.SelectMany(r => r.Authors);
+
+                var newRows = orderedRows.Where(r => r.AttachedWorkId is null).ToList();
+                var attachIds = orderedRows
+                    .Where(r => r.AttachedWorkId is int)
+                    .Select(r => r.AttachedWorkId!.Value)
+                    .Distinct()
+                    .ToList();
+
+                // Resolve the union of distinct author names across new-work
+                // rows in one pass — calling FindOrCreate per row would
+                // create duplicate Author entities when the same name
+                // appears in multiple stories (the existence check queries
+                // the committed DB, missing pending entities in the change
+                // tracker).
+                var allNames = SingleAuthor ? SharedAuthors : newRows.SelectMany(r => r.Authors);
                 var allAuthors = await AuthorResolver.FindOrCreateAllAsync(allNames, db);
                 var byName = allAuthors.ToDictionary(a => a.Name, StringComparer.OrdinalIgnoreCase);
 
-                // Resolve the union of distinct genre ids across all rows in
-                // one query — same reason as authors above, and a single
-                // round-trip beats N row-by-row Genres lookups.
+                // Resolve the union of distinct genre ids across new-work
+                // rows in one query.
                 var allGenreIds = (SingleGenre
                     ? SharedGenreIds
-                    : rows.SelectMany(r => r.GenreIds))
+                    : newRows.SelectMany(r => r.GenreIds))
                     .Distinct()
                     .ToList();
                 var collectionGenres = allGenreIds.Count == 0
@@ -501,9 +557,27 @@ public class BookAddViewModel(
                     : await db.Genres.Where(g => allGenreIds.Contains(g.Id)).ToListAsync();
                 var genresById = collectionGenres.ToDictionary(g => g.Id);
 
-                works = new List<Work>(rows.Count);
-                foreach (var row in rows)
+                // Load the attach-existing Works in one query. Missing ids
+                // are silently dropped — they can only happen if the Work
+                // was deleted between picking it in the dialog and saving;
+                // failing the whole save over that would be unhelpful.
+                var attachedWorks = attachIds.Count == 0
+                    ? new List<Work>()
+                    : await db.Works.Where(w => attachIds.Contains(w.Id)).ToListAsync();
+                var attachedById = attachedWorks.ToDictionary(w => w.Id);
+
+                works = new List<Work>(orderedRows.Count);
+                foreach (var row in orderedRows)
                 {
+                    if (row.AttachedWorkId is int existingId)
+                    {
+                        if (attachedById.TryGetValue(existingId, out var existing))
+                        {
+                            works.Add(existing);
+                        }
+                        continue;
+                    }
+
                     var rowAuthors = AuthorsFor(row)
                         .Select(n => n?.Trim())
                         .Where(n => !string.IsNullOrEmpty(n))

--- a/BookTracker.Web/ViewModels/WorkFormViewModel.cs
+++ b/BookTracker.Web/ViewModels/WorkFormViewModel.cs
@@ -33,5 +33,16 @@ public class WorkFormViewModel
         // captures still route genre selection through the page's own
         // selectedGenreIds field rather than this list.
         public List<int> GenreIds { get; set; } = [];
+
+        // Attach-existing mode (collection rows only). When AttachedWorkId is
+        // set the row represents "attach this already-saved Work to the new
+        // Book" rather than "create a new Work with the fields above" —
+        // save-time skips the create branch for that row, validation skips
+        // the title/author requirement, and the UI hides the editable fields
+        // in favour of a compact summary card. AttachedWorkAuthor is the
+        // lead-author display string captured at pick time so the summary
+        // can render without re-querying.
+        public int? AttachedWorkId { get; set; }
+        public string? AttachedWorkAuthor { get; set; }
     }
 }

--- a/BookTracker.Web/wwwroot/js/collection-works.js
+++ b/BookTracker.Web/wwwroot/js/collection-works.js
@@ -2,15 +2,18 @@
 //
 // Two responsibilities:
 //
-//   (a) Suppress the Enter key in collection-mode Title inputs so it
+//   (a) Suppress the Enter key on each collection-mode Title input so it
 //       doesn't submit the surrounding form. Mirrors the chip-picker
 //       arc's trap — Blazor's @onkeydown:preventDefault is a compile-
 //       time constant; can't be conditional on the key. A document-
-//       level keydown listener delegating to inputs marked with
-//       data-collection-work-title preventDefaults Enter without
-//       disturbing other keys (digits, letters, backspace) which still
-//       reach the input normally. Blazor's element-level @onkeydown
-//       still fires after — it handles the row-add / focus-next logic.
+//       level keydown listener delegating to inputs inside an element
+//       marked with data-collection-work-title preventDefaults Enter
+//       without disturbing other keys. When MudAutocomplete has a
+//       highlighted dropdown suggestion (aria-activedescendant or the
+//       DOM-highlighted .mud-selected-item) we defer — MudAutocomplete's
+//       own listener will commit the pick via ValueChanged. Otherwise
+//       we invoke the page's [JSInvokable] OnCollectionTitleEnter to
+//       run the "add new row / focus next row" logic.
 //
 //   (b) Imperative focus on a specific row's Title input by index.
 //       Called from Blazor after OnAfterRenderAsync sees a freshly-
@@ -18,35 +21,63 @@
 //
 // The suppression binds idempotently — first OnAfterRenderAsync after
 // page load installs the listener; subsequent calls (re-renders, page
-// revisits within the same SPA session) no-op.
+// revisits within the same SPA session) no-op. The DotNetObjectReference
+// is stashed for the lifetime of the page; replaced if bindEnterSuppression
+// is called again with a new ref (e.g. after a circuit reconnect).
 window.collectionWorks = (function () {
     let suppressionBound = false;
+    let pageDotnetRef = null;
 
-    function bindEnterSuppression() {
+    function bindEnterSuppression(dotnetRef) {
+        // Always update the ref — a stale one from a previous circuit
+        // would hand the keydown to a disposed Blazor object.
+        pageDotnetRef = dotnetRef;
         if (suppressionBound) return;
         suppressionBound = true;
-        document.addEventListener('keydown', function (e) {
+        document.addEventListener('keydown', async function (e) {
             if (e.key !== 'Enter') return;
             const t = e.target;
             if (!t || typeof t.matches !== 'function') return;
-            if (!t.matches('[data-collection-work-title]')) return;
-            // preventDefault stops the form's default Enter-submits-form
-            // behaviour. Other listeners (Blazor's @onkeydown) still
-            // receive the event.
+
+            // Match either the wrapper itself or any input/element inside one.
+            // MudAutocomplete renders the input deep inside its own DOM, so
+            // we can't put the data-attribute directly on the input.
+            const wrapper = t.closest === undefined ? null : t.closest('[data-collection-work-title]');
+            if (!wrapper) return;
+
+            // Always preventDefault Enter — keeps the surrounding form from
+            // submitting. Other listeners (MudAutocomplete's own) still fire.
             e.preventDefault();
+
+            // Defer to MudAutocomplete when a dropdown suggestion is
+            // highlighted — its ValueChanged will flip the row to attach-
+            // existing mode. Same shape as the chip-picker arc.
+            const input = t.tagName === 'INPUT' ? t : wrapper.querySelector('input');
+            const ariaActive = input ? input.getAttribute('aria-activedescendant') : null;
+            const domHighlighted = document.querySelector('.mud-popover-open .mud-selected-item');
+            if (ariaActive || domHighlighted) {
+                return;
+            }
+
+            const indexStr = wrapper.getAttribute('data-collection-work-title');
+            const index = parseInt(indexStr, 10);
+            if (isNaN(index)) return;
+
+            if (pageDotnetRef) {
+                await pageDotnetRef.invokeMethodAsync('OnCollectionTitleEnter', index);
+            }
         });
     }
 
     function focusTitle(index) {
-        const el = document.getElementById('collection-work-title-' + index);
-        if (!el) return;
-        el.focus();
-        // Defensive: if the target had pre-filled text (shouldn't, for
-        // a freshly-added empty row) put the cursor at the end rather
-        // than selecting all and over-typing.
-        if (typeof el.setSelectionRange === 'function') {
-            const len = el.value ? el.value.length : 0;
-            el.setSelectionRange(len, len);
+        const wrapper = document.querySelector('[data-collection-work-title="' + index + '"]');
+        if (!wrapper) return;
+        const input = wrapper.querySelector('input');
+        if (!input) return;
+        input.focus();
+        if (typeof input.setSelectionRange === 'function') {
+            const len = input.value ? input.value.length : 0;
+            input.setSelectionRange(len, len);
         }
     }
 

--- a/BookTracker.Web/wwwroot/js/collection-works.js
+++ b/BookTracker.Web/wwwroot/js/collection-works.js
@@ -103,6 +103,19 @@ window.collectionWorks = (function () {
             // Free-text Enter: block MudAutocomplete's auto-pick of the
             // first-highlighted item, then invoke the page's add-row /
             // focus-next handler with the typed text intact.
+            //
+            // Known trade-off: the popover stays visible after this
+            // Enter because stopImmediatePropagation prevents
+            // MudAutocomplete from learning about the keypress. The
+            // user dismisses it with Esc (universal "close popup"
+            // affordance). Three close-it-for-them attempts failed:
+            // input.blur() doesn't cascade to a portaled popover;
+            // synthetic Esc keydown gets filtered out by Blazor's
+            // event delegation (isTrusted=false); directly removing
+            // the .mud-popover-open class drifted MudAutocomplete's
+            // internal state vs. the DOM and didn't actually hide
+            // the popover. Living with the papercut is cheaper than
+            // a fragile fix.
             e.stopImmediatePropagation();
 
             const indexStr = wrapper.getAttribute('data-collection-work-title');

--- a/BookTracker.Web/wwwroot/js/collection-works.js
+++ b/BookTracker.Web/wwwroot/js/collection-works.js
@@ -1,63 +1,109 @@
 // JS helpers for the Add Book collection-mode "capture works" flow.
 //
-// Two responsibilities:
+// Three responsibilities:
 //
-//   (a) Suppress the Enter key on each collection-mode Title input so it
-//       doesn't submit the surrounding form. Mirrors the chip-picker
-//       arc's trap — Blazor's @onkeydown:preventDefault is a compile-
-//       time constant; can't be conditional on the key. A document-
-//       level keydown listener delegating to inputs inside an element
-//       marked with data-collection-work-title preventDefaults Enter
-//       without disturbing other keys. When MudAutocomplete has a
-//       highlighted dropdown suggestion (aria-activedescendant or the
-//       DOM-highlighted .mud-selected-item) we defer — MudAutocomplete's
-//       own listener will commit the pick via ValueChanged. Otherwise
-//       we invoke the page's [JSInvokable] OnCollectionTitleEnter to
-//       run the "add new row / focus next row" logic.
+//   (a) Stop the surrounding form from submitting on Enter inside a
+//       collection-mode Title input. Mirrors the chip-picker arc's
+//       trap — Blazor's @onkeydown:preventDefault is a compile-time
+//       constant and can't be conditional on the key.
 //
-//   (b) Imperative focus on a specific row's Title input by index.
+//   (b) Decide what Enter MEANS on a Title input. MudAutocomplete
+//       auto-highlights the first dropdown match as soon as the
+//       dropdown opens, so a naive "if highlighted, defer to
+//       MudAutocomplete" check would pick "Condor" whenever the user
+//       typed "Con" and pressed Enter — even if they intended to
+//       capture "Con..." as a new Work. Drew's repro. Fix: track
+//       whether the user has explicitly arrow-keyed since the last
+//       text edit. Only THEN does Enter defer to MudAutocomplete; an
+//       Enter on a never-navigated input goes to our row-add handler
+//       with the typed text intact.
+//
+//       Implementation runs at the CAPTURE phase so we fire BEFORE
+//       MudAutocomplete's own keydown listener. When we decide the
+//       Enter is "free text", we stopImmediatePropagation — that
+//       blocks MudAutocomplete from committing its auto-highlighted
+//       item. When we decide it's "navigated", we let the event flow
+//       through and MudAutocomplete commits the pick (→ ValueChanged
+//       → OnExistingWorkPickedAsync).
+//
+//   (c) Imperative focus on a specific row's Title input by index.
 //       Called from Blazor after OnAfterRenderAsync sees a freshly-
 //       added row so the DOM has had a chance to render the element.
 //
-// The suppression binds idempotently — first OnAfterRenderAsync after
-// page load installs the listener; subsequent calls (re-renders, page
-// revisits within the same SPA session) no-op. The DotNetObjectReference
-// is stashed for the lifetime of the page; replaced if bindEnterSuppression
-// is called again with a new ref (e.g. after a circuit reconnect).
+// Idempotent binding — first OnAfterRenderAsync after page load
+// installs the listener; subsequent calls (re-renders, page revisits
+// within the same SPA session) just refresh the DotNetObjectReference.
 window.collectionWorks = (function () {
-    let suppressionBound = false;
+    let listenerBound = false;
     let pageDotnetRef = null;
+    // WeakSet of input elements where the user has pressed Down/Up since
+    // the last text edit. WeakSet so detached input elements (removed
+    // rows, mode flips to attach) get garbage-collected without a leak.
+    const navigatedInputs = new WeakSet();
+
+    function isPrintableKey(key) {
+        // Single-char keys are typing; Backspace/Delete also count as
+        // "the user is editing the text" and should reset navigation.
+        return (key && key.length === 1) || key === 'Backspace' || key === 'Delete';
+    }
 
     function bindEnterSuppression(dotnetRef) {
-        // Always update the ref — a stale one from a previous circuit
-        // would hand the keydown to a disposed Blazor object.
         pageDotnetRef = dotnetRef;
-        if (suppressionBound) return;
-        suppressionBound = true;
+        if (listenerBound) return;
+        listenerBound = true;
+
         document.addEventListener('keydown', async function (e) {
-            if (e.key !== 'Enter') return;
             const t = e.target;
             if (!t || typeof t.matches !== 'function') return;
 
-            // Match either the wrapper itself or any input/element inside one.
-            // MudAutocomplete renders the input deep inside its own DOM, so
-            // we can't put the data-attribute directly on the input.
             const wrapper = t.closest === undefined ? null : t.closest('[data-collection-work-title]');
             if (!wrapper) return;
 
-            // Always preventDefault Enter — keeps the surrounding form from
-            // submitting. Other listeners (MudAutocomplete's own) still fire.
-            e.preventDefault();
-
-            // Defer to MudAutocomplete when a dropdown suggestion is
-            // highlighted — its ValueChanged will flip the row to attach-
-            // existing mode. Same shape as the chip-picker arc.
             const input = t.tagName === 'INPUT' ? t : wrapper.querySelector('input');
-            const ariaActive = input ? input.getAttribute('aria-activedescendant') : null;
-            const domHighlighted = document.querySelector('.mud-popover-open .mud-selected-item');
-            if (ariaActive || domHighlighted) {
+            if (!input) return;
+
+            if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+                navigatedInputs.add(input);
                 return;
             }
+
+            if (isPrintableKey(e.key)) {
+                // User edited the text — reset navigation. A fresh search
+                // will re-populate the dropdown with first-item auto-
+                // highlighted; we treat that as "not yet navigated" again.
+                navigatedInputs.delete(input);
+                return;
+            }
+
+            if (e.key === 'Escape') {
+                // Clear navigation flag so a subsequent Enter is "free
+                // text". (MudAutocomplete handles closing the dropdown
+                // itself — we don't preventDefault here.)
+                navigatedInputs.delete(input);
+                return;
+            }
+
+            if (e.key !== 'Enter') return;
+
+            // preventDefault unconditionally — Enter inside a form must
+            // never submit it.
+            e.preventDefault();
+
+            if (navigatedInputs.has(input)) {
+                // User explicitly arrow-keyed to a suggestion — let
+                // MudAutocomplete's own listener (which fires after this
+                // capture-phase one, at the input/bubble phase) commit
+                // the pick. ValueChanged → OnExistingWorkPickedAsync
+                // flips the row to attach mode. Clear the flag so the
+                // next typing cycle starts fresh.
+                navigatedInputs.delete(input);
+                return;
+            }
+
+            // Free-text Enter: block MudAutocomplete's auto-pick of the
+            // first-highlighted item, then invoke the page's add-row /
+            // focus-next handler with the typed text intact.
+            e.stopImmediatePropagation();
 
             const indexStr = wrapper.getAttribute('data-collection-work-title');
             const index = parseInt(indexStr, 10);
@@ -66,7 +112,7 @@ window.collectionWorks = (function () {
             if (pageDotnetRef) {
                 await pageDotnetRef.invokeMethodAsync('OnCollectionTitleEnter', index);
             }
-        });
+        }, true /* capture phase — fire BEFORE input-level listeners */);
     }
 
     function focusTitle(index) {


### PR DESCRIPTION
- **chore(memory): capture Blazor dialog VM lifetime trap from PR 4**
- **feat(add): keyboard-first existing-Work autocomplete on collection rows**
- **fix(add): only commit autocomplete pick when user has arrow-keyed**
- **docs(add): note popover-stays-open trade-off inline**
