### PR TITLE
feat(tools): snapshot dump CLI + prod-to-JSON driver script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,11 @@ project.fragment.lock.json
 artifacts/
 *.pdb
 
+# Snapshot dumps from infra/dump-prod-to-json.ps1 — production data
+# intended for upload into the local "BookTracker Analysis" Claude
+# Project. Stays local; never committed.
+snapshots/
+
 # App config with secrets — committed only as *.Example.json templates
 appsettings.json
 appsettings.*.json

--- a/BookTracker.Tools.SnapshotDump/AnalysisSnapshot.cs
+++ b/BookTracker.Tools.SnapshotDump/AnalysisSnapshot.cs
@@ -1,0 +1,112 @@
+using BookTracker.Data.Models;
+
+namespace BookTracker.Tools.SnapshotDump;
+
+// DTO shape for the JSON file uploaded to the Claude "BookTracker
+// Analysis" Project. Distinct from BookTracker.Shared's CatalogSnapshot
+// (which is the slim ISBN-keyed Bookshelf wire format) — this is the
+// richer, analysis-oriented shape: includes Notes, Rating, soft-delete-
+// excluded Books, full Author rollup graph, and tags.
+//
+// Editions nest inside Books because the relationship is dense and
+// rarely-shared. Authors / Genres / Series / Publishers / Tags are
+// top-level lists referenced from Books / Works by ID — keeps the JSON
+// readable when entities are reused.
+//
+// Field semantics: see docs/DATA-DICTIONARY.md.
+
+public sealed record CatalogAnalysisSnapshot(
+    DateTime GeneratedAtUtc,
+    string Source,
+    int BookCount,
+    int WorkCount,
+    int AuthorCount,
+    IReadOnlyList<BookAnalysis> Books,
+    IReadOnlyList<WorkAnalysis> Works,
+    IReadOnlyList<AuthorAnalysis> Authors,
+    IReadOnlyList<GenreAnalysis> Genres,
+    IReadOnlyList<SeriesAnalysis> Series,
+    IReadOnlyList<PublisherAnalysis> Publishers,
+    IReadOnlyList<TagAnalysis> Tags,
+    IReadOnlyList<WishlistItemAnalysis> WishlistItems);
+
+public sealed record BookAnalysis(
+    int Id,
+    string Title,
+    BookCategory Category,
+    BookStatus Status,
+    int Rating,
+    string? Notes,
+    DateTime DateAdded,
+    DateTime UpdatedAt,
+    string? DefaultCoverArtUrl,
+    IReadOnlyList<EditionAnalysis> Editions,
+    IReadOnlyList<int> WorkIds,
+    IReadOnlyList<string> TagNames);
+
+public sealed record EditionAnalysis(
+    int Id,
+    string? Isbn,
+    BookFormat Format,
+    DateOnly? DatePrinted,
+    DatePrecision DatePrintedPrecision,
+    string? CoverUrl,
+    bool IsUserSupplied,
+    string? PublisherName,
+    IReadOnlyList<CopyAnalysis> Copies);
+
+public sealed record CopyAnalysis(
+    int Id,
+    BookCondition Condition,
+    DateTime? DateAcquired,
+    string? Notes);
+
+public sealed record WorkAnalysis(
+    int Id,
+    string Title,
+    string? Subtitle,
+    DateOnly? FirstPublishedDate,
+    DatePrecision FirstPublishedDatePrecision,
+    IReadOnlyList<WorkAuthorRef> Authors,
+    IReadOnlyList<string> GenreNames,
+    int? SeriesId,
+    int? SeriesOrder,
+    IReadOnlyList<int> BookIds);
+
+public sealed record WorkAuthorRef(int AuthorId, string Name, int Order);
+
+public sealed record AuthorAnalysis(
+    int Id,
+    string Name,
+    int? CanonicalAuthorId,
+    string? CanonicalAuthorName,
+    IReadOnlyList<int> AliasIds);
+
+public sealed record GenreAnalysis(
+    int Id,
+    string Name,
+    int? ParentGenreId,
+    string? ParentGenreName);
+
+public sealed record SeriesAnalysis(
+    int Id,
+    string Name,
+    string? Author,
+    SeriesType Type,
+    int? ExpectedCount,
+    string? Description);
+
+public sealed record PublisherAnalysis(int Id, string Name);
+
+public sealed record TagAnalysis(int Id, string Name);
+
+public sealed record WishlistItemAnalysis(
+    int Id,
+    string Title,
+    string Author,
+    WishlistPriority Priority,
+    decimal? Price,
+    DateTime DateAdded,
+    string? Isbn,
+    int? SeriesId,
+    int? SeriesOrder);

