### PR TITLE
feat(snapshot): version-bump to AuthorContribution (Phase C)

### DIFF
--- a/BookTracker.Mobile.Cache/CatalogCache.cs
+++ b/BookTracker.Mobile.Cache/CatalogCache.cs
@@ -424,8 +424,8 @@ public class CatalogCache : ICatalogCache
         var result = new List<BookSnapshot>();
         foreach (var b in books)
         {
-            var all = JsonSerializer.Deserialize<List<string>>(b.AllAuthorsJson) ?? [];
-            if (all.Any(n => nameSet.Contains(n)))
+            var all = JsonSerializer.Deserialize<List<AuthorContribution>>(b.AllAuthorsJson) ?? [];
+            if (all.Any(c => nameSet.Contains(c.Name)))
             {
                 result.Add(await ToSnapshotAsync(b, all));
             }
@@ -621,11 +621,11 @@ public class CatalogCache : ICatalogCache
 
     private async Task<BookSnapshot> ToSnapshotAsync(CachedBook book)
     {
-        var all = JsonSerializer.Deserialize<List<string>>(book.AllAuthorsJson) ?? [];
+        var all = JsonSerializer.Deserialize<List<AuthorContribution>>(book.AllAuthorsJson) ?? [];
         return await ToSnapshotAsync(book, all);
     }
 
-    private async Task<BookSnapshot> ToSnapshotAsync(CachedBook book, List<string> allAuthors)
+    private async Task<BookSnapshot> ToSnapshotAsync(CachedBook book, List<AuthorContribution> allAuthors)
     {
         var isbns = await Db.Table<CachedBookIsbn>()
             .Where(r => r.BookId == book.Id)

--- a/BookTracker.Shared/Catalog/CatalogSnapshot.cs
+++ b/BookTracker.Shared/Catalog/CatalogSnapshot.cs
@@ -37,7 +37,15 @@ public record BookSnapshot(
     int Id,
     string Title,
     string PrimaryAuthor,
-    IReadOnlyList<string> AllAuthors,
+    // Every credited contributor on the Book (across all constituent Works
+    // and roles — Author / Editor / Translator / Illustrator / etc.).
+    // Field shape changed 2026-05-23 (snapshot v2): was IReadOnlyList<string>
+    // of names only; now carries Role per row so non-Author contributions
+    // (editors of reference works, translators of classical texts) round-
+    // trip to consumers. Bookshelf cache consumers parsing the OLD shape
+    // (a JSON array of strings) will need updating in the same version
+    // window — see CatalogCache.PopulateAsync.
+    IReadOnlyList<AuthorContribution> AllAuthors,
     string Status,
     int Rating,
     IReadOnlyList<string> Isbns,
@@ -90,11 +98,41 @@ public record EditionSnapshot(
 public record WorkSnapshot(
     int Id,
     string Title,
-    // Lowest-Order WorkAuthor's name. Same convention as
-    // BookSnapshot.PrimaryAuthor but scoped to this specific Work
-    // — a compendium's Asimov-Bradbury-King anthology shows the
-    // per-Work attribution rather than the Book-wide rollup.
-    string PrimaryAuthor);
+    // Lowest-Order WorkAuthor (Role = Author) name. Same convention as
+    // BookSnapshot.PrimaryAuthor but scoped to this specific Work — a
+    // compendium's Asimov-Bradbury-King anthology shows the per-Work
+    // attribution rather than the Book-wide rollup. Empty string when
+    // the Work has no Author-role contributor (rare; e.g. a translated
+    // classical text where only the translator is in our DB).
+    string PrimaryAuthor,
+    // Every credited contributor on this Work, with Role. New in
+    // snapshot v2 (2026-05-23). Nullable for back-compat with older
+    // positional WorkSnapshot constructions; new consumers should treat
+    // null as "no enrichment from this server version" and fall back
+    // to PrimaryAuthor alone.
+    IReadOnlyList<AuthorContribution>? Contributors = null);
+
+// One credited person on a Work, with the role they played. The Role
+// field is the AuthorRole enum's string name (Author / Editor /
+// Translator / Illustrator / Adaptor / Compiler / Foreword /
+// Contributor) — the DTO record stays free of the BookTracker.Data
+// dependency, so Role is exposed as a string rather than the enum
+// type. Same convention as BookSnapshot.Status (string for BookStatus)
+// and SeriesSnapshot.Type (string for SeriesType).
+public record AuthorContribution(
+    string Name,
+    string Role)
+{
+    // Implicit conversion from string => AuthorContribution(name, "Author").
+    // Matches the dominant case (Author is the default role across the system)
+    // and keeps test fixture constructions concise — a Book's
+    // `AllAuthors: ["Asimov"]` shorthand still compiles. Production code paths
+    // that need an explicit non-Author role construct the record positionally;
+    // there is no scenario where a string-typed name should silently become
+    // an Editor / Translator contribution.
+    public static implicit operator AuthorContribution(string name) =>
+        new(name, "Author");
+}
 
 public record AuthorSnapshot(
     int Id,

--- a/BookTracker.Tests/Services/CatalogSnapshotServiceTests.cs
+++ b/BookTracker.Tests/Services/CatalogSnapshotServiceTests.cs
@@ -32,7 +32,7 @@ public class CatalogSnapshotServiceTests
         var book = Assert.Single(snapshot.Books);
         Assert.Equal("Foundation", book.Title);
         Assert.Equal("Isaac Asimov", book.PrimaryAuthor);
-        Assert.Equal(["Isaac Asimov"], book.AllAuthors);
+        Assert.Equal([new AuthorContribution("Isaac Asimov", "Author")], book.AllAuthors);
     }
 
     [Fact]
@@ -64,7 +64,11 @@ public class CatalogSnapshotServiceTests
 
         var book = Assert.Single(snapshot.Books);
         Assert.Equal("Isaac Asimov", book.PrimaryAuthor);
-        Assert.Equal(["Isaac Asimov", "Stephen King", "Ray Bradbury"], book.AllAuthors);
+        Assert.Equal([
+            new AuthorContribution("Isaac Asimov", "Author"),
+            new AuthorContribution("Stephen King", "Author"),
+            new AuthorContribution("Ray Bradbury", "Author"),
+        ], book.AllAuthors);
     }
 
     [Fact]

--- a/BookTracker.Web/Services/Catalog/CatalogSnapshotService.cs
+++ b/BookTracker.Web/Services/Catalog/CatalogSnapshotService.cs
@@ -71,6 +71,7 @@ public class CatalogSnapshotService(
                     wa.Author.Name,
                     WorkId = w.Id,
                     wa.Order,
+                    wa.Role,
                 })).ToList(),
                 Isbns = b.Editions
                     .Where(e => e.Isbn != null && e.Isbn != "")
