### PR TITLE
fix(bookshelf): surrogate PK for CachedBookWork to allow shared Works

### DIFF
--- a/BookTracker.Mobile.Cache.Tests/CatalogCacheTests.cs
+++ b/BookTracker.Mobile.Cache.Tests/CatalogCacheTests.cs
@@ -963,6 +963,70 @@ public class CatalogCacheTests
         Assert.Null(await cache.GetBookEnrichedDetailAsync(1));
     }
 
+    // ---- shared-Work + shared-data-shape regressions ----
+
+    [Fact]
+    public async Task PopulateAsync_SameWorkAttachedToMultipleBooks_DoesNotCollide()
+    {
+        // Regression for the 2026-05-14 prod report: PopulateAsync
+        // threw "UNIQUE constraint failed: book_works.Id" when a Work
+        // appeared in more than one Book (Lovecraft's "Call of Cthulhu"
+        // in two different anthologies). Work is many-to-many with
+        // Book on the server; CachedBookWork needs a surrogate
+        // AutoIncrement PK so the same server-side Work.Id can repeat
+        // across rows.
+        var cache = await NewCacheAsync();
+        var sharedWork = new WorkSnapshot(42, "The Call of Cthulhu", "H.P. Lovecraft");
+
+        await cache.PopulateAsync(SampleSnapshot(
+            books:
+            [
+                new(1, "Lovecraft Anthology A", "Lovecraft", ["Lovecraft"], "Read", 5, [],
+                    null, null, null,
+                    Works: [sharedWork]),
+                new(2, "Lovecraft Anthology B", "Lovecraft", ["Lovecraft"], "Read", 5, [],
+                    null, null, null,
+                    Works: [sharedWork]),
+            ]));
+
+        // Both books should resolve the shared Work via GetBookEnrichedDetailAsync.
+        var detailA = await cache.GetBookEnrichedDetailAsync(1);
+        var detailB = await cache.GetBookEnrichedDetailAsync(2);
+        Assert.NotNull(detailA);
+        Assert.NotNull(detailB);
+        var workA = Assert.Single(detailA!.Works);
+        var workB = Assert.Single(detailB!.Works);
+        Assert.Equal(42, workA.Id);
+        Assert.Equal(42, workB.Id);
+        Assert.Equal("The Call of Cthulhu", workA.Title);
+    }
+
+    [Fact]
+    public async Task ApplyDeltaAsync_SameWorkAttachedToMultipleBooks_DoesNotCollide()
+    {
+        // Same regression as above but on the delta path — a delta
+        // refresh shouldn't introduce the collision either.
+        var cache = await NewCacheAsync();
+        await cache.PopulateAsync(SampleSnapshot(
+            latestUpdatedAt: new DateTime(2026, 5, 14, 8, 0, 0, DateTimeKind.Utc)));
+
+        var sharedWork = new WorkSnapshot(42, "The Call of Cthulhu", "H.P. Lovecraft");
+        await cache.ApplyDeltaAsync(SampleSnapshot(
+            books:
+            [
+                new(1, "Anthology A", "Lovecraft", ["Lovecraft"], "Read", 5, [],
+                    null, null, null,
+                    Works: [sharedWork]),
+                new(2, "Anthology B", "Lovecraft", ["Lovecraft"], "Read", 5, [],
+                    null, null, null,
+                    Works: [sharedWork]),
+            ],
+            latestUpdatedAt: new DateTime(2026, 5, 14, 9, 0, 0, DateTimeKind.Utc)));
+
+        Assert.Single((await cache.GetBookEnrichedDetailAsync(1))!.Works);
+        Assert.Single((await cache.GetBookEnrichedDetailAsync(2))!.Works);
+    }
+
     // ---- helpers ----
 
     private static byte[] MakePngBytes(int width, int height)

--- a/BookTracker.Mobile.Cache/CatalogCache.cs
+++ b/BookTracker.Mobile.Cache/CatalogCache.cs
@@ -154,13 +154,14 @@ public class CatalogCache : ICatalogCache
                 }
                 // Editions + Works — back-compat for older servers
                 // that don't ship these yet (deserialised as null).