--- a/BookTracker.Tools.SnapshotDump/BookTracker.Tools.SnapshotDump.csproj
+++ b/BookTracker.Tools.SnapshotDump/BookTracker.Tools.SnapshotDump.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    One-shot console CLI that reads the BookTracker catalogue from a
+    SQL Server connection (typically prod) and emits a single JSON
+    file in an analysis-oriented shape for upload into the "BookTracker
+    Analysis" Claude Project.
+
+    Driver: infra/dump-prod-to-json.ps1 — handles Az sign-in, opens a
+    temporary SQL firewall rule for the caller's IP, sets the
+    connection string env var, and invokes this CLI.
+
+    Why a CLI rather than a PowerShell-only solution: reuses
+    BookTracker.Data entity classes so the dump shape evolves with the
+    model (add a property to an entity → it lands in the DTO via the
+    projection in Program.cs), and the soft-delete global query filter
+    is honoured automatically.
+  -->
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>BookTracker.Tools.SnapshotDump</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\BookTracker.Data\BookTracker.Data.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/BookTracker.Tools.SnapshotDump/Program.cs
+++ b/BookTracker.Tools.SnapshotDump/Program.cs
@@ -1,0 +1,225 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using BookTracker.Data;
+using BookTracker.Data.Models;
+using BookTracker.Tools.SnapshotDump;
+using Microsoft.EntityFrameworkCore;
+
+// ---- Parse args -------------------------------------------------------------
+//
+// Two flags supported:
+//   --out <path>          Output file path. Default:
+//                         ./snapshots/booktracker-{yyyy-MM-dd-HHmm}.json
+//   --source <label>      Free-text label embedded in the snapshot's
+//                         `source` field — typically "prod", "local",
+//                         or "staging". Default: "unknown".
+//
+// Connection string comes from env var ConnectionStrings__DefaultConnection
+// (matches Bookcase's config convention). The driver script
+// (infra/dump-prod-to-json.ps1) sets this from Az-CLI-resolved prod
+// SQL details before invoking; running locally against the Docker SQL
+// container, set it manually first.
+
+string? outPath = null;
+string source = "unknown";
+
+for (int i = 0; i < args.Length; i++)
+{
+    switch (args[i])
+    {
+        case "--out" when i + 1 < args.Length:
+            outPath = args[++i];
+            break;
+        case "--source" when i + 1 < args.Length:
+            source = args[++i];
+            break;
+        case "--help" or "-h":
+            Console.WriteLine("Usage: dotnet run --project BookTracker.Tools.SnapshotDump -- [--out <path>] [--source <label>]");
+            Console.WriteLine();
+            Console.WriteLine("Reads ConnectionStrings__DefaultConnection from env.");
+            return 0;
+    }
+}
+
+if (string.IsNullOrWhiteSpace(outPath))
+{
+    var stamp = DateTime.UtcNow.ToString("yyyy-MM-dd-HHmm");
+    outPath = Path.Combine("snapshots", $"booktracker-{stamp}.json");
+}
+
+var connectionString = Environment.GetEnvironmentVariable("ConnectionStrings__DefaultConnection");
+if (string.IsNullOrWhiteSpace(connectionString))
+{
+    Console.Error.WriteLine("ConnectionStrings__DefaultConnection env var is not set.");
+    Console.Error.WriteLine("Set it before running, or use infra/dump-prod-to-json.ps1 which sets it for you.");
+    return 1;
+}
+
+// ---- Open DbContext + read all entities ------------------------------------
+//
+// Soft-deleted Books are excluded automatically by the global EF query
+// filter on Book.DeletedAt — no IgnoreQueryFilters call here, by design.
+//
+// Each .Include / .ThenInclude chain is shaped so EF emits one bounded
+// query per entity (with split-query for the deeper chains so the
+// SQL Server cartesian explosion stays manageable). Catalogue size is
+// O(thousands) so loading everything into memory is fine; the dump
+// runs once per session, not in a hot loop.
+
+var options = new DbContextOptionsBuilder<BookTrackerDbContext>()
+    .UseSqlServer(connectionString, sql => sql.CommandTimeout(120))
+    .Options;
+
+Console.WriteLine($"Opening DbContext against the configured DefaultConnection...");
+await using var db = new BookTrackerDbContext(options);
+
+var bookEntities = await db.Books
+    .AsNoTracking()
+    .AsSplitQuery()
+    .Include(b => b.Editions).ThenInclude(e => e.Copies)
+    .Include(b => b.Editions).ThenInclude(e => e.Publisher)
+    .Include(b => b.Works)
+    .Include(b => b.Tags)
+    .OrderBy(b => b.Id)
+    .ToListAsync();
+
+var workEntities = await db.Works
+    .AsNoTracking()
+    .AsSplitQuery()
+    .Include(w => w.WorkAuthors).ThenInclude(wa => wa.Author)
+    .Include(w => w.Genres)
+    .Include(w => w.Books)
+    .OrderBy(w => w.Id)
+    .ToListAsync();
+
+var authorEntities = await db.Authors
+    .AsNoTracking()
+    .Include(a => a.Aliases)
+    .OrderBy(a => a.Id)
+    .ToListAsync();
+
+var genreEntities = await db.Genres
+    .AsNoTracking()
+    .Include(g => g.ParentGenre)
+    .OrderBy(g => g.Id)
+    .ToListAsync();
+
+var seriesEntities = await db.Series.AsNoTracking().OrderBy(s => s.Id).ToListAsync();
+var publisherEntities = await db.Publishers.AsNoTracking().OrderBy(p => p.Id).ToListAsync();
+var tagEntities = await db.Tags.AsNoTracking().OrderBy(t => t.Id).ToListAsync();
+var wishlistEntities = await db.WishlistItems.AsNoTracking().OrderBy(w => w.Id).ToListAsync();
+
+Console.WriteLine($"  Books: {bookEntities.Count}  Works: {workEntities.Count}  Authors: {authorEntities.Count}");
+Console.WriteLine($"  Genres: {genreEntities.Count}  Series: {seriesEntities.Count}  Publishers: {publisherEntities.Count}");
+Console.WriteLine($"  Tags: {tagEntities.Count}  Wishlist: {wishlistEntities.Count}");
+
+// ---- Project to DTOs --------------------------------------------------------
+
+var authorLookup = authorEntities.ToDictionary(a => a.Id);
+
+var books = bookEntities.Select(b => new BookAnalysis(
+    b.Id,
+    b.Title,
+    b.Category,
+    b.Status,
+    b.Rating,
+    b.Notes,
+    b.DateAdded,
+    b.UpdatedAt,
+    b.DefaultCoverArtUrl,
+    b.Editions
+        .OrderBy(e => e.Id)
+        .Select(e => new EditionAnalysis(
+            e.Id,
+            e.Isbn,
+            e.Format,
+            e.DatePrinted,
+            e.DatePrintedPrecision,
+            e.CoverUrl,
+            e.IsUserSupplied,
+            e.Publisher?.Name,
+            e.Copies
+                .OrderBy(c => c.Id)
+                .Select(c => new CopyAnalysis(c.Id, c.Condition, c.DateAcquired, c.Notes))
+                .ToList()))
+        .ToList(),
+    b.Works.Select(w => w.Id).OrderBy(id => id).ToList(),
+    b.Tags.Select(t => t.Name).OrderBy(n => n).ToList())).ToList();
+
+var works = workEntities.Select(w => new WorkAnalysis(
+    w.Id,
+    w.Title,
+    w.Subtitle,
+    w.FirstPublishedDate,
+    w.FirstPublishedDatePrecision,
+    w.WorkAuthors
+        .OrderBy(wa => wa.Order)
+        .Select(wa => new WorkAuthorRef(wa.AuthorId, wa.Author.Name, wa.Order))
+        .ToList(),
+    w.Genres.Select(g => g.Name).OrderBy(n => n).ToList(),
+    w.SeriesId,
+    w.SeriesOrder,
+    w.Books.Select(b => b.Id).OrderBy(id => id).ToList())).ToList();
+
+var authors = authorEntities.Select(a => new AuthorAnalysis(
+    a.Id,
+    a.Name,
+    a.CanonicalAuthorId,
+    a.CanonicalAuthorId.HasValue && authorLookup.TryGetValue(a.CanonicalAuthorId.Value, out var canon) ? canon.Name : null,
+    a.Aliases.Select(x => x.Id).OrderBy(id => id).ToList())).ToList();
+
+var genres = genreEntities.Select(g => new GenreAnalysis(
+    g.Id,
+    g.Name,
+    g.ParentGenreId,
+    g.ParentGenre?.Name)).ToList();
+
+var series = seriesEntities.Select(s => new SeriesAnalysis(
+    s.Id, s.Name, s.Author, s.Type, s.ExpectedCount, s.Description)).ToList();
+
+var publishers = publisherEntities.Select(p => new PublisherAnalysis(p.Id, p.Name)).ToList();
+var tags = tagEntities.Select(t => new TagAnalysis(t.Id, t.Name)).ToList();
+
+var wishlist = wishlistEntities.Select(w => new WishlistItemAnalysis(
+    w.Id, w.Title, w.Author, w.Priority, w.Price, w.DateAdded, w.Isbn, w.SeriesId, w.SeriesOrder)).ToList();
+
+var snapshot = new CatalogAnalysisSnapshot(
+    GeneratedAtUtc: DateTime.UtcNow,
+    Source: source,
+    BookCount: books.Count,
+    WorkCount: works.Count,
+    AuthorCount: authors.Count,
+    Books: books,
+    Works: works,
+    Authors: authors,
+    Genres: genres,
+    Series: series,
+    Publishers: publishers,
+    Tags: tags,
+    WishlistItems: wishlist);
+
+// ---- Serialise --------------------------------------------------------------
+
+var outDir = Path.GetDirectoryName(Path.GetFullPath(outPath));
+if (!string.IsNullOrEmpty(outDir) && !Directory.Exists(outDir))
+{
+    Directory.CreateDirectory(outDir);
+}
+
+var jsonOptions = new JsonSerializerOptions
+{
+    WriteIndented = true,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    Converters = { new JsonStringEnumConverter() }
+};
+
+await using (var stream = File.Create(outPath))
+{
+    await JsonSerializer.SerializeAsync(stream, snapshot, jsonOptions);
+}
+
+var info = new FileInfo(outPath);
+Console.WriteLine();
+Console.WriteLine($"Wrote {info.FullName}");
+Console.WriteLine($"Size: {info.Length / 1024.0:N1} KB");
+return 0;

