### PR TITLE
feat(genre): seed Popular Science, Memoir, Philosophy, Poetry

### DIFF
--- a/BookTracker.Data/Migrations/20260522023150_SeedNonFictionSubGenresAndPoetry.Designer.cs
+++ b/BookTracker.Data/Migrations/20260522023150_SeedNonFictionSubGenresAndPoetry.Designer.cs
@@ -4,6 +4,7 @@ using BookTracker.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BookTracker.Data.Migrations
 {
     [DbContext(typeof(BookTrackerDbContext))]
-    partial class BookTrackerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260522023150_SeedNonFictionSubGenresAndPoetry")]
+    partial class SeedNonFictionSubGenresAndPoetry
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BookTracker.Data/Migrations/20260522023150_SeedNonFictionSubGenresAndPoetry.cs
+++ b/BookTracker.Data/Migrations/20260522023150_SeedNonFictionSubGenresAndPoetry.cs
@@ -1,0 +1,67 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BookTracker.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class SeedNonFictionSubGenresAndPoetry : Migration
+    {
+        // Idempotent NOT-EXISTS guard per row, mirroring SeedGenreExpansion.
+        // Round 2 (2026-05-22) of the genre-restructure arc — surfaces three
+        // missing non-fiction branches (popular science, memoir, philosophy)
+        // and one missing top-level fiction-adjacent branch (poetry) that the
+        // bulk-changeset review identified as currently misclassified under
+        // Reference and Literary Fiction respectively.
+        private static readonly string[] ReferenceSubGenres =
+        [
+            "Popular Science",
+            "Memoir",
+            "Philosophy",
+        ];
+
+        private static readonly string[] NewTopLevel =
+        [
+            "Poetry",
+        ];
+
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            SeedUnder(migrationBuilder, "Reference", ReferenceSubGenres);
+            SeedTopLevel(migrationBuilder, NewTopLevel);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            foreach (var name in ReferenceSubGenres)
+                migrationBuilder.Sql($@"DELETE FROM [Genres] WHERE [Name] = N'{name}';");
+            foreach (var name in NewTopLevel)
+                migrationBuilder.Sql($@"DELETE FROM [Genres] WHERE [Name] = N'{name}' AND [ParentGenreId] IS NULL;");
+        }
+
+        private static void SeedUnder(MigrationBuilder migrationBuilder, string parentName, string[] names)
+        {
+            foreach (var name in names)
+            {
+                migrationBuilder.Sql($@"
+IF NOT EXISTS (SELECT 1 FROM [Genres] WHERE [Name] = N'{name}')
+    INSERT INTO [Genres] ([Name], [ParentGenreId])
+    VALUES (N'{name}',
+            (SELECT TOP 1 [Id] FROM [Genres] WHERE [Name] = N'{parentName}' AND [ParentGenreId] IS NULL));");
+            }
+        }
+
+        private static void SeedTopLevel(MigrationBuilder migrationBuilder, string[] names)
+        {
+            foreach (var name in names)
+            {
+                migrationBuilder.Sql($@"
+IF NOT EXISTS (SELECT 1 FROM [Genres] WHERE [Name] = N'{name}' AND [ParentGenreId] IS NULL)
+    INSERT INTO [Genres] ([Name], [ParentGenreId])
+    VALUES (N'{name}', NULL);");
+            }
+        }
+    }
+}

--- a/BookTracker.Data/Models/GenreSeed.cs
+++ b/BookTracker.Data/Models/GenreSeed.cs
@@ -92,8 +92,11 @@ public static class GenreSeed
 
 
         // Non-fiction starter set — reference, art, and religious books.
-        // Further non-fiction branches (History, Biography, Science,
-        // Poetry, etc.) are left for a follow-up expansion.
+        // Further non-fiction branches (History, Biography, etc.) are
+        // left for a future expansion; the 2026-05-22 round-2 work
+        // added Popular Science, Memoir, Philosophy as Reference
+        // children and Poetry as a top-level (see Provenance in
+        // GENRE-TAXONOMY.md).
         new("Reference", null),
         new("Dictionaries", "Reference"),
         new("Encyclopedias", "Reference"),
@@ -101,6 +104,11 @@ public static class GenreSeed
         new("Field Guides", "Reference"),
         new("Style Guides", "Reference"),
         new("Language Learning", "Reference"),
+        new("Popular Science", "Reference"),
+        new("Memoir", "Reference"),
+        new("Philosophy", "Reference"),
+
+        new("Poetry", null),
 
         new("Art", null),
         new("Art History", "Art"),

--- a/docs/GENRE-TAXONOMY.md
+++ b/docs/GENRE-TAXONOMY.md
@@ -105,7 +105,10 @@ Reference
 ├── Atlases
 ├── Field Guides
 ├── Style Guides
-└── Language Learning
+├── Language Learning
+├── Popular Science
+├── Memoir
+└── Philosophy
 
 Art
 ├── Art History
@@ -121,6 +124,8 @@ Religion & Spirituality
 ├── Theology
 ├── Comparative Religion
 └── Mythology
+
+Poetry                       (top-level, no sub-genres yet)
 ```
 
 ---
@@ -134,6 +139,7 @@ Religion & Spirituality
 | Reference + Art + Religion & Spirituality (all three branches and their sub-genres) | Non-fiction starter set | `20260422090308_SeedNonFictionReferenceArtReligion` |
 | Science Fiction sub-tree (Hard SF / Space Opera / Cyberpunk / Military SF / Time Travel / First Contact / Post-Apocalyptic / Dystopian SF / Alternate History / Young Adult SF) + Horror sub-tree extension (Cosmic Horror / Gothic Horror / Supernatural / Psychological Horror / Splatterpunk / Folk Horror / Body Horror) | Genre-restructure pass (PR 1) | `20260516233131_SeedGenreExpansion` |
 | `Graphic Novels` + `Short Story Collections` removed from the tree (moved to `format:*` Tag convention); `format:graphic-novel` + `format:short-stories` Tag rows seeded | Genre-restructure pass (PR 2) | `20260517041346_RemoveFormatGenres` |
+| Reference sub-genres (Popular Science / Memoir / Philosophy) + top-level Poetry | Genre-restructure round 2 (this PR) | `20260522023150_SeedNonFictionSubGenresAndPoetry` |
 
 User-added genres (created via the Add page typeahead's free-text fall-through, if that surface allows it — currently the picker is closed-list against `GenreSeed.All`) would *not* be in `GenreSeed.cs` but would live in the DB. If you see a Genre row in the snapshot that's not in this file, it's either a stale row from a withdrawn seed, an out-of-band insert, or this file is behind. As of this writing, the picker is closed-list, so the DB and `GenreSeed.cs` should match exactly.
 
@@ -144,9 +150,8 @@ User-added genres (created via the Add page typeahead's free-text fall-through, 
 The original comment in `GenreSeed.cs` flags non-fiction expansion as deliberate future work — branches that are missing today and would be the obvious next additions:
 
 - **History** (Ancient / Medieval / Modern / Military / Local-regional)
-- **Biography** (Memoir / Autobiography / Authorised / Unauthorised)
-- **Science** (Popular / Mathematics / Physics / Biology / Earth-science / etc.)
-- **Poetry**
+- **Biography** (Autobiography / Authorised / Unauthorised — `Memoir` was seeded under Reference in the 2026-05-22 round-2 pass; a sibling `Biography` branch may earn its keep if the corpus demands the distinction)
+- **Science** (Mathematics / Physics / Biology / Earth-science / etc. — `Popular Science` was seeded under Reference in the 2026-05-22 round-2 pass as the catch-all for trade-press science writing)
 - **Cookery / Cookbooks** (currently no home — cookbooks tagged today go under Reference or unclassified)
 - **Travel writing**
 - **Essays / Letters**


### PR DESCRIPTION
Round 2 of the genre-restructure arc. The 2026-05-22 bulk-changeset
review (genre-bulk-patch/) flagged that popular science (Genome,
Chaos, Drunkard's Walk), memoir (Herriot, Lansing, Anne Frank),
philosophy (Nietzsche, Plato), and poetry (Morrison, Graves, Milton)
currently misclassify as Reference or Literary Fiction because no
proper branch exists. The original GenreSeed.cs already flagged this
expansion as deliberate future work (lines 94-96).

Adds:
- Popular Science, Memoir, Philosophy as sub-genres of Reference.
- Poetry as a new top-level (it's neither prose-fiction nor reference).

Biography is intentionally NOT added in this pass - Memoir covers the
corpus's narrative-non-fiction surface, and Lansing's Endurance is the
only borderline case. A sibling Biography branch can be added later if
the corpus grows the distinction.

Migration mirrors the SeedGenreExpansion / SeedHorrorSubGenres pattern:
idempotent NOT-EXISTS guards per row, deterministic Down. Verified
end-to-end against the local Docker SQL container - all four genres
landed with correct parents.

The follow-up reclassification (moving existing Reference-tagged works
into the new branches) is a separate .debug/*.ps1 pass that runs once
this migration has deployed.