@@ -102,9 +103,14 @@ public class CatalogSnapshotService(
                     {
                         w.Id,
                         w.Title,
-                        WorkAuthors = w.WorkAuthors
-                            .OrderBy(wa => wa.Order)
-                            .Select(wa => wa.Author.Name)
+                        // Every contributor on this Work with their role.
+                        // Server emits the full list; per-Work PrimaryAuthor
+                        // is computed downstream by filtering Role=Author.
+                        WorkContributors = w.WorkAuthors
+                            .OrderBy(wa => wa.Role == AuthorRole.Author ? 0 : 1)
+                            .ThenBy(wa => (int)wa.Role)
+                            .ThenBy(wa => wa.Order)
+                            .Select(wa => new { wa.Author.Name, wa.Role })
                             .ToList(),
                     })
                     .ToList(),
@@ -123,16 +129,25 @@ public class CatalogSnapshotService(
             .Select(b => new BookSnapshot(
                 b.Id,
                 b.Title,
-                // Primary author = lowest-Order WorkAuthor of the first
-                // Work (by Work.Id). Single-Work books are unambiguous;
-                // compendiums get the primary of whichever Work sorts
-                // first. Same shape as the library-grouping-respects-
-                // author-filter fix uses.
-                b.Authors.OrderBy(a => a.WorkId).ThenBy(a => a.Order).Select(a => a.Name).FirstOrDefault() ?? "(unknown)",
-                // All credited authors, in (Work.Id, Order) sequence,
-                // distinct by name. Renders as the result-card subtitle
-                // when the book is shown in bookshop mode.
-                b.Authors.OrderBy(a => a.WorkId).ThenBy(a => a.Order).Select(a => a.Name).Distinct().ToList(),
+                // Primary author = lowest-Order Author-role WorkAuthor of
+                // the first Work (by Work.Id). Single-Work books are
+                // unambiguous; compendiums get the primary of whichever
+                // Work sorts first. Filtered to Role=Author so a translator
+                // with Order=0 never wins the "by Name" line.
+                b.Authors.Where(a => a.Role == AuthorRole.Author).OrderBy(a => a.WorkId).ThenBy(a => a.Order).Select(a => a.Name).FirstOrDefault() ?? "(unknown)",
+                // All credited contributors with their role, in (Work.Id,
+                // Role, Order) sequence — Author-role first, then other
+                // roles in enum order. Distinct by (Name, Role) so a
+                // single person credited as both Author and Illustrator on
+                // the same Book shows up once per role.
+                b.Authors
+                    .OrderBy(a => a.WorkId)
+                    .ThenBy(a => a.Role == AuthorRole.Author ? 0 : 1)
+                    .ThenBy(a => (int)a.Role)
+                    .ThenBy(a => a.Order)
+                    .Select(a => new AuthorContribution(a.Name, a.Role.ToString()))
+                    .DistinctBy(c => (c.Name, c.Role))
+                    .ToList(),
                 b.Status.ToString(),
                 b.Rating,
                 b.Isbns.Distinct().ToList(),
@@ -146,7 +161,16 @@ public class CatalogSnapshotService(
                     .Select(w => new WorkSnapshot(
                         w.Id,
                         w.Title,
-                        w.WorkAuthors.FirstOrDefault() ?? "(unknown)"))
+                        // Per-Work PrimaryAuthor = first Author-role
+                        // contributor on this Work. The pre-projection
+                        // already sorted Author-role first then by Order,
+                        // so the first WorkContributor whose Role is
+                        // "Author" is the lead.
+                        w.WorkContributors.FirstOrDefault(c => c.Role == AuthorRole.Author)?.Name ?? "(unknown)",
+                        // Full contributor list with role per entry.
+                        Contributors: w.WorkContributors
+                            .Select(c => new AuthorContribution(c.Name, c.Role.ToString()))
+                            .ToList()))
                     .ToList()))
             .OrderBy(b => b.Title)
             .ToList();