--- a/BookTracker.slnx
+++ b/BookTracker.slnx
@@ -19,5 +19,6 @@
   <Project Path="BookTracker.Mobile.Cache.Tests/BookTracker.Mobile.Cache.Tests.csproj" />
   <Project Path="BookTracker.Shared/BookTracker.Shared.csproj" />
   <Project Path="BookTracker.Tests/BookTracker.Tests.csproj" />
+  <Project Path="BookTracker.Tools.SnapshotDump/BookTracker.Tools.SnapshotDump.csproj" />
   <Project Path="BookTracker.Web/BookTracker.Web.csproj" />
 </Solution>

--- a/infra/README.md
+++ b/infra/README.md
@@ -179,6 +179,34 @@ Direction: **prod → local only**. There is no reverse path — data flows into
 
 Flags: `-SkipExport` reuses the most recent BACPAC in `./artifacts/` (handy when iterating on import). `-SkipImport` just downloads the BACPAC.
 
+### Dump prod to JSON for Claude analysis
+
+To brainstorm shelving / categorisation / genre simplification with a Claude Project against real catalogue data:
+
+```powershell
+./infra/dump-prod-to-json.ps1 -TenantId '<tenant-guid>' -SubscriptionId '<sub-guid>'
+```
+
+What it does:
+
+1. Signs in to Azure, locates the prod SQL server (same pattern as `refresh-local-db.ps1`).
+2. Temporarily enables SQL public network access + opens a firewall rule for the caller's IP.
+3. Builds an AAD-auth connection string (`Authentication=Active Directory Default`, same mode the prod App Service uses) and sets `ConnectionStrings__DefaultConnection`.
+4. Invokes `BookTracker.Tools.SnapshotDump`, which loads the catalogue via EF Core (soft-deleted Books are excluded by the global query filter) and emits a single JSON file to `./snapshots/` (gitignored).
+5. Restores the firewall state in `finally` even if the dotnet step fails.
+
+Upload the resulting `./snapshots/booktracker-<stamp>.json` to the "BookTracker Analysis" Claude Project alongside `docs/DATA-DICTIONARY.md` and `docs/GENRE-TAXONOMY.md` to give the agent the interpretation layer for the data.
+
+Direction: **prod → JSON only**. Read-only — no schema or data changes. Any data updates the brainstorm produces come back as EF migrations or manual SQL via the normal PR flow; the air gap is deliberate.
+
+Prereqs:
+
+- .NET 10 SDK on PATH.
+- `Az.Accounts`, `Az.Resources`, `Az.Sql` modules — auto-install on first run.
+- Caller is the prod SQL server's AAD admin (Drew is, per `deploy.ps1`'s `sqlAadAdminObjectId = $me.Id` wiring). Anyone else needs `CREATE USER ... FROM EXTERNAL PROVIDER` + `db_datareader` on the `booktracker` database first.
+
+Flags: `-OutputPath <path>` overrides the default output location.
+
 ## GitHub Actions CI/CD
 
 After the first `deploy.ps1` run, set up the GitHub → Azure OIDC link:

