### PR TITLE
feat(workauthor): Role enum + schema + display formatter + rollup filters

### DIFF
--- a/BookTracker.Data/BookTrackerDbContext.cs
+++ b/BookTracker.Data/BookTrackerDbContext.cs
@@ -161,8 +161,10 @@ public class BookTrackerDbContext(DbContextOptions<BookTrackerDbContext> options
             .OnDelete(DeleteBehavior.SetNull);
 
         // Work ↔ Author is many-to-many through the WorkAuthor join entity.
-        // Composite PK on (WorkId, AuthorId) — the same Author can't appear
-        // twice on a single Work. Cascade on Work delete (the join row only
+        // Composite PK on (WorkId, AuthorId, Role) — the same Author can't
+        // appear twice on a single Work in the same role, but CAN hold
+        // multiple roles (Tolkien is Author + Illustrator on *The Hobbit*).
+        // Cascade on Work delete (the join row only
         // exists as long as the Work does); Restrict on Author delete (don't
         // allow deleting an Author that's still credited on a Work).
         //
@@ -182,7 +184,11 @@ public class BookTrackerDbContext(DbContextOptions<BookTrackerDbContext> options
                       .WithMany(w => w.WorkAuthors)
                       .HasForeignKey(wa => wa.WorkId)
                       .OnDelete(DeleteBehavior.Cascade),
-                j => j.HasKey(wa => new { wa.WorkId, wa.AuthorId }));
+                j =>
+                {
+                    j.HasKey(wa => new { wa.WorkId, wa.AuthorId, wa.Role });
+                    j.Property(wa => wa.Role).HasDefaultValue(AuthorRole.Author);
+                });
 
         modelBuilder.Entity<Author>()
             .HasIndex(a => a.Name)

--- a/BookTracker.Data/Migrations/20260522080320_AddWorkAuthorRole.Designer.cs
+++ b/BookTracker.Data/Migrations/20260522080320_AddWorkAuthorRole.Designer.cs
@@ -4,6 +4,7 @@ using BookTracker.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BookTracker.Data.Migrations
 {
     [DbContext(typeof(BookTrackerDbContext))]
-    partial class BookTrackerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260522080320_AddWorkAuthorRole")]
+    partial class AddWorkAuthorRole
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BookTracker.Data/Migrations/20260522080320_AddWorkAuthorRole.cs
+++ b/BookTracker.Data/Migrations/20260522080320_AddWorkAuthorRole.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BookTracker.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddWorkAuthorRole : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_WorkAuthors",
+                table: "WorkAuthors");
+
+            migrationBuilder.AddColumn<int>(
+                name: "Role",
+                table: "WorkAuthors",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_WorkAuthors",
+                table: "WorkAuthors",
+                columns: new[] { "WorkId", "AuthorId", "Role" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_WorkAuthors",
+                table: "WorkAuthors");
+
+            migrationBuilder.DropColumn(
+                name: "Role",
+                table: "WorkAuthors");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_WorkAuthors",
+                table: "WorkAuthors",
+                columns: new[] { "WorkId", "AuthorId" });
+        }
+    }
+}

--- a/BookTracker.Data/Models/WorkAuthor.cs
+++ b/BookTracker.Data/Models/WorkAuthor.cs
@@ -1,24 +1,50 @@
 namespace BookTracker.Data.Models;
 
