### PR TITLE
fix: default new books to Unread

### DIFF
--- a/BookTracker.Data/Models/Book.cs
+++ b/BookTracker.Data/Models/Book.cs
@@ -37,7 +37,7 @@ public class Book
 
     public BookCategory Category { get; set; } = BookCategory.Fiction;
 
-    public BookStatus Status { get; set; } = BookStatus.Read;
+    public BookStatus Status { get; set; } = BookStatus.Unread;
 
     [Range(0, 5)]
     public int Rating { get; set; }

--- a/BookTracker.Tests/ViewModels/BookAddViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/BookAddViewModelTests.cs
@@ -656,6 +656,25 @@ public class BookAddViewModelTests
     }
 
     [Fact]
+    public async Task SaveAsync_DefaultsNewBookToUnread()
+    {
+        // New books default to Unread (the user marks Read as they actually
+        // read them). The Add form never touches BookInput.Status here, so
+        // this asserts the BookFormInput default carries through SaveAsync.
+        var vm = CreateVm();
+        vm.BookInput.Title = "The Hobbit";
+        vm.WorkInput.Title = "The Hobbit";
+        vm.WorkInput.Authors = ["J.R.R. Tolkien"];
+
+        var ok = await vm.SaveAsync(new List<int>());
+
+        Assert.NotNull(ok);
+        using var db = _factory.CreateDbContext();
+        var book = db.Books.Single();
+        Assert.Equal(BookStatus.Unread, book.Status);
+    }
+
+    [Fact]
     public async Task SaveAsync_MultipleAuthors_DualWritesLeadAndJoin()
     {
         // Multi-author cutover PR1: save path sets Work.Author = lead chip

--- a/BookTracker.Web/ViewModels/BookFormViewModel.cs
+++ b/BookTracker.Web/ViewModels/BookFormViewModel.cs
@@ -21,7 +21,7 @@ public class BookFormViewModel
 
         public BookCategory Category { get; set; } = BookCategory.Fiction;
 
-        public BookStatus Status { get; set; } = BookStatus.Read;
+        public BookStatus Status { get; set; } = BookStatus.Unread;
 
         [Range(0, 5)]
         public int Rating { get; set; }


### PR DESCRIPTION
New books defaulted to Read, which meant the library filled with
"Read" rows that were never actually read. Flip the default to Unread
so Read is something the user marks deliberately.

Two creation paths covered:
- Book.cs entity default (used by bulk-add, which never sets Status)
- BookFormInput default (used by single-add via BookInput.Status)

No migration: these are C# object defaults, not DB defaults. Existing
prod rows are reset separately via a one-off .debug script (gitignored).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
