### PR TITLE
fix(bookshelf): re-fetch full snapshot on version-mismatch reset

### DIFF
--- a/BookTracker.Mobile/MainPage.xaml.cs
+++ b/BookTracker.Mobile/MainPage.xaml.cs
@@ -110,9 +110,16 @@ public partial class MainPage : ContentPage
             }
             else if (!string.Equals(snapshot.Version, storedVersion, StringComparison.Ordinal))
             {
-                // Version moved on the server. The delta response is
-                // still valid for the new shape, but our local rows
-                // were keyed to the old shape — safer to wipe.
+                // Version moved on the server. The snapshot we just
+                // fetched is a DELTA — we sent `since=<storedToken>`
+                // so the server filtered to Books with UpdatedAt > since.
+                // Populating with it would wipe-and-rewrite the cache
+                // using only the delta-window books, leaving everything
+                // older missing locally (which we hit 2026-05-14 on the
+                // Arc D deploy — search returned only the few books
+                // changed in the deploy window). Re-fetch without the
+                // token for a true full snapshot before wiping.
+                snapshot = await _api.GetCatalogSnapshotAsync(since: null);
                 await _cache.PopulateAsync(snapshot);
                 statusSuffix = "full (version changed)";
             }


### PR DESCRIPTION
Drew's 2026-05-14 prod report: after updating both Bookcase + Bookshelf
to the Arc D build and tapping Load catalog, author drilldown showed
"57 books in your library" in the header but zero rows in the body,
and title search only matched the handful of books changed between the
previous refresh and the new deploy.

Root cause: MainPage.OnLoadCatalogClicked's version-mismatch path was
fetching with `since=<storedToken>` (always-on because a watermark was
stored), getting back a DELTA snapshot, then calling PopulateAsync with
it. PopulateAsync DeleteAll's CachedBook and reinserts whatever's in
the incoming snapshot — but the incoming snapshot was a delta, so the
post-populate cache contained only the few books whose UpdatedAt fell
after the stored watermark. Authors + Series wipe-and-rewrite was
already correct (server full-lists those regardless of since), which
is why AuthorSnapshot.BookCount still showed "57" but Book lookup
matched nothing.

Fix: on the version-mismatch branch, re-fetch with `since: null` to
get a true full snapshot before populating. One extra HTTP request on
the rare deploy-just-happened path; happy path (version matches) is
unchanged.

Manual test plan:
1. Bookshelf installed with cached catalog from a previous deploy
2. Server deployed with a new SHA
3. Tap Load catalog → status reads "full (version changed)"
4. Find by author → tap a known author → all their books appear
5. Find by title → fragment of a known title hits

The bug only manifests on the deploy-window edge — version-matches
deltas and first-load fulls were both unaffected. Worth a hot fix
before tomorrow's break since the catalog is essentially unusable
on Bookshelf right now until the next deploy.
