### PR TITLE
fix(ci): install dotnet-ef on the runner before building the bundle

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,6 +23,12 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
+      - name: Install dotnet-ef
+        # Required for `dotnet ef migrations bundle` below. Fresh GH
+        # runners don't have it preinstalled. Pinned to 10.0.7 to match
+        # the .NET runtime version.
+        run: dotnet tool install --global dotnet-ef --version 10.0.7
+
       - name: Restore
         run: dotnet restore BookTracker.slnx
 

--- a/.github/workflows/swap.yml
+++ b/.github/workflows/swap.yml
@@ -22,6 +22,12 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
+      - name: Install dotnet-ef
+        # Required for `dotnet ef migrations bundle` below. Fresh GH
+        # runners don't have it preinstalled. Pinned to 10.0.7 to match
+        # the .NET runtime version.
+        run: dotnet tool install --global dotnet-ef --version 10.0.7
+
       - name: Restore
         run: dotnet restore BookTracker.slnx
 


### PR DESCRIPTION
PR #275 (deploy-time migrations) calls `dotnet ef migrations bundle`
in both deploy.yml and swap.yml but didn't install the dotnet-ef
global tool. Fresh GH Actions runners don't have it. First post-merge
deploy failed at the bundle step with:

  Could not execute because the specified command or file was not
  found. ... dotnet-ef does not exist.

Adds `dotnet tool install --global dotnet-ef --version 10.0.7` ahead
of the bundle step in both workflows. Pinned to the runtime version
to avoid the tool-vs-runtime mismatch warning.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