+/// <summary>
+/// What kind of contribution this person made to the Work. Default is
+/// <see cref="Author"/> — the original-content author. Other roles cover
+/// the contributor types that surface in non-fiction (editors of reference
+/// works, translators of classical / sacred texts, illustrators of
+/// graphic novels and children's books).
+///
+/// Rollup queries that count "books by X" default to <c>Role = Author</c>
+/// to protect the Top-Authors report from being polluted by translators
+/// and editors of reference works. Anything wider is an explicit opt-in.
+/// </summary>
+public enum AuthorRole
+{
+    Author = 0,        // original-content author (default)
+    Editor = 1,
+    Translator = 2,
+    Illustrator = 3,
+    Adaptor = 4,
+    Compiler = 5,
+    Foreword = 6,      // prominent forewords (Bryson writing a foreword to X)
+    Contributor = 7,   // multi-contributor anthologies where the named individual is one of many
+}
+
 // Join entity for Work ↔ Author (M:N). A Work can credit multiple Authors
 // (Preston + Child writing *Relic* together; the Destroyer series credits
 // Murphy + Sapir for ~90% of the run).
 //
 // `Order` = display position. 0 = lead/primary, ascending for additional
 // authors — keeps "Preston & Child" stable rather than alphabetising.
+// Order is per-Role: a Work's Authors share an Order sequence, and its
+// Translators share a separate Order sequence.
+//
+// `Role` = what kind of contribution this is. Default Author for original
+// content; other roles for editors / translators / illustrators / etc.
+// See [[AuthorRole]] for the enum.
 //
 // Author canonical-alias rollup chains transparently: each WorkAuthor.Author
 // → Author.CanonicalAuthorId resolves the same way as before. A Work
 // co-credited to Stephen King + Richard Bachman rolls up under King's
 // canonical for aggregations that dedupe by canonical.
 //
-// Composite PK (WorkId, AuthorId) encodes the invariant that the same
-// Author can't appear twice on a single Work.
-//
-// PR1 of the multi-author cutover (additive): Work keeps both AuthorId
-// (legacy single-author FK) and WorkAuthors (this join) — saves dual-write,
-// reads still come from AuthorId. PR2 drops AuthorId and switches reads
-// to WorkAuthors.
+// Composite PK (WorkId, AuthorId, Role) encodes the invariant that the
+// same Author can't appear twice on a single Work in the SAME role —
+// but the same Author CAN hold multiple roles on the same Work
+// (Tolkien is Author + Illustrator on *The Hobbit*).
 public class WorkAuthor
 {
     public int WorkId { get; set; }
@@ -27,6 +53,13 @@ public class WorkAuthor
     public int AuthorId { get; set; }
     public Author Author { get; set; } = null!;
 
-    /// <summary>Display position. 0 = lead/primary author, ascending for additional authors.</summary>
+    /// <summary>Display position. 0 = lead/primary author, ascending for additional authors. Per-Role.</summary>
     public int Order { get; set; }
+
+    /// <summary>
+    /// What kind of contribution this person made to the Work. Default
+    /// <see cref="AuthorRole.Author"/>; rollup queries filter to Author
+    /// by default and opt in to other roles explicitly.
+    /// </summary>
+    public AuthorRole Role { get; set; }
 }

--- a/BookTracker.Web/Services/Catalog/CatalogSnapshotService.cs
+++ b/BookTracker.Web/Services/Catalog/CatalogSnapshotService.cs
@@ -1,4 +1,5 @@
 using BookTracker.Data;
+using BookTracker.Data.Models;
 using BookTracker.Shared.Catalog;
 using Microsoft.EntityFrameworkCore;
 
