### PR TITLE
memory(2026-05-25): wishlist rework arc — PR plan

### DIFF
--- a/.claude-memory/MEMORY.md
+++ b/.claude-memory/MEMORY.md
@@ -35,4 +35,5 @@
 - [Runbook: prod SQL access](runbook_prod_sql_access.md) — prod Azure SQL needs temp firewall rule + public-access toggle + Entra auth; canonical pattern in `infra/refresh-local-db.ps1`.
 - [DBNull in Invoke-Sqlcmd](feedback_dbnull_in_invoke_sqlcmd.md) — SQL NULLs come back as `[DBNull]`, which is truthy in PowerShell; explicit `-is [System.DBNull]` check before any string coercion.
 - [Disposable scripts in .debug/](feedback_disposable_scripts_in_debug.md) — one-off data cleanups go in `.debug/*.ps1` (gitignored), not a `BookTracker.Tools.*` csproj.
-- [Pre-reference-capture arc](project_pre_reference_capture_arc.md) — ordered work queue after PR 2d (#290) and before reference-book mass capture: lookup-side contributors (#52), then Phases D+E mobile, then EditionNumber + BookStatus.Reference. Pick from top next session.
+- [Pre-reference-capture arc](project_pre_reference_capture_arc.md) — all three buckets closed 2026-05-24 (#292/#295/#297); flagged for retirement on next sync.
+- [Wishlist rework arc](project_wishlist_rework_arc.md) — four-PR arc splitting /shopping into bookcase-capture + bookshelf-consumption. PR A shipped 2026-05-25; PRs B (search-and-add), C (series-driven), D (Bookshelf surface + scan-flag) pending in order.

--- a/.claude-memory/project_wishlist_rework_arc.md
+++ b/.claude-memory/project_wishlist_rework_arc.md
@@ -1,0 +1,58 @@
+---
+name: wishlist-rework-arc
+description: Four-PR arc reshaping the original /shopping surface into a clearer split — in-shop consumption stays on bookshelf / /bookshop; capture / wishlist management lives on bookcase web. Each PR sequenced in order with the explicit decisions Drew named 2026-05-25 baked in.
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 0613aa7d-1b0d-4ae3-ae9e-2227b8cabcd7
+---
+
+Drew's framing 2026-05-25 (browsing prompted him to realise "what am I looking for" wasn't surfaced on Bookshelf): consolidate the in-shop concerns into bookshelf, and rework what's on Bookcase web into a *capture* surface for proactively managing the want list.
+
+**Why:** `/shopping` today mixes three things — "do I have this?", series gaps, wishlist — none of which are visible on Bookshelf where Drew is when the questions actually bite (in a bookshop). Two surfaces, two concerns: bookcase = at-home capture, bookshelf = on-the-go consumption. The split also unblocks TODO #48 (Bookshelf wishlist surface — backend already shipped) which had been waiting on a planning trigger.
+
+**How to apply:** When Drew opens a "what's next" conversation, this arc is the active queue. Pick from the top — sequential shipping, not parallel.
+
+## PR A — Rename `/shopping` → `/wishlist` + drop "Do I have this?" — **SHIPPED 2026-05-25**
+
+Prequel cleanup. Card 1 was a duplicate of /bookshop's scan + Bookshelf ScanPage. `/shopping` kept as a secondary `@page` directive so old bookmarks survive. ShoppingViewModel rename + dead-code removal deferred to PR B (touches the VM anyway). Branch: `feat/wishlist-rename-and-drop-card-1`.
+
+## PR B — Search-and-add to wishlist (M, next up)
+
+Richest single win. New search box on `/wishlist` that reuses `BookLookupService` (the same ISBN/title/author lookup powering Add Book). Pick-from-candidates UX. Wishlist row captures Title, Author, all known ISBNs, and CoverUrl — lightweight, not a full Book/Work entity, just enough metadata to recognise the same book when scanned later on Bookshelf.
+
+**Schema additions** (locked 2026-05-25):
+- `WishlistItem.CoverUrl: string? (MaxLength 500)`
+- **Separate `WishlistItemIsbn` table** (not comma-joined) — mirrors `Edition.Isbn` shape, one row per ISBN, clean query path for the scan-flag lookup that PR D will need
+- One migration adding both
+
+**Out of scope:** the existing `WishlistItem.Isbn` (single column) stays for back-compat; PR B writes new entries to the multi-ISBN table only.
+
+## PR C — Series-driven wishlist additions (M)
+
+From a Series detail page (or a new tab on /wishlist), "Mark this series as sought" view. Lists missing slots from gap detection. Two flows:
+
+- **Finite series (`ExpectedCount` set):** checkbox-grid of missing slots; "Add selected" creates one `WishlistItem` per slot
+- **Infinite / no ExpectedCount:** offer "Add next N missing" with **N=10 default** (Drew's call 2026-05-25 — round number, low friction, can re-run for more)
+
+The series-add path doesn't have title data for unowned slots without an upstream lookup. v1 approach: capture as stubs ("Foundation #4 — unknown title") and let Drew enrich later from the wishlist surface. Optional follow-on: fire OpenLibrary search-by-series-slot to pre-fill.
+
+## PR D — Bookshelf wishlist surface + scan-flag (M)
+
+Closes TODO #48 (backend `/api/wishlist-snapshot` already shipped 2026-05-13 — verified during the 2026-05-24 TODO sync). Two pieces:
+
+- New `WishlistPage` on Bookshelf MAUI — list view backed by `/api/wishlist-snapshot`. Local SQLite `WishlistBoughtLocal` table for the "bought" toggle (self-heals on next catalog refresh: server-side wishlist row gone = local-bought entry becomes a no-op).
+- **ScanPage scan-flag** — when the scanned ISBN matches any wishlisted ISBN (looked up via the new `WishlistItemIsbn` table from PR B), the result card highlights with "On your wishlist" badge.
+
+Optional in same PR: parallel wishlist tab on Web `/bookshop` (the sub-piece (c) from the original TODO #28 plan).
+
+## Deferred from this arc (explicitly out of scope)
+
+- **Book-level Editor model** — separate from this arc; held under TODO #51's "full editor model" sub-row, still needs its own planning session.
+- **Auto-resolve wishlist hit → Book on save.** When a wishlisted ISBN is later scanned + added via Add Book, the wishlist row could auto-resolve as "bought" rather than needing a manual mark. Tempting but cross-cutting; defer to its own decision after PR D ships and Drew has the surface in real use.
+
+## What this memory is NOT
+
+Not a list of all open work — TODO.md is the master. This memory is just the load-bearing PR ordering + the design calls Drew named upfront (`N=10` default, separate `WishlistItemIsbn` table, etc.) so the next session picks up where this one left off.
+
+Retire after PR D ships.


### PR DESCRIPTION
Four-PR arc reshaping /shopping into a bookcase-capture + bookshelf-
consumption split, with Drew's design calls (N=10 infinite-series
default, separate WishlistItemIsbn table for multi-ISBN, CoverUrl on
WishlistItem) baked in so future sessions pick up cleanly.

PR A (rename + drop Card 1) shipping in parallel on its own branch.
PRs B / C / D queue sequentially.

Also marked the pre-reference-capture-arc memory for retirement
in the MEMORY.md index — all three buckets closed 2026-05-24.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
