### PR TITLE
chore(memory): sharper TODO sync — add step 4 probing Open rows vs codebase

### DIFF
--- a/.claude-memory/MEMORY.md
+++ b/.claude-memory/MEMORY.md
@@ -12,7 +12,7 @@
 - [Testing conventions](feedback_testing_conventions.md) — minimal tests for new logic to prevent regression; skip for pure markup.
 - [Deployment safety](feedback_deployment_safety.md) — migrations must retain data; breaking changes need defaults and review tags.
 - [Performance target](project_performance_target.md) — system must handle 3000+ copies; flag designs that might struggle at scale.
-- [TODO tracking](feedback_todo_tracking.md) — all TODOs in TODO.md; "sync TODOs" reconciles memory + code + TODO.md.
+- [TODO tracking](feedback_todo_tracking.md) — all TODOs in TODO.md; "sync TODOs" reconciles memory + code + TODO.md AND probes each Open row against the codebase for shipped-but-not-moved drift.
 - [Memory excluded from PRs](feedback_memory_commits.md) — don't stage .claude-memory/ in feature commits; flag changes for a separate commit.
 - [Keep ARCHITECTURE.md updated](feedback_architecture_doc.md) — update when structural changes are made (entities, pages, services, patterns).
 - [Blog post backlog](blog_post_backlog.md) — corpus-derived candidate posts mineable from existing retros + `patterns.md`. 7 shipped + 7 strong / 6 possible candidates remaining from the 2026-04-28 catch-up mine.

--- a/.claude-memory/feedback_todo_tracking.md
+++ b/.claude-memory/feedback_todo_tracking.md
@@ -1,6 +1,6 @@
 ---
 name: TODO tracking conventions
-description: All TODOs go in TODO.md. Code TODOs mirror there. "Sync TODOs" means reconcile memory + code + TODO.md.
+description: All TODOs go in TODO.md. Code TODOs mirror there. "Sync TODOs" reconciles memory + code + TODO.md AND probes each Open row against the codebase for "already shipped, never moved" drift.
 type: feedback
 originSessionId: f4ac39e5-d24f-4335-a75d-edce7263c131
 ---
@@ -12,9 +12,10 @@ When Drew says "sync TODO items" (or similar), scan:
 1. Memory for any TODO-type entries
 2. Code for `// TODO` comments (grep for `TODO`)
 3. `TODO.md` for the current list
+4. **Each Open row's named artefacts against the actual codebase** — for every Open row that mentions specific files / functions / properties (e.g. "add `SearchBooksByTitleAsync`", "layer four BoxView rectangles in `ScanPage.xaml`"), grep the named bits. If they already exist, the row is stale: move it to Shipped with the PR number from `git log --all -- <file> | grep -i 'TODO #N'`.
 
-Reconcile all three — add anything missing to `TODO.md`, flag any stale entries that look completed.
+Reconcile all four — add anything missing to `TODO.md`, move shipped-but-stale rows to Shipped, flag any rows that look completed but can't be confirmed.
 
-**Why:** TODOs were scattered across memory, code comments, and README files. A single `TODO.md` is visible to both Drew and Claude, versioned in git, and has no size limits.
+**Why:** TODOs were scattered across memory, code comments, and README files. A single `TODO.md` is visible to both Drew and Claude, versioned in git, and has no size limits. The Open-vs-reality probe (step 4) was added after the 2026-05-13 Bookshelf arc sync session found four Open rows (#30, #31, #32, #35a) that had genuinely shipped weeks earlier on dedicated PRs (#218, #229, #230, #233) — `feedback_close_todos_in_same_pr` post-dated those PRs so the move was missed, and the earlier sync only checked code `// TODO` comments vs TODO.md, not "is the feature actually shipped" against Open rows. Cost a wasted "go ship #30" branch before I noticed the overlay was already in `ScanPage.xaml`.
 
-**How to apply:** New TODOs always go to `TODO.md` first. Keep code-level `// TODO` comments for local context but treat `TODO.md` as the source of truth when enumerating outstanding work.
+**How to apply:** New TODOs always go to `TODO.md` first. Keep code-level `// TODO` comments for local context but treat `TODO.md` as the source of truth when enumerating outstanding work. Before starting any "ship TODO #N" work, do step 4 for that row specifically — even when you trust the Open list. The first commit of a feature branch should reveal nothing already done.


### PR DESCRIPTION
2026-05-13 lesson from the Bookshelf arc planning session. See commit message