### PR TITLE
chore(memory): hot-reload-commit-gap feedback from PR2 follow-up arc

### DIFF
--- a/.claude-memory/MEMORY.md
+++ b/.claude-memory/MEMORY.md
@@ -2,6 +2,7 @@
 - ["plan:" prefix](feedback_plan_prefix.md) — when a message starts with "plan:", propose with defaults + open questions and wait; don't execute.
 - [Drew — solo developer](user_drew.md) — context on the user, their stack (Windows/PowerShell/Azure/GitHub `N3rdage/the-library`, Gandi DNS), and collaboration style.
 - [Auto-commit locally](feedback_commit_locally.md) — always stage and commit before handing off; don't wait to be asked.
+- [Hot-reload ≠ committed](feedback_hot_reload_commit_gap.md) — every mid-PR-cycle edit must be committed before the user tests it; hot-reload makes uncommitted edits feel "done".
 - [Delete merged branches](feedback_delete_merged_branch.md) — delete local feature branch after pulling the merge into main.
 - [Branch from main](feedback_branch_from_main.md) — always start a new branch from a fresh `main` pull; never from a sibling branch (squash-merge would bundle content).
 - [Use PowerShell tool](feedback_use_powershell.md) — default shell for this project is PowerShell 7, not Bash; CLAUDE.md mandates Windows shell and Drew works in PowerShell.

--- a/.claude-memory/feedback_hot_reload_commit_gap.md
+++ b/.claude-memory/feedback_hot_reload_commit_gap.md
@@ -1,0 +1,14 @@
+---
+name: hot-reload-commit-gap
+description: "Every mid-PR-cycle change must be committed before the user tests it. Hot-reload makes uncommitted edits feel \"done\" to the user — when they then say \"merged\", the merge only contains what was actually pushed."
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 357f34b8-2b9f-4268-b445-cf71fd75fda6
+---
+
+When iterating on a PR after the initial push — Drew flags an issue, I edit, Drew checks via `dotnet watch` hot-reload — every accepted change must be committed (and Drew pinged to push the follow-up) before Drew tests it, OR I must explicitly flag "these are uncommitted local-only" each time.
+
+**Why:** PR2 of the MudBlazor reskin arc (#248) shipped without two follow-up fixes (BulkAdd MudTable + AIProviderToggle Mud conversion). Drew flagged them in browser, I edited, hot-reload picked them up live, Drew tested in browser, said "tested and merged" — but those edits were uncommitted local-only. The merge contained only the original commit. Required a separate clean-up PR (#249) just to land what Drew thought was already merged.
+
+**How to apply:** After making any code change during a "review the live PR" cycle, immediately commit on the existing branch and tell Drew to push the new tip *before* asking them to re-test. The hot-reload preview is not a substitute for a git commit. Pairs with [[feedback_commit_locally]] — same rule, but applied to mid-cycle iterations rather than end-of-task hand-off.


### PR DESCRIPTION
Captures the process trap from PRs #248/#249. See commit message.