--- a/infra/dump-prod-to-json.ps1
+++ b/infra/dump-prod-to-json.ps1
@@ -1,0 +1,148 @@
+# Dump the production BookTracker catalogue to a single JSON file for
+# upload into the "BookTracker Analysis" Claude Project.
+#
+# Read-only operation against prod. Connects via AAD (Drew is SQL AAD
+# admin on the prod server per deploy.ps1's `sqlAadAdminObjectId = $me.Id`
+# wiring) — there are no SQL-auth credentials to handle.
+#
+# Prereqs:
+#   - .NET 10 SDK on PATH (the script invokes `dotnet run` against the
+#     BookTracker.Tools.SnapshotDump project).
+#   - Az PowerShell modules (auto-installed if missing).
+#   - Signed-in Az account with permission to (a) read the prod SQL
+#     server resource, (b) temporarily add a firewall rule. The script
+#     uses the same temp-firewall pattern as refresh-local-db.ps1.
+#   - Drew himself: the prod SQL server's AAD admin (set at deploy
+#     time). Anyone else needs an explicit `CREATE USER ... FROM
+#     EXTERNAL PROVIDER` + role grant on the booktracker database.
+#
+# Typical run:
+#   ./infra/dump-prod-to-json.ps1 -TenantId '<guid>' -SubscriptionId '<guid>'
+#
+# Output:
+#   .\snapshots\booktracker-<yyyy-MM-dd-HHmm>.json (gitignored)
+#
+# Cost / impact:
+#   - Read-only — no schema or data changes.
+#   - Single short transaction; runs through EF Core's normal split-
+#     query loaders. Catalogue is O(thousands of rows) so the dump
+#     completes in seconds.
+#   - Firewall rule is opened for the caller's public IP and removed
+#     in the `finally` block, even if the dotnet step fails.
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)] [string] $TenantId,
+    [Parameter(Mandatory)] [string] $SubscriptionId,
+
+    [string] $AppName             = 'booktracker',
+    [string] $ResourceGroupName   = 'rg-booktracker-prod',
+    [string] $ProdDatabaseName    = 'booktracker',
+
+    # Defaults to .\snapshots\booktracker-<stamp>.json under the repo root.
+    [string] $OutputPath          = ''
+)
+
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+
+# ---- Resolve output path -----------------------------------------------------
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
+$snapshotDir = Join-Path $repoRoot 'snapshots'
+if (-not (Test-Path $snapshotDir)) {
+    New-Item -ItemType Directory -Path $snapshotDir -Force | Out-Null
+}
+
+if (-not $OutputPath) {
+    $stamp = Get-Date -Format 'yyyy-MM-dd-HHmm'
+    $OutputPath = Join-Path $snapshotDir "booktracker-$stamp.json"
+}
+
+# ---- Prereq: dotnet ---------------------------------------------------------
+$dotnet = Get-Command dotnet -ErrorAction SilentlyContinue
+if (-not $dotnet) {
+    throw "dotnet is not on PATH. Install the .NET 10 SDK from https://dotnet.microsoft.com/."
+}
+
+# ---- Modules + sign-in -------------------------------------------------------
+$required = @('Az.Accounts','Az.Resources','Az.Sql')
+foreach ($m in $required) {
+    if (-not (Get-Module -ListAvailable -Name $m)) {
+        Write-Host "Installing $m..."
+        Install-Module $m -Scope CurrentUser -Force -AllowClobber -Repository PSGallery
+    }
+    Import-Module $m -ErrorAction Stop | Out-Null
+}
+
+Write-Host "Connecting to Azure ($TenantId / $SubscriptionId)..."
+Connect-AzAccount -Tenant $TenantId -Subscription $SubscriptionId | Out-Null
+Set-AzContext -Tenant $TenantId -Subscription $SubscriptionId | Out-Null
+
+# ---- Locate the prod SQL server ---------------------------------------------
+# Naming convention from resources.bicep: "<AppName>-sql-<uniqueSuffix>".
+# Same lookup as refresh-local-db.ps1.
+$sqlServers = Get-AzSqlServer -ResourceGroupName $ResourceGroupName
+$sqlServer = $sqlServers | Where-Object { $_.ServerName -like "$AppName-sql-*" } | Select-Object -First 1
+if (-not $sqlServer) {
+    throw "No SQL server matching '$AppName-sql-*' found in resource group '$ResourceGroupName'."
+}
+$sqlServerName = $sqlServer.ServerName
+$sqlServerFqdn = "$sqlServerName.database.windows.net"
+Write-Host "Prod SQL: $sqlServerFqdn / $ProdDatabaseName"
+
+# ---- Open temp firewall for caller's IP -------------------------------------
+$publicAccessWas = (Get-AzSqlServer -ResourceGroupName $ResourceGroupName -ServerName $sqlServerName).PublicNetworkAccess
+if ($publicAccessWas -ne 'Enabled') {
+    Write-Host "Temporarily enabling SQL public network access..."
+    Set-AzSqlServer -ResourceGroupName $ResourceGroupName -ServerName $sqlServerName -PublicNetworkAccess 'Enabled' | Out-Null
+}
+
+$myIp = (Invoke-RestMethod -Uri 'https://api.ipify.org' -TimeoutSec 10).Trim()
+$tempRuleName = "dump-$([guid]::NewGuid().ToString('N').Substring(0,8))"
+Write-Host "Adding temp firewall rule for $myIp ($tempRuleName)..."
+New-AzSqlServerFirewallRule `
+    -ResourceGroupName $ResourceGroupName `
+    -ServerName $sqlServerName `
+    -FirewallRuleName $tempRuleName `
+    -StartIpAddress $myIp `
+    -EndIpAddress $myIp | Out-Null
+# Server-side propagation can lag the API response (~5-10s).
+Start-Sleep -Seconds 10
+
+try {
+    # AAD-auth connection string. `Active Directory Default` picks up
+    # the Az PowerShell session via Azure.Identity's DefaultAzureCredential
+    # chain. Same auth mode the prod App Service uses (app-config.bicep).
+    $connStr = "Server=tcp:$sqlServerFqdn,1433;Database=$ProdDatabaseName;Authentication=Active Directory Default;Encrypt=True;TrustServerCertificate=False;"
+    $env:ConnectionStrings__DefaultConnection = $connStr
+
+    $cliProject = Join-Path $repoRoot 'BookTracker.Tools.SnapshotDump' 'BookTracker.Tools.SnapshotDump.csproj'
+    Write-Host "Running snapshot dump..."
+    Write-Host ""
+    & dotnet run --project $cliProject --configuration Release -- --out $OutputPath --source prod
+    if ($LASTEXITCODE -ne 0) {
+        throw "Snapshot dump CLI failed (exit $LASTEXITCODE)."
+    }
+}
+finally {
+    # Always clean up — don't leave a stale firewall rule pointing at
+    # the caller's IP, and don't leave the SQL server publicly reachable
+    # if it wasn't before.
+    Write-Host ""
+    Write-Host "Removing temp firewall rule..."
+    Remove-AzSqlServerFirewallRule `
+        -ResourceGroupName $ResourceGroupName `
+        -ServerName $sqlServerName `
+        -FirewallRuleName $tempRuleName `
+        -Force -ErrorAction SilentlyContinue | Out-Null
+
+    if ($publicAccessWas -ne 'Enabled') {
+        Write-Host "Restoring SQL public network access to '$publicAccessWas'..."
+        Set-AzSqlServer -ResourceGroupName $ResourceGroupName -ServerName $sqlServerName -PublicNetworkAccess $publicAccessWas -ErrorAction SilentlyContinue | Out-Null
+    }
+
+    Remove-Item Env:\ConnectionStrings__DefaultConnection -ErrorAction SilentlyContinue
+}
+
+Write-Host ""
+Write-Host "Done. Upload $OutputPath to the 'BookTracker Analysis' Claude Project."


### PR DESCRIPTION
PR 1b of the Claude-Project-for-brainstorming arc. Produces the JSON
catalogue file that gets uploaded to the "BookTracker Analysis"
Project alongside the docs shipped in PR 1a (DATA-DICTIONARY +
GENRE-TAXONOMY).

BookTracker.Tools.SnapshotDump (new console project, net10.0):
  References BookTracker.Data so the dump shape evolves with the
  model. AnalysisSnapshot.cs defines analysis-oriented DTOs (richer
  than the slim Bookshelf CatalogSnapshot — includes Notes, Rating,
  full Author rollup graph including alias names, tag names, etc.).
  Program.cs loads each entity set via EF Core (split-query, AsNoTracking)
  and projects to the DTOs. Editions nest inside Books (dense
  relationship); M:N relationships flatten to top-level lists with
  ID references for readability. Soft-deleted Books are excluded
  automatically by the global query filter — analysis sees live data
  only. JSON output uses System.Text.Json with WriteIndented + string
  enum converter.

infra/dump-prod-to-json.ps1:
  Driver script. Mirrors refresh-local-db.ps1's structure for Az
  sign-in + temporary SQL firewall rule. Builds an AAD connection
  string (`Authentication=Active Directory Default`, same auth mode
  the prod App Service uses — Azure.Identity's DefaultAzureCredential
  chain picks up the Az PowerShell session) and runs the CLI with it.
  `finally` block always closes the firewall + restores public-access
  state, even if the dotnet step fails.

.gitignore: snapshots/ — production data, stays local.
infra/README.md: usage section under "Refresh the local dev DB".

Read-only end-to-end. Any data changes coming back from a brainstorm
land via the normal EF-migration / manual-SQL PR flow. The air gap
between prod and the discussion surface is deliberate.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