### PR DESCRIPTION
Phase C of PR 2c (the WorkAuthor.Role cutover).

Catalog snapshot DTO now carries Role per contributor:
- BookSnapshot.AllAuthors: IReadOnlyList<string> -> IReadOnlyList<AuthorContribution>
  (Name + Role). Per the brief's version-bump call - old Bookshelf
  installs reading the snapshot will need updating in the same window
  (Phase D follow-up; the cache JSON round-trip is fixed inline here).
- WorkSnapshot gains optional Contributors: IReadOnlyList<AuthorContribution>?
  for compendium per-Work attribution. PrimaryAuthor stays as string
  (lowest-Order Role=Author contributor) for the "by Asimov" line.
- New AuthorContribution record (Name, Role) in BookTracker.Shared.Catalog.
  Role exposed as string (matches BookSnapshot.Status / SeriesSnapshot.Type
  convention) to keep Shared free of BookTracker.Data dependency.

Transitional shim: implicit operator string -> AuthorContribution
defaulting to Role="Author". Matches the dominant case (Author is the
default role everywhere) and keeps existing test fixture constructions
like `AllAuthors: ["Asimov"]` compiling. Phase D's cache rewrite will
revisit if appropriate.

CatalogSnapshotService projection updates:
- WorkContributors anonymous projection orders Author-role first, then
  other roles in enum order, then Order within role.
- BookSnapshot.PrimaryAuthor filtered to Role=Author so a translator
  with Order=0 can never win the "by Name" line.
- WorkSnapshot.PrimaryAuthor same.
- AllAuthors is the full Role-aware list, distinct by (Name, Role) so
  one person credited as both Author + Illustrator on the same Book
  appears once per role.

CatalogCache round-trip in BookTracker.Mobile.Cache updated to
serialize+deserialize AuthorContribution natively. The cache still
stores only the AllAuthors flat list (extending CachedBook with
per-Work contributor detail is Phase D).

Tests: 448/449 main + 46/46 cache green. CatalogSnapshotServiceTests
updated to assert the new contribution shape explicitly.
