### PR TITLE
chore/skiasharp 3.119.4 coordinated

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,19 @@ updates:
       ef-core:
         patterns:
           - "Microsoft.EntityFrameworkCore*"
+      # SkiaSharp 3.x splits the platform native assets into separate
+      # NuGet packages (SkiaSharp + SkiaSharp.NativeAssets.Linux /
+      # .Win32 / .macOS). Their versions ship in lockstep — the main
+      # package's transitive resolution requires the NativeAssets to
+      # match exactly, or the test runner can't load native libs.
+      # Without this grouping, Dependabot opens one PR per package
+      # and merging only some of them leaves the build broken
+      # (encountered 2026-05-26 on the 3.119.2 → 3.119.4 bump). Group
+      # all of them into a single PR so version mismatches are
+      # impossible by construction.
+      skiasharp:
+        patterns:
+          - "SkiaSharp*"
     ignore:
       # Microsoft.ApplicationInsights.AspNetCore 3.x is a full OpenTelemetry
       # rewrite of the classic SDK — ITelemetryInitializer (currently used

--- a/BookTracker.Mobile.Cache.Tests/BookTracker.Mobile.Cache.Tests.csproj
+++ b/BookTracker.Mobile.Cache.Tests/BookTracker.Mobile.Cache.Tests.csproj
@@ -31,7 +31,7 @@
          one matching its RID and ignores the others. -->
     <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.119.4" />
     <PackageReference Include="SkiaSharp.NativeAssets.Win32" Version="3.119.4" />
-    <PackageReference Include="SkiaSharp.NativeAssets.macOS" Version="3.119.2" />
+    <PackageReference Include="SkiaSharp.NativeAssets.macOS" Version="3.119.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/BookTracker.Mobile.Cache/BookTracker.Mobile.Cache.csproj
+++ b/BookTracker.Mobile.Cache/BookTracker.Mobile.Cache.csproj
@@ -32,7 +32,6 @@
     <!-- sqlite-net-pcl: ORM-lite over SQLite. Bundles a managed +
          native SQLite via SQLitePCLRaw; works on Android, iOS, and
          desktop with no manual native-library hookup. -->
-    <PackageReference Include="SkiaSharp.NativeAssets.Win32" Version="3.119.4" />
     <PackageReference Include="sqlite-net-pcl" Version="1.9.172" />
     <!-- SkiaSharp: cross-platform image decode + resize. Pulls native
          assets for Android (via transitive SkiaSharp.NativeAssets.*)
@@ -44,7 +43,7 @@
          16KB-page-aligned and fail to load on Android 16 devices
          with 16KB pages enabled (the XA0141 build warning). 3.x's
          Resize API replaces SKFilterQuality with SKSamplingOptions. -->
-    <PackageReference Include="SkiaSharp" Version="3.119.2" />
+    <PackageReference Include="SkiaSharp" Version="3.119.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- **chore(deps): bump SkiaSharp + NativeAssets to 3.119.4 in lockstep**
- **chore(deps): group SkiaSharp + NativeAssets PRs in dependabot.yml**