@@ -168,9 +169,12 @@ public class CatalogSnapshotService(
         // Distinct (canonical_id, book_id) pairs across the whole
         // WorkAuthor graph. Group-by canonical gives the rolled-up
         // count without double-counting books credited to both
-        // canonical and alias.
+        // canonical and alias. Filtered to Role = Author so the snapshot's
+        // BookCount stays a true "books this person wrote" rollup —
+        // matches the /authors and Home top-authors semantics.
         var canonicalBookPairs = await db.WorkAuthors
             .AsNoTracking()
+            .Where(wa => wa.Role == AuthorRole.Author)
             .SelectMany(wa => wa.Work.Books.Select(b => new
             {
                 CanonicalId = wa.Author.CanonicalAuthorId ?? wa.AuthorId,

--- a/BookTracker.Web/Services/DuplicateDetectionService.cs
+++ b/BookTracker.Web/Services/DuplicateDetectionService.cs
@@ -286,10 +286,10 @@ public class DuplicateDetectionService(IDbContextFactory<BookTrackerDbContext> d
                 CopyCount = b.Editions.SelectMany(e => e.Copies).Count(),
                 WorkIds = b.Works.Select(w => w.Id).ToList(),
                 FirstAuthorId = b.Works
-                    .SelectMany(w => w.WorkAuthors.OrderBy(wa => wa.Order).Select(wa => (int?)wa.AuthorId))
+                    .SelectMany(w => w.WorkAuthors.Where(wa => wa.Role == AuthorRole.Author).OrderBy(wa => wa.Order).Select(wa => (int?)wa.AuthorId))
                     .FirstOrDefault(),
                 FirstAuthorName = b.Works
-                    .SelectMany(w => w.WorkAuthors.OrderBy(wa => wa.Order).Select(wa => wa.Author.Name))
+                    .SelectMany(w => w.WorkAuthors.Where(wa => wa.Role == AuthorRole.Author).OrderBy(wa => wa.Order).Select(wa => wa.Author.Name))
                     .FirstOrDefault()
             })
             .ToListAsync(ct);

--- a/BookTracker.Web/Services/WorkAuthorshipFormatter.cs
+++ b/BookTracker.Web/Services/WorkAuthorshipFormatter.cs
@@ -12,17 +12,24 @@ namespace BookTracker.Web.Services;
 // for co-authored books on covers; comma-list for three+ matches what
 // anthology spines do.
 //
+// Post-2026-05-23 Role support: when a Work has non-Author contributors
+// (Editor / Translator / Illustrator / etc.) they render after the
+// Author-role contributors with a role suffix:
+//   "Doug Mauss (editor); Sergio Cariello (illustrator)"
+// Author-role contributors lead with no suffix; non-Author contributors
+// follow, semicolon-separated, with the lowercase role name in
+// parentheses.
+//
 // Sites: BookListViewModel, BookDetailViewModel, AuthorListViewModel,
 // SeriesEditViewModel, ShoppingViewModel, HomeViewModel, the Library
 // list / BookDetail / Shopping Razor surfaces, and the merge dialogs.
-// Anywhere that previously read `work.Author.Name` reads through this
-// helper post-cutover.
 public static class WorkAuthorshipFormatter
 {
     /// <summary>
-    /// Format an ordered sequence of author names for display.
-    /// Empty input returns "(unknown author)" — defensive; shouldn't happen
-    /// post-cutover because every Work has at least one WorkAuthor row.
+    /// Format an ordered sequence of author names (Author-role only) for
+    /// display. Kept as the simple-string overload for callers that don't
+    /// need Role awareness (e.g. plain author rollups). Empty input
+    /// returns "(unknown author)".
     /// </summary>
     public static string Display(IEnumerable<string> names)
     {
@@ -37,10 +44,49 @@ public static class WorkAuthorshipFormatter
     }
 
     /// <summary>
-    /// Convenience overload: pull names directly from a Work's WorkAuthors
-    /// collection in Order ascending. Caller is responsible for having
-    /// loaded WorkAuthors + Author.
+    /// Role-aware overload. Author-role contributors render with the
+    /// standard "Preston & Child" treatment; non-Author contributors
+    /// append after with a "; Name (role)" suffix.
+    /// </summary>
+    public static string Display(IEnumerable<(string Name, AuthorRole Role)> contributors)
+    {
+        var ordered = (contributors ?? [])
+            .Where(c => !string.IsNullOrWhiteSpace(c.Name))
+            .ToList();
+
+        var authors = ordered.Where(c => c.Role == AuthorRole.Author).Select(c => c.Name).ToList();
+        var others  = ordered.Where(c => c.Role != AuthorRole.Author).ToList();
+
+        var authorPart = Display(authors);
+        if (others.Count == 0) return authorPart;
+
+        var otherPart = string.Join("; ", others.Select(c => $"{c.Name} ({RoleLabel(c.Role)})"));
+        return authors.Count == 0 ? otherPart : $"{authorPart}; {otherPart}";
+    }
+
+    /// <summary>
+    /// Convenience overload: pull contributors directly from a Work's
+    /// WorkAuthors collection, sorted by (Role, Order) so Author-role
+    /// contributors come first then other roles each in their own Order
+    /// sequence. Caller is responsible for having loaded WorkAuthors +
+    /// Author.
     /// </summary>
     public static string Display(Work work) =>
-        Display(work.WorkAuthors.OrderBy(wa => wa.Order).Select(wa => wa.Author.Name));
+        Display(work.WorkAuthors
+            .OrderBy(wa => wa.Role == AuthorRole.Author ? 0 : 1) // Author first
+            .ThenBy(wa => (int)wa.Role)                          // then other roles in enum order
+            .ThenBy(wa => wa.Order)
+            .Select(wa => (wa.Author.Name, wa.Role)));
+
+    private static string RoleLabel(AuthorRole role) => role switch
+    {
+        AuthorRole.Editor      => "editor",
+        AuthorRole.Translator  => "translator",
+        AuthorRole.Illustrator => "illustrator",
+        AuthorRole.Adaptor     => "adaptor",
+        AuthorRole.Compiler    => "compiler",
+        AuthorRole.Foreword    => "foreword",
+        AuthorRole.Contributor => "contributor",
+        _                      => role.ToString().ToLowerInvariant(),
+    };
 }

--- a/BookTracker.Web/Services/WorkSearchService.cs
+++ b/BookTracker.Web/Services/WorkSearchService.cs
@@ -1,4 +1,5 @@
 using BookTracker.Data;
+using BookTracker.Data.Models;
 using Microsoft.EntityFrameworkCore;
 
 namespace BookTracker.Web.Services;
@@ -62,7 +63,7 @@ public class WorkSearchService(IDbContextFactory<BookTrackerDbContext> dbFactory
                 // Lead-author name only — the search dropdown row is tight, so
                 // co-authors are elided here. The full multi-author display
                 // appears once the user picks the work and lands on BookDetail.
-                AuthorName = w.WorkAuthors.OrderBy(wa => wa.Order).Select(wa => wa.Author.Name).FirstOrDefault() ?? "",
+                AuthorName = w.WorkAuthors.Where(wa => wa.Role == AuthorRole.Author).OrderBy(wa => wa.Order).Select(wa => wa.Author.Name).FirstOrDefault() ?? "",
                 Year = (int?)(w.FirstPublishedDate == null ? null : (int?)w.FirstPublishedDate.Value.Year),
                 BookCount = w.Books.Count,
                 TitleLower = w.Title.ToLower()

--- a/BookTracker.Web/ViewModels/AIAssistantViewModel.cs
+++ b/BookTracker.Web/ViewModels/AIAssistantViewModel.cs
@@ -46,7 +46,7 @@ public class AIAssistantViewModel(
                 // Lead author name only — the AI prompt context is per-Work, and
                 // the genre suggestion service still takes a single author string.
                 // Multi-author surfaces use the formatter; this row is internal.
-                b.Works.FirstOrDefault()!.WorkAuthors.OrderBy(wa => wa.Order).Select(wa => wa.Author.Name).FirstOrDefault() ?? "",
+                b.Works.FirstOrDefault()!.WorkAuthors.Where(wa => wa.Role == AuthorRole.Author).OrderBy(wa => wa.Order).Select(wa => wa.Author.Name).FirstOrDefault() ?? "",
                 b.Works.SelectMany(w => w.Genres).Select(g => g.Name).Distinct().ToList()))
             .ToListAsync();
 
@@ -173,7 +173,7 @@ public class AIAssistantViewModel(
             .ToListAsync();
 
         var authorNames = matchedBooks
-            .SelectMany(b => b.Works.SelectMany(w => w.WorkAuthors.OrderBy(wa => wa.Order).Select(wa => wa.Author.Name)))
+            .SelectMany(b => b.Works.SelectMany(w => w.WorkAuthors.Where(wa => wa.Role == AuthorRole.Author).OrderBy(wa => wa.Order).Select(wa => wa.Author.Name)))
             .Distinct()
             .ToList();
         if (authorNames.Count == 1)

--- a/BookTracker.Web/ViewModels/AuthorDetailViewModel.cs
+++ b/BookTracker.Web/ViewModels/AuthorDetailViewModel.cs
@@ -74,11 +74,14 @@ public class AuthorDetailViewModel(IDbContextFactory<BookTrackerDbContext> dbFac
             ids.AddRange(author.Aliases.Select(a => a.Id));
         }
 
+        // Default drilldown: only Works where this author is in an
+        // Author role. Editor/translator/illustrator contributions can be
+        // shown via a future opt-in toggle.
         var works = await db.Works
             .Include(w => w.WorkAuthors).ThenInclude(wa => wa.Author)
             .Include(w => w.Books)
             .Include(w => w.Series)
-            .Where(w => w.WorkAuthors.Any(wa => ids.Contains(wa.AuthorId)))
+            .Where(w => w.WorkAuthors.Any(wa => ids.Contains(wa.AuthorId) && wa.Role == AuthorRole.Author))
             .OrderBy(w => w.SeriesId == null)
             .ThenBy(w => w.Series!.Name)
             .ThenBy(w => w.SeriesOrder ?? int.MaxValue)
@@ -92,9 +95,13 @@ public class AuthorDetailViewModel(IDbContextFactory<BookTrackerDbContext> dbFac
             // "Written as" tag only on canonical drill-downs; alias rows always
             // are themselves so the label would be redundant.
             isCanonical
-                ? w.WorkAuthors.OrderBy(wa => wa.Order).Select(wa => wa.Author).FirstOrDefault() is { } leadAuthor && leadAuthor.Id != author.Id
-                    ? leadAuthor.Name
-                    : null
+                ? w.WorkAuthors
+                    .Where(wa => wa.Role == AuthorRole.Author)
+                    .OrderBy(wa => wa.Order)
+                    .Select(wa => wa.Author)
+                    .FirstOrDefault() is { } leadAuthor && leadAuthor.Id != author.Id
+                        ? leadAuthor.Name
+                        : null
                 : null,
             PartialDateParser.Format(w.FirstPublishedDate, w.FirstPublishedDatePrecision),
             w.Series?.Name,

--- a/BookTracker.Web/ViewModels/AuthorListViewModel.cs
+++ b/BookTracker.Web/ViewModels/AuthorListViewModel.cs
@@ -1,4 +1,5 @@
 using BookTracker.Data;
+using BookTracker.Data.Models;
 using Microsoft.EntityFrameworkCore;
 
 namespace BookTracker.Web.ViewModels;
@@ -61,7 +62,12 @@ public class AuthorListViewModel(IDbContextFactory<BookTrackerDbContext> dbFacto
             .OrderBy(a => a.Name)
             .ToListAsync();
 
+        // Default rollup: Role = Author only. Editor/Translator/Illustrator
+        // contributions are intentionally excluded from the headline "books
+        // by X" count so reference-work translators don't pollute the list.
+        // Per-author drilldowns showing all contributions are a future opt-in.
         var workAuthors = await db.WorkAuthors
+            .Where(wa => wa.Role == AuthorRole.Author)
             .Select(wa => new { wa.AuthorId, wa.WorkId })
             .ToListAsync();
 

--- a/BookTracker.Web/ViewModels/BookAddViewModel.cs
+++ b/BookTracker.Web/ViewModels/BookAddViewModel.cs
@@ -273,7 +273,7 @@ public class BookAddViewModel(
                         existing.Id,
                         existing.Book.Title,
                         string.Join(", ", existing.Book.Works
-                            .SelectMany(w => w.WorkAuthors.OrderBy(wa => wa.Order).Select(wa => wa.Author.Name))
+                            .SelectMany(w => w.WorkAuthors.Where(wa => wa.Role == AuthorRole.Author).OrderBy(wa => wa.Order).Select(wa => wa.Author.Name))
                             .Distinct()),
                         existing.Copies.Count);
                     LookupMessage = null;

--- a/BookTracker.Web/ViewModels/BookDetailViewModel.cs
+++ b/BookTracker.Web/ViewModels/BookDetailViewModel.cs
@@ -464,7 +464,7 @@ public class BookDetailViewModel(
         WorkAuthorshipFormatter.Display(w),
         // LeadAuthorId is the first WorkAuthor entry's Author — used by the
         // BookDetail '+author' link to deep-link into the /authors page.
-        w.WorkAuthors.OrderBy(wa => wa.Order).Select(wa => wa.AuthorId).FirstOrDefault(),
+        w.WorkAuthors.Where(wa => wa.Role == AuthorRole.Author).OrderBy(wa => wa.Order).Select(wa => wa.AuthorId).FirstOrDefault(),
         PartialDateParser.Format(w.FirstPublishedDate, w.FirstPublishedDatePrecision),
         w.Genres.OrderBy(g => g.Name).Select(g => g.Name).ToList(),
         w.Series is null ? null : new SeriesInfo(w.Series.Id, w.Series.Name, w.Series.Type, w.SeriesOrder));

--- a/BookTracker.Web/ViewModels/BookListViewModel.cs
+++ b/BookTracker.Web/ViewModels/BookListViewModel.cs
@@ -459,7 +459,7 @@ public class BookListViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
         // than the prettier "Preston & Child" — list views stay uniform; the
         // " & " formatter is reserved for single-book / single-Work surfaces
         // (BookDetail, dialogs).
-        string.Join(", ", b.Works.SelectMany(w => w.WorkAuthors.OrderBy(wa => wa.Order).Select(wa => wa.Author.Name)).Distinct()),
+        string.Join(", ", b.Works.SelectMany(w => w.WorkAuthors.Where(wa => wa.Role == AuthorRole.Author).OrderBy(wa => wa.Order).Select(wa => wa.Author.Name)).Distinct()),
         b.DefaultCoverArtUrl,
         b.Status,
         b.Rating,

--- a/BookTracker.Web/ViewModels/HomeViewModel.cs
+++ b/BookTracker.Web/ViewModels/HomeViewModel.cs
@@ -1,4 +1,5 @@
 using BookTracker.Data;
+using BookTracker.Data.Models;
 using Microsoft.EntityFrameworkCore;
 
 namespace BookTracker.Web.ViewModels;
@@ -29,7 +30,11 @@ public class HomeViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory)
         // WorkAuthor row contributes one tally — co-authored works contribute
         // to BOTH credited authors (post-PR2 behaviour change vs the lead-only
         // legacy where Preston + Child only counted toward the lead).
+        // Default Top-Authors filter: Role = Author. Editor/Translator/
+        // Illustrator contributions are intentionally excluded so the
+        // headline doesn't get polluted by reference-work translators.
         var authorTotals = await db.WorkAuthors
+            .Where(wa => wa.Role == AuthorRole.Author)
             .GroupBy(wa => wa.Author.CanonicalAuthorId ?? wa.AuthorId)
             .Select(g => new { CanonicalId = g.Key, Count = g.Count() })
             .OrderByDescending(x => x.Count)

--- a/BookTracker.Web/ViewModels/SeriesEditViewModel.cs
+++ b/BookTracker.Web/ViewModels/SeriesEditViewModel.cs
@@ -153,7 +153,7 @@ public class SeriesEditViewModel(IDbContextFactory<BookTrackerDbContext> dbFacto
             .Select(w => new WorkSearchResult(
                 w.Id,
                 w.Title,
-                w.WorkAuthors.OrderBy(wa => wa.Order).Select(wa => wa.Author.Name).FirstOrDefault() ?? "",
+                w.WorkAuthors.Where(wa => wa.Role == AuthorRole.Author).OrderBy(wa => wa.Order).Select(wa => wa.Author.Name).FirstOrDefault() ?? "",
                 w.SeriesId))
             .ToListAsync();
     }

--- a/BookTracker.Web/ViewModels/ShoppingViewModel.cs
+++ b/BookTracker.Web/ViewModels/ShoppingViewModel.cs
@@ -221,7 +221,7 @@ public class ShoppingViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
     private static string PrimaryAuthor(Book book)
     {
         var names = book.Works
-            .SelectMany(w => w.WorkAuthors.OrderBy(wa => wa.Order).Select(wa => wa.Author?.Name))
+            .SelectMany(w => w.WorkAuthors.Where(wa => wa.Role == AuthorRole.Author).OrderBy(wa => wa.Order).Select(wa => wa.Author?.Name))
             .Where(n => !string.IsNullOrWhiteSpace(n))
             .Distinct()
             .ToList();


### PR DESCRIPTION
PR 2 of the non-fiction expansion arc. Phase A (schema + entity) and
Phase B (display formatter + rollup filters).

Phase A — schema + entity:
- AuthorRole enum (8 values, Author=0 default): Author / Editor /
  Translator / Illustrator / Adaptor / Compiler / Foreword / Contributor.
- WorkAuthor.Role property; composite PK extended from (WorkId, AuthorId)
  to (WorkId, AuthorId, Role) so the same person can hold multiple roles
  on the same Work (Tolkien is Author + Illustrator on *The Hobbit*).
- EF migration AddWorkAuthorRole: drop PK -> add Role int NOT NULL
  default 0 -> recreate PK with Role added. All existing rows default
  to Author so behaviour is preserved post-migration.
- BookTrackerDbContext: HasKey + HasDefaultValue(AuthorRole.Author).

Phase B — display formatter + rollup filters:
- WorkAuthorshipFormatter gains a Role-aware overload that groups
  Author-role contributors with the standard "Preston & Child" treatment
  and appends non-Author roles with a "; Name (role)" suffix
  (e.g. "Doug Mauss; Sergio Cariello (illustrator)").
- Default rollup behaviour: Role = Author only. Filters added to
  AuthorListViewModel (the /authors page), AuthorDetailViewModel (the
  drilldown), HomeViewModel (Top-Authors widget), and
  CatalogSnapshotService.AuthorSnapshot.BookCount.
- PrimaryAuthor lookups across 8 read sites filter Role = Author to
  protect the convention against a Translator with Order=0 winning:
  AIAssistantViewModel (x2), BookAddViewModel duplicate banner,
  BookDetailViewModel deep-link, BookListViewModel display,
  SeriesEditViewModel drill, ShoppingViewModel, WorkSearchService,
  DuplicateDetectionService display sides (the matching sides stay
  unfiltered intentionally).

What is NOT in this commit (still pending):
- Phase C: WorkSnapshot version bump to include Authors[] of {Name, Role}.
- Phase D: Bookshelf cache update for the new shape.
- Phase E: MAUI ScanPage display.
- Phase F: AuthorResolver + Add/Edit save sites + MudAuthorPicker Role
  dropdown.
- Phase G: AuthorMergeService + WorkMergeService Role handling.
- Phase H: tests for Role-aware rollups + Role projection.

Build clean, all 448 existing tests pass.
