### PR TITLE
feat(ci): deploy-time EF migrations via bundle (TODO #21 PR A)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,13 +33,19 @@ jobs:
         # runs --no-build and would not pick up a property added there.
         run: dotnet build BookTracker.slnx --configuration Release --no-restore /p:SourceRevisionId=${{ github.sha }}
 
-      - name: Publish
-        run: dotnet publish BookTracker.Web/BookTracker.Web.csproj --configuration Release --no-build -o ./publish
-
-      - name: Zip publish output
+      - name: Build migration bundle
+        # Self-contained linux-x64 binary that applies pending migrations against a
+        # passed --connection string. Same model the app's Database.MigrateAsync()
+        # used at startup, just packaged into a deploy-time step. See TODO #21.
         run: |
-          cd publish
-          zip -r ../app.zip .
+          dotnet ef migrations bundle \
+            --project BookTracker.Data \
+            --startup-project BookTracker.Web \
+            --configuration Release \
+            --self-contained \
+            -r linux-x64 \
+            --output ./migrate \
+            --force
 
       - name: Azure login (OIDC)
         uses: azure/login@v2
@@ -47,6 +53,84 @@ jobs:
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Resolve SQL server + open temp firewall
+        id: sql-fw
+        env:
+          AZURE_RG: ${{ vars.AZURE_RG }}
+        run: |
+          set -euo pipefail
+          SQL_SERVER=$(az sql server list \
+            --resource-group "$AZURE_RG" \
+            --query "[?starts_with(name, 'booktracker-sql-')].name | [0]" -o tsv)
+          if [ -z "$SQL_SERVER" ]; then
+            echo "::error::No SQL server matching booktracker-sql-* in $AZURE_RG"
+            exit 1
+          fi
+          echo "sql_server=$SQL_SERVER" >> "$GITHUB_OUTPUT"
+          echo "sql_fqdn=$SQL_SERVER.database.windows.net" >> "$GITHUB_OUTPUT"
+
+          PUBLIC_ACCESS_WAS=$(az sql server show \
+            --resource-group "$AZURE_RG" --name "$SQL_SERVER" \
+            --query "publicNetworkAccess" -o tsv)
+          echo "public_access_was=$PUBLIC_ACCESS_WAS" >> "$GITHUB_OUTPUT"
+
+          if [ "$PUBLIC_ACCESS_WAS" != "Enabled" ]; then
+            az sql server update \
+              --resource-group "$AZURE_RG" --name "$SQL_SERVER" \
+              --set publicNetworkAccess=Enabled --output none
+          fi
+
+          MY_IP=$(curl -fsSL https://api.ipify.org)
+          RULE_NAME="ghactions-deploy-${{ github.run_id }}-${{ github.run_attempt }}"
+          echo "rule_name=$RULE_NAME" >> "$GITHUB_OUTPUT"
+          az sql server firewall-rule create \
+            --resource-group "$AZURE_RG" --server "$SQL_SERVER" \
+            --name "$RULE_NAME" \
+            --start-ip-address "$MY_IP" --end-ip-address "$MY_IP" \
+            --output none
+          # Server-side propagation lags the API response.
+          sleep 10
+
+      - name: Apply migrations to staging DB
+        env:
+          # `Active Directory Default` picks up the OIDC token via
+          # Azure.Identity's WorkloadIdentityCredential — the env vars
+          # azure/login@v2 set (AZURE_CLIENT_ID / AZURE_TENANT_ID /
+          # AZURE_FEDERATED_TOKEN_FILE) provide the chain.
+          STAGING_CONN: Server=tcp:${{ steps.sql-fw.outputs.sql_fqdn }},1433;Database=booktracker-staging;Authentication=Active Directory Default;Encrypt=True;TrustServerCertificate=False;
+        run: |
+          chmod +x ./migrate
+          ./migrate --connection "$STAGING_CONN"
+
+      - name: Close temp firewall
+        # `if: always()` so a failed migration apply still cleans up
+        # the firewall rule and restores the SQL server's prior
+        # public-network-access state.
+        if: always() && steps.sql-fw.outputs.rule_name != ''
+        env:
+          AZURE_RG: ${{ vars.AZURE_RG }}
+          SQL_SERVER: ${{ steps.sql-fw.outputs.sql_server }}
+          RULE_NAME: ${{ steps.sql-fw.outputs.rule_name }}
+          PUBLIC_ACCESS_WAS: ${{ steps.sql-fw.outputs.public_access_was }}
+        run: |
+          az sql server firewall-rule delete \
+            --resource-group "$AZURE_RG" --server "$SQL_SERVER" \
+            --name "$RULE_NAME" --output none || true
+          if [ "$PUBLIC_ACCESS_WAS" != "Enabled" ]; then
+            az sql server update \
+              --resource-group "$AZURE_RG" --name "$SQL_SERVER" \
+              --set publicNetworkAccess="$PUBLIC_ACCESS_WAS" \
+              --output none || true
+          fi
+
+      - name: Publish
+        run: dotnet publish BookTracker.Web/BookTracker.Web.csproj --configuration Release --no-build -o ./publish
+
+      - name: Zip publish output
+        run: |
+          cd publish
+          zip -r ../app.zip .
 
       - name: Deploy to staging slot
         uses: azure/webapps-deploy@v3

--- a/.github/workflows/swap.yml
+++ b/.github/workflows/swap.yml
@@ -16,12 +16,100 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Restore
+        run: dotnet restore BookTracker.slnx
+
+      - name: Build migration bundle
+        # Same bundle the deploy.yml workflow built against staging DB,
+        # rebuilt here from the same commit on `main` for atomicity.
+        # Applies pending migrations against the connection string the
+        # bundle is invoked with. See TODO #21.
+        run: |
+          dotnet ef migrations bundle \
+            --project BookTracker.Data \
+            --startup-project BookTracker.Web \
+            --configuration Release \
+            --self-contained \
+            -r linux-x64 \
+            --output ./migrate \
+            --force
+
       - name: Azure login (OIDC)
         uses: azure/login@v2
         with:
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Resolve SQL server + open temp firewall
+        id: sql-fw
+        env:
+          AZURE_RG: ${{ vars.AZURE_RG }}
+        run: |
+          set -euo pipefail
+          SQL_SERVER=$(az sql server list \
+            --resource-group "$AZURE_RG" \
+            --query "[?starts_with(name, 'booktracker-sql-')].name | [0]" -o tsv)
+          if [ -z "$SQL_SERVER" ]; then
+            echo "::error::No SQL server matching booktracker-sql-* in $AZURE_RG"
+            exit 1
+          fi
+          echo "sql_server=$SQL_SERVER" >> "$GITHUB_OUTPUT"
+          echo "sql_fqdn=$SQL_SERVER.database.windows.net" >> "$GITHUB_OUTPUT"
+
+          PUBLIC_ACCESS_WAS=$(az sql server show \
+            --resource-group "$AZURE_RG" --name "$SQL_SERVER" \
+            --query "publicNetworkAccess" -o tsv)
+          echo "public_access_was=$PUBLIC_ACCESS_WAS" >> "$GITHUB_OUTPUT"
+
+          if [ "$PUBLIC_ACCESS_WAS" != "Enabled" ]; then
+            az sql server update \
+              --resource-group "$AZURE_RG" --name "$SQL_SERVER" \
+              --set publicNetworkAccess=Enabled --output none
+          fi
+
+          MY_IP=$(curl -fsSL https://api.ipify.org)
+          RULE_NAME="ghactions-swap-${{ github.run_id }}-${{ github.run_attempt }}"
+          echo "rule_name=$RULE_NAME" >> "$GITHUB_OUTPUT"
+          az sql server firewall-rule create \
+            --resource-group "$AZURE_RG" --server "$SQL_SERVER" \
+            --name "$RULE_NAME" \
+            --start-ip-address "$MY_IP" --end-ip-address "$MY_IP" \
+            --output none
+          sleep 10
+
+      - name: Apply migrations to prod DB
+        # If this step fails, the swap below does NOT run — prod stays on
+        # both old code AND old schema (clean abort, no partial state).
+        env:
+          PROD_CONN: Server=tcp:${{ steps.sql-fw.outputs.sql_fqdn }},1433;Database=booktracker;Authentication=Active Directory Default;Encrypt=True;TrustServerCertificate=False;
+        run: |
+          chmod +x ./migrate
+          ./migrate --connection "$PROD_CONN"
+
+      - name: Close temp firewall
+        if: always() && steps.sql-fw.outputs.rule_name != ''
+        env:
+          AZURE_RG: ${{ vars.AZURE_RG }}
+          SQL_SERVER: ${{ steps.sql-fw.outputs.sql_server }}
+          RULE_NAME: ${{ steps.sql-fw.outputs.rule_name }}
+          PUBLIC_ACCESS_WAS: ${{ steps.sql-fw.outputs.public_access_was }}
+        run: |
+          az sql server firewall-rule delete \
+            --resource-group "$AZURE_RG" --server "$SQL_SERVER" \
+            --name "$RULE_NAME" --output none || true
+          if [ "$PUBLIC_ACCESS_WAS" != "Enabled" ]; then
+            az sql server update \
+              --resource-group "$AZURE_RG" --name "$SQL_SERVER" \
+              --set publicNetworkAccess="$PUBLIC_ACCESS_WAS" \
+              --output none || true
+          fi
 
       - name: Swap staging into production
         run: |

--- a/BookTracker.Web/Program.cs
+++ b/BookTracker.Web/Program.cs
@@ -1,7 +1,14 @@
 using BookTracker.Web;
 
 var app = ProgramSetup.Build(args);
-await ProgramSetup.RunMigrationsAsync(app);
+// Migrations apply at deploy-time (CI bundle) in Staging/Production —
+// see .github/workflows/deploy.yml + swap.yml and TODO #21. Local
+// dev keeps migrate-on-startup so `dotnet watch` Just Works without
+// a separate `dotnet ef database update` step.
+if (app.Environment.IsDevelopment())
+{
+    await ProgramSetup.RunMigrationsAsync(app);
+}
 await app.RunAsync();
 
 // Surfaces the implicit top-level Program class so test code can

--- a/infra/deploy.ps1
+++ b/infra/deploy.ps1
@@ -26,7 +26,14 @@ param(
     # Optional Trove (National Library of Australia) API key. Used as a
     # third-line ISBN lookup provider for titles Open Library and Google
     # Books don't index. Same storage pattern as AnthropicApiKey.
-    [string] $TroveApiKey = ''
+    [string] $TroveApiKey = '',
+    # Optional: display name (in this tenant) of the Azure AD app
+    # registration / SP that GitHub Actions OIDC authenticates as.
+    # When supplied, the script grants that identity db_ddladmin on both
+    # databases so the deploy.yml / swap.yml workflows can apply EF
+    # migrations against staging + prod via the deploy-time bundle (see
+    # TODO #21). Leave blank to skip the CI grant on this run.
+    [string] $GitHubOidcAppName = ''
 )
 
 $ErrorActionPreference = 'Stop'
@@ -246,6 +253,30 @@ END
     Invoke-Sqlcmd -ServerInstance $sqlFqdn -Database $sqlDb -AccessToken $token -Query $prodGrantSql -Encrypt Mandatory
     Write-Host "  Granting staging identity on '$stagingSqlDb'..."
     Invoke-Sqlcmd -ServerInstance $sqlFqdn -Database $stagingSqlDb -AccessToken $token -Query $stagingGrantSql -Encrypt Mandatory
+
+    # GitHub Actions OIDC identity (TODO #21 — deploy-time migrations).
+    # Grants db_ddladmin so the deploy.yml/swap.yml workflows can apply
+    # the EF migration bundle. The runtime managed identities above will
+    # eventually downgrade to db_datareader + db_datawriter (PR B of the
+    # TODO #21 arc); for now they retain db_ddladmin while migrate-on-
+    # startup is still gated to local-dev only.
+    if ($GitHubOidcAppName) {
+        $ghGrantSql = @"
+IF NOT EXISTS (SELECT 1 FROM sys.database_principals WHERE name = '$GitHubOidcAppName')
+BEGIN
+    CREATE USER [$GitHubOidcAppName] FROM EXTERNAL PROVIDER;
+    ALTER ROLE db_datareader ADD MEMBER [$GitHubOidcAppName];
+    ALTER ROLE db_datawriter ADD MEMBER [$GitHubOidcAppName];
+    ALTER ROLE db_ddladmin  ADD MEMBER [$GitHubOidcAppName];
+END
+"@
+        Write-Host "  Granting GitHub OIDC identity '$GitHubOidcAppName' on '$sqlDb'..."
+        Invoke-Sqlcmd -ServerInstance $sqlFqdn -Database $sqlDb -AccessToken $token -Query $ghGrantSql -Encrypt Mandatory
+        Write-Host "  Granting GitHub OIDC identity '$GitHubOidcAppName' on '$stagingSqlDb'..."
+        Invoke-Sqlcmd -ServerInstance $sqlFqdn -Database $stagingSqlDb -AccessToken $token -Query $ghGrantSql -Encrypt Mandatory
+    } else {
+        Write-Host "  Skipping GitHub OIDC identity grant (-GitHubOidcAppName not supplied)."
+    }
 }
 finally {
     Write-Host "  Removing temporary SQL firewall rule..."


### PR DESCRIPTION
Moves Database.MigrateAsync() out of app startup and into explicit
CI steps wrapping the existing deploy + swap workflows. Separates
"did migrations succeed" from "did the app boot" — the slot-swap
warmup probe no longer waits 30 minutes for a migration crash to
look like slowness.

Changes:

- .github/workflows/deploy.yml — builds a self-contained linux-x64
  EF migration bundle, opens a temp SQL firewall rule for the runner
  IP, applies pending migrations against `booktracker-staging` via
  AAD auth (Active Directory Default picks up the OIDC token
  azure/login@v2 surfaces). Firewall always closed via if: always().
  Slot deploy happens AFTER migrations succeed — a failed apply
  blocks the deploy step.

- .github/workflows/swap.yml — same pattern against `booktracker`.
  Migration applies BEFORE az webapp deployment slot swap; failed
  apply aborts the swap, so prod stays on both old code AND old
  schema (no partial state).

- BookTracker.Web/Program.cs — RunMigrationsAsync now gated on
  IsDevelopment so `dotnet watch` keeps its migrate-on-startup
  convenience locally; Production/Staging skip it.

- infra/deploy.ps1 — new -GitHubOidcAppName parameter. When set,
  grants the GH OIDC identity db_ddladmin (plus reader/writer) on
  both DBs so the workflows can apply migrations. Runtime managed
  identities keep db_ddladmin for now; PR B (follow-up) downgrades
  them to db_datareader + db_datawriter and removes the
  SECURITY-AUDIT.md §10 suppression.

Local smoke-tested: `dotnet ef migrations bundle` produces a 161MB
self-contained linux-x64 binary; Program.cs change builds clean;
existing test container (`SqlServerContainer.cs`) untouched.

Drew's next-deploy steps:
  1. Pass -GitHubOidcAppName when running infra/deploy.ps1 (look up
     the display name of the GH OIDC SP in Entra → App registrations).
  2. Merge this PR. The next push-to-main deploy runs the new
     workflow; the next swap dispatch runs the new swap workflow.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
