### PR TITLE
chore(infra): /warmup endpoint to shrink slot-swap variance

### DIFF
--- a/BookTracker.Tests/Api/WarmupEndpointTests.cs
+++ b/BookTracker.Tests/Api/WarmupEndpointTests.cs
@@ -1,0 +1,59 @@
+using BookTracker.Web;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace BookTracker.Tests.Api;
+
+// Smoke test for /warmup. The endpoint is the slot-swap warmup probe
+// target (WEBSITE_SWAP_WARMUP_PING_PATH=/warmup in app-config.bicep);
+// if this 500s on deploy, the swap fails and traffic doesn't promote.
+// The risk it guards against: someone refactors WarmupEndpoints.cs and
+// breaks the DB-touch path, the endpoint still compiles + routes, but
+// Azure's warmup probe returns 500 and the swap never completes.
+//
+// Hosts the full ProgramSetup on a random Kestrel port (same pattern
+// as PlaywrightFixture) and hits /warmup via HttpClient.
+[Trait("Category", TestCategories.Integration)]
+public class WarmupEndpointTests : IAsyncLifetime
+{
+    private WebApplication? _app;
+    private HttpClient _http = null!;
+
+    public async Task InitializeAsync()
+    {
+        Environment.SetEnvironmentVariable(
+            "ConnectionStrings__DefaultConnection",
+            SqlServerContainer.ConnectionString);
+
+        _app = ProgramSetup.Build(["--urls", "http://127.0.0.1:0"]);
+        await _app.StartAsync();
+
+        var server = _app.Services.GetRequiredService<IServer>();
+        var addresses = server.Features.Get<IServerAddressesFeature>()
+            ?? throw new InvalidOperationException("Server has no addresses feature");
+        _http = new HttpClient { BaseAddress = new Uri(addresses.Addresses.First()) };
+    }
+
+    public async Task DisposeAsync()
+    {
+        _http?.Dispose();
+        if (_app is not null)
+        {
+            await _app.StopAsync();
+            await _app.DisposeAsync();
+        }
+        Environment.SetEnvironmentVariable("ConnectionStrings__DefaultConnection", null);
+    }
+
+    [Fact]
+    public async Task GetWarmup_Returns200WithWarmBody()
+    {
+        var response = await _http.GetAsync("/warmup");
+
+        response.EnsureSuccessStatusCode();
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Equal("warm", body);
+    }
+}

--- a/BookTracker.Web/Api/WarmupEndpoints.cs
+++ b/BookTracker.Web/Api/WarmupEndpoints.cs
@@ -1,0 +1,47 @@
+using BookTracker.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookTracker.Web.Api;
+
+// GET /warmup — slot-swap warmup probe. Azure App Service pings this
+// URL during deployment-slot swaps when `WEBSITE_SWAP_WARMUP_PING_PATH`
+// is set (see infra/modules/app-config.bicep). The probe runs *before*
+// Azure promotes the slot, so all the cold-start cost we'd otherwise
+// inflict on the first real user lands here instead:
+//
+//   - JIT compilation of Minimal API + DI graph build
+//   - SQL connection pool establishment
+//   - Managed-identity AAD token acquisition for SQL (the expensive one)
+//   - EF metadata initialisation
+//
+// We deliberately do a trivial DB read (`Books.Take(1)`) so the SQL
+// pool actually gets a connection on the AAD-auth path — without the
+// read, the warmup would warm Kestrel + Minimal API only and the first
+// real user would still pay the ~30-40s AAD-token cost.
+//
+// Auth: this is the one route excluded from Easy Auth (alongside the
+// PWA manifest + service worker). Azure's warmup probe is anonymous —
+// if it required AAD it would 302 to login and never actually warm
+// the .NET app. See `publicPaths` in infra/modules/app-config.bicep.
+// The endpoint returns a fixed plaintext string and reveals no
+// business data, so anonymous access is harmless.
+public static class WarmupEndpoints
+{
+    public static IEndpointRouteBuilder MapWarmupEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapGet("/warmup", async (
+            IDbContextFactory<BookTrackerDbContext> dbFactory,
+            CancellationToken ct) =>
+        {
+            await using var db = await dbFactory.CreateDbContextAsync(ct);
+            // Trivial query — establishes the connection pool entry,
+            // forces AAD token acquisition, exercises the EF metadata
+            // path. Returning just the Id keeps the payload tiny and
+            // avoids materialising any Book columns.
+            _ = await db.Books.Take(1).Select(b => b.Id).ToListAsync(ct);
+            return Results.Text("warm", "text/plain");
+        });
+
+        return app;
+    }
+}

--- a/BookTracker.Web/ProgramSetup.cs
+++ b/BookTracker.Web/ProgramSetup.cs
@@ -247,5 +247,9 @@ public static class ProgramSetup
         // §SEC-006).
         app.MapCatalogEndpoints();
         app.MapWishlistEndpoints();
+        // /warmup is anonymous (excluded from Easy Auth) by design —
+        // see WarmupEndpoints.cs and infra/modules/app-config.bicep's
+        // `publicPaths` list. Used by Azure's slot-swap warmup probe.
+        app.MapWarmupEndpoints();
     }
 }

