### PR TITLE
chore: TODO sync — drop stale comments, fix swap.yml TODO ref

### DIFF
--- a/.github/workflows/swap.yml
+++ b/.github/workflows/swap.yml
@@ -3,7 +3,7 @@ name: Swap staging to production
 # The `production` GitHub Environment (Settings -> Environments) gates this
 # job: 2-minute wait timer (cancellable window for fat-finger dispatches) and
 # Deployment branches restricted to `main`. Required-reviewer approval is a
-# future step, blocked on having a collaborator (TODO.md #26).
+# future step, blocked on having a collaborator (TODO.md #22).
 on:
   workflow_dispatch:
 

--- a/BookTracker.Data/Models/Publisher.cs
+++ b/BookTracker.Data/Models/Publisher.cs
@@ -2,9 +2,6 @@ using System.ComponentModel.DataAnnotations;
 
 namespace BookTracker.Data.Models;
 
-// TODO: add a "Manage publishers" feature — UI to rename/merge duplicates,
-// delete unused publishers, and see which editions each publisher covers.
-// Right now Publishers are only created via find-or-create on the Add page.
 public class Publisher
 {
     public int Id { get; set; }


### PR DESCRIPTION
- `Publisher.cs` carried a `// TODO: add a Manage publishers feature` comment;
  the feature shipped as PR #121 and `/publishers` page exists. Comment
  removed.
- `swap.yml` referenced `TODO.md #26` for the "blocked on having a
  collaborator" note. Current TODO numbering puts that as #22
  ("Claude-driven PR review for external contributions"); the Shipped row
  for the swap.yml feature already references #22 correctly, this is the
  drift.

All other code-level `// TODO` references verified against TODO.md.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
