### PR TITLE
feat(genres): remove format genres, seed format:* Book tags

### DIFF
--- a/BookTracker.Data/BookTrackerDbContext.cs
+++ b/BookTracker.Data/BookTrackerDbContext.cs
@@ -133,7 +133,10 @@ public class BookTrackerDbContext(DbContextOptions<BookTrackerDbContext> options
             .IsUnique();
 
         modelBuilder.Entity<Tag>()
-            .HasData(new Tag { Id = 1, Name = "follow-up" });
+            .HasData(
+                new Tag { Id = 1, Name = "follow-up" },
+                new Tag { Id = 2, Name = "format:graphic-novel" },
+                new Tag { Id = 3, Name = "format:short-stories" });
 
         modelBuilder.Entity<MaintenanceLog>()
             .HasIndex(m => m.Name)

--- a/BookTracker.Data/Migrations/20260517041346_RemoveFormatGenres.Designer.cs
+++ b/BookTracker.Data/Migrations/20260517041346_RemoveFormatGenres.Designer.cs
@@ -4,6 +4,7 @@ using BookTracker.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BookTracker.Data.Migrations
 {
     [DbContext(typeof(BookTrackerDbContext))]
-    partial class BookTrackerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260517041346_RemoveFormatGenres")]
+    partial class RemoveFormatGenres
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BookTracker.Data/Migrations/20260517041346_RemoveFormatGenres.cs
+++ b/BookTracker.Data/Migrations/20260517041346_RemoveFormatGenres.cs
@@ -1,0 +1,63 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
+
+namespace BookTracker.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemoveFormatGenres : Migration
+    {
+        // `Graphic Novels` and `Short Story Collections` are format indicators,
+        // not genres, and now live as `format:*` Tags on the Book. The DELETE
+        // is guarded by "no GenreWork refs" so it's safe on a prod DB where the
+        // once-off data-fix script hasn't run yet — the orphan rows simply
+        // linger until cleanup, then drop on a later deploy. On a fresh install
+        // (or any DB where the rows have no refs), the DELETE fires immediately.
+        private static readonly string[] FormatGenres = ["Graphic Novels", "Short Story Collections"];
+
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.InsertData(
+                table: "Tags",
+                columns: new[] { "Id", "Name" },
+                values: new object[,]
+                {
+                    { 2, "format:graphic-novel" },
+                    { 3, "format:short-stories" }
+                });
+
+            foreach (var name in FormatGenres)
+            {
+                migrationBuilder.Sql($@"
+DELETE FROM [Genres]
+WHERE [Name] = N'{name}'
+  AND [ParentGenreId] IS NULL
+  AND NOT EXISTS (SELECT 1 FROM [GenreWork] WHERE [GenresId] = [Genres].[Id]);");
+            }
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            foreach (var name in FormatGenres)
+            {
+                migrationBuilder.Sql($@"
+IF NOT EXISTS (SELECT 1 FROM [Genres] WHERE [Name] = N'{name}' AND [ParentGenreId] IS NULL)
+    INSERT INTO [Genres] ([Name], [ParentGenreId]) VALUES (N'{name}', NULL);");
+            }
+
+            migrationBuilder.DeleteData(
+                table: "Tags",
+                keyColumn: "Id",
+                keyValue: 2);
+
+            migrationBuilder.DeleteData(
+                table: "Tags",
+                keyColumn: "Id",
+                keyValue: 3);
+        }
+    }
+}

--- a/BookTracker.Data/Models/GenreSeed.cs
+++ b/BookTracker.Data/Models/GenreSeed.cs
@@ -84,8 +84,12 @@ public static class GenreSeed
         new("Magical Realism", null),
         new("Biographical Fiction", null),
         new("Western", null),
-        new("Graphic Novels", null),
-        new("Short Story Collections", null),
+        // `Graphic Novels` and `Short Story Collections` were removed
+        // 2026-05-17 — they're format indicators, not genres. They now
+        // live as `format:graphic-novel` / `format:short-stories` tags
+        // on the Book. See GENRE-TAXONOMY.md Provenance for the
+        // RemoveFormatGenres migration and DATA-DICTIONARY.md §Tag.
+
 
         // Non-fiction starter set — reference, art, and religious books.
         // Further non-fiction branches (History, Biography, Science,

--- a/docs/DATA-DICTIONARY.md
+++ b/docs/DATA-DICTIONARY.md
@@ -207,7 +207,22 @@ Free-form labels on Books (not Works). Distinct from Genre — tags are user-def
 | `Name` | string (≤100, **unique**, required) | |
 | `Books` | List | M:N via `BookTag`. |
 
-Seeded with one row: `follow-up` (Id = 1) — used to flag books needing later attention.
+Seeded rows:
+
+| Id | Name | Purpose |
+|----|------|---------|
+| 1 | `follow-up` | Flag books needing later attention. |
+| 2 | `format:graphic-novel` | Format indicator — replaces the former `Graphic Novels` genre. |
+| 3 | `format:short-stories` | Format indicator — replaces the former `Short Story Collections` genre. |
+
+### Tag conventions
+
+Two prefix conventions are reserved by convention (not enforced by constraint):
+
+- **`format:*`** — physical-or-structural format indicators that aren't genres. Currently `format:graphic-novel` and `format:short-stories`. Applied at the Book level even though the constituent Works carry the *thematic* genres (e.g. a Christie short-story compendium has `format:short-stories` on the Book + `Mystery` genre on each Work).
+- **`shelf:*`** — physical-shelf membership. **Not yet shipped** — captured in TODO #9 as part of the shelf-organisation work. When it ships, exactly one `shelf:*` tag per Book (convention, not constraint).
+
+Any other tag is free-form user attention markers (e.g. `follow-up`).
 
 ---
 

--- a/docs/GENRE-TAXONOMY.md
+++ b/docs/GENRE-TAXONOMY.md
@@ -92,9 +92,9 @@ Utopian                      (top-level, no sub-genres yet)
 Magical Realism              (top-level, no sub-genres yet)
 Biographical Fiction         (top-level, no sub-genres yet)
 Western                      (top-level, no sub-genres yet)
-Graphic Novels               (top-level, no sub-genres yet)
-Short Story Collections      (top-level, no sub-genres yet)
 ```
+
+> `Graphic Novels` and `Short Story Collections` were removed 2026-05-17 — they're format indicators, not genres. They now live as `format:graphic-novel` / `format:short-stories` Tags on the Book. See [`DATA-DICTIONARY.md`](DATA-DICTIONARY.md) §Tag conventions.
 
 ### Non-fiction branches
 
@@ -133,6 +133,7 @@ Religion & Spirituality
 | Horror sub-genres (Cthulhu Mythos / Vampire / Zombie) | Follow-up seed | `20260419110101_SeedHorrorSubGenres` |
 | Reference + Art + Religion & Spirituality (all three branches and their sub-genres) | Non-fiction starter set | `20260422090308_SeedNonFictionReferenceArtReligion` |
 | Science Fiction sub-tree (Hard SF / Space Opera / Cyberpunk / Military SF / Time Travel / First Contact / Post-Apocalyptic / Dystopian SF / Alternate History / Young Adult SF) + Horror sub-tree extension (Cosmic Horror / Gothic Horror / Supernatural / Psychological Horror / Splatterpunk / Folk Horror / Body Horror) | Genre-restructure pass (PR 1) | `20260516233131_SeedGenreExpansion` |
+| `Graphic Novels` + `Short Story Collections` removed from the tree (moved to `format:*` Tag convention); `format:graphic-novel` + `format:short-stories` Tag rows seeded | Genre-restructure pass (PR 2) | `20260517041346_RemoveFormatGenres` |
 
 User-added genres (created via the Add page typeahead's free-text fall-through, if that surface allows it — currently the picker is closed-list against `GenreSeed.All`) would *not* be in `GenreSeed.cs` but would live in the DB. If you see a Genre row in the snapshot that's not in this file, it's either a stale row from a withdrawn seed, an out-of-band insert, or this file is behind. As of this writing, the picker is closed-list, so the DB and `GenreSeed.cs` should match exactly.
 
@@ -173,6 +174,6 @@ If a brainstorming session proposes adding a branch, the addition is:
 
 1. **Where do cookbooks go?** Currently nowhere clean — Reference subtree was scoped to dictionaries / encyclopaedias / atlases / field guides / style guides / language learning. A new top-level "Cookery" or sub-branch under Reference would resolve it. Surfaced because reference book capture is the next planned wave (TODO #51).
 2. ~~**Sci-fi has no sub-genres yet** despite being one of the largest fiction branches.~~ **Resolved 2026-05-17** by `SeedGenreExpansion` — 10 sub-genres added including `Dystopian SF`. The existing top-level `Dystopian` is kept for non-SF dystopias (literary, near-future thriller) per the genre-restructure brief.
-3. **`Short Story Collections` as a top-level genre is structurally odd** — it's a *format* indicator, not a genre. A Christie short-story collection has Genre = Mystery on its constituent Works, plus the volume might (or might not) carry the Short-Story-Collections tag. Worth deciding whether to keep it, or migrate volumes that use it to a Book-level Tag instead.
-4. **`Graphic Novels` similar concern** — format or genre? Currently treated as genre.
+3. ~~**`Short Story Collections` as a top-level genre is structurally odd** — it's a *format* indicator, not a genre.~~ **Resolved 2026-05-17** by `RemoveFormatGenres` — moved to `format:short-stories` Tag on the Book. Constituent Works keep their thematic genre (e.g. Mystery for a Christie collection).
+4. ~~**`Graphic Novels` similar concern** — format or genre? Currently treated as genre.~~ **Resolved 2026-05-17** by `RemoveFormatGenres` — moved to `format:graphic-novel` Tag on the Book.
 5. **`Romantasy` vs `Paranormal Fantasy` vs `Paranormal Romance`** — three sub-genres at the boundary that may overlap in practice. Worth a usage scan: are all three actively used? Do any captures land in two of them simultaneously?


### PR DESCRIPTION
PR 2 of the genre-restructure arc. `Graphic Novels` and `Short Story
Collections` are format indicators, not genres — moves them to
`format:graphic-novel` / `format:short-stories` Tag rows (Id 2 + 3) on
the Book. Constituent Works keep their thematic genre (Mystery for a
Christie compendium, etc).

Migration shape:
- Seeds the two `format:*` Tag rows via HasData.
- Guarded DELETE of the orphan Graphic Novels / Short Story Collections
  Genre rows: only fires when no GenreWork refs exist. Safe on fresh
  installs (drops immediately after the historical seed inserts them)
  and on Drew's prod (skips the DELETE if associations still exist; the
  once-off data-fix script handles the cleanup).

Once-off SQL `.debug/data-fixes/migrate-format-genres-to-tags.sql` is
gitignored (per Drew's convention: catalogue-specific data fixes don't
go in source). It re-points GenreWork associations to BookTag and
drops the Genre rows on prod. Idempotent and safe to re-run. Run order
documented inside the script: deploy migration first, then run the
script.

Docs:
- `GENRE-TAXONOMY.md` — tree updated, Provenance row added, open Qs 3+4
  resolved.
- `DATA-DICTIONARY.md` §Tag — adds the `format:*` and `shelf:*` (TODO
  #9, deferred) prefix conventions.

Verified locally end-to-end: applied migration (Graphic Novels has 3
refs so guard skipped; Short Story Collections has 0 refs so row
dropped). Then ran the once-off SQL: 3 BookTag rows for
format:graphic-novel created, 3 GenreWork rows removed, Graphic Novels
Genre row dropped. Second run of the script is a no-op (idempotent).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