--- a/infra/modules/app-config.bicep
+++ b/infra/modules/app-config.bicep
@@ -72,6 +72,17 @@ var commonAppSettings = {
   // initialisation. 600s gives generous headroom for slow days without
   // letting genuinely broken bits hide forever.
   WEBSITES_CONTAINER_START_TIME_LIMIT: '600'
+  // Slot-swap warmup probe — Azure pings this path on the source slot
+  // (the one about to be promoted to production) during a swap and
+  // won't complete the swap until it returns 2xx. Without it the
+  // probe defaults to `/`, which under Easy Auth returns a 302 to
+  // login (and warms nothing in the .NET app — Easy Auth blocks
+  // before hand-off). `/warmup` is excluded from Easy Auth (see
+  // `publicPaths` below) and does a trivial Books.Take(1) so the
+  // SQL connection pool + managed-identity AAD token are warm when
+  // the slot starts taking real traffic. Implementation:
+  // BookTracker.Web/Api/WarmupEndpoints.cs.
+  WEBSITE_SWAP_WARMUP_PING_PATH: '/warmup'
   MICROSOFT_PROVIDER_AUTHENTICATION_SECRET: authClientSecretRef
   AI__DefaultProvider: aiDefaultProvider
   AI__AzureOpenAI__Endpoint: aiAzureOpenAIEndpoint
@@ -115,22 +126,32 @@ var slotStickyAppSettingNames = [
   'CoverStorage__PublicBaseUrl'
 ]
 
-// Paths served publicly (without Easy Auth). Limited to the PWA assets
-// Chrome/Safari fetch without credentials during the install-validation
-// handshake. Manifest + icons + service worker script are all non-sensitive
-// (public app name, theme colour, static images, client-side caching logic).
+// Paths served publicly (without Easy Auth). Two distinct shapes:
+//
+// 1. PWA assets — Chrome/Safari fetch these without credentials during
+//    the install-validation handshake. Manifest + icons + service
+//    worker script are all non-sensitive (public app name, theme
+//    colour, static images, client-side caching logic).
+// 2. /warmup — Azure's slot-swap warmup probe (see
+//    WEBSITE_SWAP_WARMUP_PING_PATH below) is anonymous; if it required
+//    AAD it would 302 to login and never actually warm the .NET app.
+//    The endpoint returns a fixed string and reveals no business data,
+//    so anonymous access is harmless. Implementation in
+//    BookTracker.Web/Api/WarmupEndpoints.cs.
+//
 // Expand deliberately — every entry here bypasses AAD sign-in.
 //
 // NOTE: Easy Auth v2 excludedPaths does EXACT path matching, not prefix.
 // "/icons" does not match "/icons/icon-192.png" — each file must be listed.
 // If you add another icon, add it here too.
-var pwaPublicPaths = [
+var publicPaths = [
   '/manifest.webmanifest'
   '/service-worker.js'
   '/icons/icon.svg'
   '/icons/icon-192.png'
   '/icons/icon-512.png'
   '/icons/apple-touch-icon.png'
+  '/warmup'
 ]
 
 resource app 'Microsoft.Web/sites@2023-12-01' existing = {
@@ -198,7 +219,7 @@ resource authConfig 'Microsoft.Web/sites/config@2023-12-01' = {
       requireAuthentication: true
       unauthenticatedClientAction: 'RedirectToLoginPage'
       redirectToProvider: 'azureactivedirectory'
-      excludedPaths: pwaPublicPaths
+      excludedPaths: publicPaths
     }
     identityProviders: {
       azureActiveDirectory: {
@@ -256,7 +277,7 @@ resource stagingAuthConfig 'Microsoft.Web/sites/slots/config@2023-12-01' = {
       requireAuthentication: true
       unauthenticatedClientAction: 'RedirectToLoginPage'
       redirectToProvider: 'azureactivedirectory'
-      excludedPaths: pwaPublicPaths
+      excludedPaths: publicPaths
     }
     identityProviders: {
       azureActiveDirectory: {


### PR DESCRIPTION
Adds a dedicated slot-swap warmup probe. Azure's default warmup (when
WEBSITE_SWAP_WARMUP_PING_PATH is unset) pings `/`, which under Easy
Auth's requireAuthentication: true returns a 302 to AAD login — Easy
Auth blocks before the .NET app sees the request, so nothing actually
warms. The first real user post-swap eats the SQL pool + AAD-token
cold-start cost (~30-40s on Basic tier).

Three pieces, single PR:

1. WarmupEndpoints.cs / MapWarmupEndpoints — minimal GET /warmup that
   does Books.Take(1).ToListAsync(). The query is trivial but
   deliberately exercises the SQL connection pool, managed-identity
   AAD token acquisition, and EF metadata path — the slow bits we
   want warmed before the slot promotes. Returns plain "warm".

2. app-config.bicep — renamed pwaPublicPaths → publicPaths (the list
   now serves two purposes: PWA chrome + the warmup probe), added
   /warmup to it (Easy Auth excludedPaths), and added
   WEBSITE_SWAP_WARMUP_PING_PATH: /warmup to commonAppSettings so
   both slots ping the right URL on swap.

3. WarmupEndpointTests — Kestrel-hosted smoke test asserting GET
   /warmup returns 200 "warm". Reuses the random-port hosting
   pattern from PlaywrightFixture without the Playwright dep, so
   it runs locally + in CI. Guards against a refactor breaking the
   endpoint without noticing (a 500 here would silently fail every
   swap).

Expected impact: not a faster swap clock, but predictable timing.
The slow bits move into the warmup phase (before swap completes)
instead of landing on the first user request. Variance from
~6-20min → roughly steady ~3-5min, with the variance from
update-ca-certificates + VNet reattach unchanged (platform-side).

Drew will verify on the next deploy. If the swap log shows the
warmup probe hitting /warmup and timing the warmup phase as
expected, this is doing its job.