-                // No-op when null/empty.
+                // No-op when null/empty. RowId is AutoIncrement-assigned;
+                // EditionId / WorkId carry the server-side natural Id.
                 foreach (var edition in book.Editions ?? [])
                 {
                     conn.Insert(new CachedBookEdition
                     {
-                        Id = edition.Id,
                         BookId = book.Id,
+                        EditionId = edition.Id,
                         Isbn = edition.Isbn,
                         Format = edition.Format ?? "",
                         CoverUrl = edition.CoverUrl,
@@ -170,8 +171,8 @@ public class CatalogCache : ICatalogCache
                 {
                     conn.Insert(new CachedBookWork
                     {
-                        Id = work.Id,
                         BookId = book.Id,
+                        WorkId = work.Id,
                         Title = work.Title ?? "",
                         PrimaryAuthor = work.PrimaryAuthor ?? "",
                     });
@@ -286,18 +287,21 @@ public class CatalogCache : ICatalogCache
                     }
                 }
 
-                // Editions + Works: same wipe-and-rewrite pattern as
-                // the ISBN join rows. Each row's PK is the server
-                // Id, so we explicitly delete by BookId rather than
-                // by PK (the incoming Ids would replace, but stale
-                // rows from a since-deleted Edition would linger).
+                // Editions + Works: wipe-and-rewrite per Book. RowId
+                // is the AutoIncrement surrogate PK; EditionId / WorkId
+                // are the server-side natural Ids. Surrogate is
+                // mandatory for Works because a single Work can belong
+                // to multiple Books (Lovecraft's "Call of Cthulhu"
+                // appearing in three anthologies you own) — a
+                // natural-Id PK would UNIQUE-constraint on the second
+                // Book's insert.
                 conn.Execute("DELETE FROM book_editions WHERE BookId = ?", book.Id);
                 foreach (var edition in book.Editions ?? [])
                 {
                     conn.Insert(new CachedBookEdition
                     {
-                        Id = edition.Id,
                         BookId = book.Id,
+                        EditionId = edition.Id,
                         Isbn = edition.Isbn,
                         Format = edition.Format ?? "",
                         CoverUrl = edition.CoverUrl,
@@ -308,8 +312,8 @@ public class CatalogCache : ICatalogCache
                 {
                     conn.Insert(new CachedBookWork
                     {
-                        Id = work.Id,
                         BookId = book.Id,
+                        WorkId = work.Id,
                         Title = work.Title ?? "",
                         PrimaryAuthor = work.PrimaryAuthor ?? "",
                     });
@@ -570,15 +574,16 @@ public class CatalogCache : ICatalogCache
             // Isbn so two paperback rows don't randomise on each read.
             .OrderBy(e => e.Format, StringComparer.OrdinalIgnoreCase)
             .ThenBy(e => e.Isbn ?? "", StringComparer.OrdinalIgnoreCase)
-            .Select(e => new EditionSnapshot(e.Id, e.Isbn, e.Format, e.CoverUrl))
+            .Select(e => new EditionSnapshot(e.EditionId, e.Isbn, e.Format, e.CoverUrl))
             .ToList();
         var works = workRows
-            // Server projects in OrderBy(w => w.Id) — same order is
-            // useful client-side because that's how the PrimaryAuthor
+            // Server projects in OrderBy(w => w.Id) — preserve that
+            // client-side because that's how the PrimaryAuthor
             // convention picks the "first Work" for series + author
-            // rollups elsewhere.
-            .OrderBy(w => w.Id)
-            .Select(w => new WorkSnapshot(w.Id, w.Title, w.PrimaryAuthor))
+            // rollups elsewhere. Order by WorkId (the server-side Id),
+            // not RowId (the local surrogate, insertion-order).
+            .OrderBy(w => w.WorkId)
+            .Select(w => new WorkSnapshot(w.WorkId, w.Title, w.PrimaryAuthor))
             .ToList();
 
         return new BookEnrichedDetail(editions, works);

--- a/BookTracker.Mobile.Cache/Models/CacheEntities.cs
+++ b/BookTracker.Mobile.Cache/Models/CacheEntities.cs
@@ -56,29 +56,39 @@ internal class CachedBookIsbn
 // One row per Edition of a Book. Backs the enhanced ScanPage "which
 // editions do I already own?" view — Hardcover, Paperback, MM, etc.
 // Indexed on BookId so the per-Book lookup is a B-tree hit.
+//
+// Surrogate AutoIncrement PK + natural EditionId column — matches the
+// CachedBookIsbn pattern. Edition is 1:N with Book on the server side
+// (an Edition belongs to one Book), so a natural-Id PK wouldn't collide
+// today, but the symmetric shape with CachedBookWork (which DOES need
+// the surrogate to avoid the shared-Work collision) is safer to maintain.
 [Table("book_editions")]
 internal class CachedBookEdition
 {
-    // Edition.Id from the server — keeps a stable identity so future
-    // upserts could diff at the Edition level. For PR 1 we wipe-and-
-    // rewrite per Book on every populate / delta-upsert; the Id is
-    // just useful for testability and future incremental shapes.
-    [PrimaryKey] public int Id { get; set; }
+    [PrimaryKey, AutoIncrement] public int RowId { get; set; }
     [Indexed] public int BookId { get; set; }
+    public int EditionId { get; set; }
     public string? Isbn { get; set; }
     public string Format { get; set; } = string.Empty;
     public string? CoverUrl { get; set; }
 }
 
-// One row per Work belonging to a Book. Almost always one Work per
-// Book; multi-Work rows are compendiums (anthologies, collections).
-// Surfaced in ScanPage when Count > 1 — "Contains: 'Foundation',
-// 'Second Foundation', ...".
+// One row per (Book, Work) pair — Book ↔ Work is many-to-many on the
+// server (a Work like Lovecraft's "Call of Cthulhu" can appear in
+// multiple anthologies you own). Surrogate AutoIncrement PK so the
+// same Work.Id can repeat across rows under different BookIds without
+// hitting a UNIQUE constraint. Indexed on BookId for the per-Book
+// lookup in GetBookEnrichedDetailAsync.
+//
+// Surfaced in ScanPage when the Book has more than one Work —
+// "Contains: 'Foundation', 'Second Foundation', ...". Single-Work
+// books still get a row each but the UI hides the section.
 [Table("book_works")]
 internal class CachedBookWork
 {
-    [PrimaryKey] public int Id { get; set; }
+    [PrimaryKey, AutoIncrement] public int RowId { get; set; }
     [Indexed] public int BookId { get; set; }
+    public int WorkId { get; set; }
     public string Title { get; set; } = string.Empty;
     public string PrimaryAuthor { get; set; } = string.Empty;
 }


### PR DESCRIPTION
Drew's 2026-05-14 prod report: PopulateAsync threw "UNIQUE constraint
failed: book_works.Id" after a fresh Bookshelf reinstall. Cache wouldn't
populate at all.

Root cause: Arc D's CachedBookWork model used the server-side Work.Id
as the SQLite primary key. But Work is many-to-many with Book on the
server — a single Work (a short story like Lovecraft's "Call of
Cthulhu") can appear in multiple Books (different anthologies the user
owns). The snapshot emits the same Work.Id under each owning Book; the
first insert succeeded, the second hit UNIQUE on Id.

The existing CachedBookIsbn already uses the right pattern — surrogate
[PrimaryKey, AutoIncrement] RowId + indexed natural Id column. Should
have done that for CachedBookWork from the start. CachedBookEdition
doesn't hit the bug today (Edition is 1:N with Book), but updating it
to the same shape for symmetry makes the cache layer's tables uniform
and removes the foot-gun for future schema additions.

Schema changes (both tables):
- [PrimaryKey, AutoIncrement] RowId — local surrogate
- [Indexed] BookId — per-Book lookup B-tree
- WorkId / EditionId — server-side natural Id, no longer PK

CatalogCache.cs:
- PopulateAsync + ApplyDeltaAsync inserts drop the explicit Id-set
  and let AutoIncrement fill RowId; carry the natural Id in the
  WorkId / EditionId column instead.
- GetBookEnrichedDetailAsync projects from the new field names
  (w.WorkId / e.EditionId) when building the WorkSnapshot /
  EditionSnapshot records sent back to the UI.

Tests (2 new):
- PopulateAsync_SameWorkAttachedToMultipleBooks_DoesNotCollide — the
  direct prod-bug repro on the full-populate path.
- ApplyDeltaAsync_SameWorkAttachedToMultipleBooks_DoesNotCollide —
  same shape on the delta path, since the same insert pattern is used
  in both.

Both would have failed before this fix; lock the contract going
forward.

Migration / deploy note: this is a PK change, not a column add — the
schema-evolution backfill pattern from feedback_sqlite_net_pcl_schema_backfill
won't cover it. Users with existing installs (Drew, after his reinstall
attempt) need to wipe the SQLite file before the new APK works. Since
the prod report came from Drew already mid-reinstall, the timing is
right: install the new APK on top of the now-empty cache and the
fresh schema gets created correctly by CreateTableAsync. If anyone
later inherits an older partial cache they hit the same UNIQUE error
again, in which case the eventual in-app Reset cache button (TODO #49)
is the recovery path.
