### PR TITLE
feat: persist Library filters in the URL query string

### DIFF
--- a/BookTracker.Tests/ViewModels/BookListViewModelQueryStateTests.cs
+++ b/BookTracker.Tests/ViewModels/BookListViewModelQueryStateTests.cs
@@ -1,0 +1,139 @@
+using BookTracker.Data.Models;
+using BookTracker.Web.ViewModels;
+
+namespace BookTracker.Tests.ViewModels;
+
+// Pure unit tests for the URL-backed filter state (PR1). ToQueryParameters /
+// ApplyQueryParameters never touch the DbContext, so the VM is constructed with
+// a null factory — these stay container-free and fast.
+[Trait("Category", TestCategories.Unit)]
+public class BookListViewModelQueryStateTests
+{
+    private static BookListViewModel NewVm() => new(null!);
+
+    [Fact]
+    public void ToQueryParameters_OmitsDefaults()
+    {
+        var vm = NewVm(); // all defaults: Author grouping, page 1, no filters.
+
+        var q = vm.ToQueryParameters();
+
+        // Defaults are omitted entirely so the URL stays clean (/books).
+        Assert.Null(q["q"]);
+        Assert.Null(q["group"]);   // Author is the default grouping
+        Assert.Null(q["category"]);
+        Assert.Null(q["genre"]);
+        Assert.Null(q["tag"]);
+        Assert.Null(q["status"]);
+        Assert.Null(q["author"]);
+        Assert.Null(q["page"]);    // page 1 is the default
+    }
+
+    [Fact]
+    public void ToQueryParameters_EmitsSetFilters()
+    {
+        var vm = NewVm();
+        vm.SearchTerm = "  dune  ";          // trimmed on serialise
+        vm.SelectedGroupBy = LibraryGroupBy.Genre;
+        vm.SelectedCategory = "Fiction";
+        vm.SelectedGenreId = 7;
+        vm.SelectedTagId = 3;
+        vm.SelectedStatus = BookStatus.Unread;
+        vm.SelectedAuthor = " Herbert ";
+        vm.CurrentPage = 4;
+
+        var q = vm.ToQueryParameters();
+
+        Assert.Equal("dune", q["q"]);
+        Assert.Equal("Genre", q["group"]);
+        Assert.Equal("Fiction", q["category"]);
+        Assert.Equal(7, q["genre"]);
+        Assert.Equal(3, q["tag"]);
+        Assert.Equal("Unread", q["status"]);
+        Assert.Equal("Herbert", q["author"]);
+        Assert.Equal(4, q["page"]);
+    }
+
+    [Fact]
+    public void ApplyQueryParameters_HydratesFields()
+    {
+        var vm = NewVm();
+
+        vm.ApplyQueryParameters(
+            q: "dune", group: "Collection", category: "NonFiction",
+            genre: 7, tag: 3, status: "Reading", author: "Herbert", page: 4);
+
+        Assert.Equal("dune", vm.SearchTerm);
+        Assert.Equal(LibraryGroupBy.Collection, vm.SelectedGroupBy);
+        Assert.Equal("NonFiction", vm.SelectedCategory);
+        Assert.Equal(7, vm.SelectedGenreId);
+        Assert.Equal(3, vm.SelectedTagId);
+        Assert.Equal(BookStatus.Reading, vm.SelectedStatus);
+        Assert.Equal("Herbert", vm.SelectedAuthor);
+        Assert.Equal(4, vm.CurrentPage);
+    }
+
+    [Fact]
+    public void ApplyQueryParameters_FallsBackToDefaultsForAbsentOrJunk()
+    {
+        var vm = NewVm();
+
+        // Absent params + an unparseable status/group degrade to defaults
+        // rather than throwing — round-tripping an omitted value is lossless.
+        vm.ApplyQueryParameters(
+            q: null, group: "NotAGroup", category: null,
+            genre: null, tag: null, status: "Bogus", author: null, page: 0);
+
+        Assert.Equal("", vm.SearchTerm);
+        Assert.Equal(LibraryGroupBy.Author, vm.SelectedGroupBy);
+        Assert.Equal("", vm.SelectedCategory);
+        Assert.Equal(0, vm.SelectedGenreId);
+        Assert.Equal(0, vm.SelectedTagId);
+        Assert.Null(vm.SelectedStatus);
+        Assert.Equal("", vm.SelectedAuthor);
+        Assert.Equal(1, vm.CurrentPage);
+    }
+
+    [Theory]
+    [InlineData("plague", LibraryGroupBy.None, "Fiction", 12, 5, BookStatus.Read, "Camus", 2)]
+    [InlineData("", LibraryGroupBy.Author, "", 0, 0, null, "", 1)]
+    [InlineData("x", LibraryGroupBy.Collection, "NonFiction", 0, 9, BookStatus.Reference, "", 3)]
+    public void RoundTrip_SerialiseThenHydrate_PreservesState(
+        string term, LibraryGroupBy group, string category,
+        int genreId, int tagId, BookStatus? status, string author, int page)
+    {
+        var source = NewVm();
+        source.SearchTerm = term;
+        source.SelectedGroupBy = group;
+        source.SelectedCategory = category;
+        source.SelectedGenreId = genreId;
+        source.SelectedTagId = tagId;
+        source.SelectedStatus = status;
+        source.SelectedAuthor = author;
+        source.CurrentPage = page;
+
+        var q = source.ToQueryParameters();
+
+        // Feed the serialised values back through the parser, mimicking what the
+        // page does after a NavigateTo round-trips through the query string.
+        var rehydrated = NewVm();
+        rehydrated.ApplyQueryParameters(
+            q: (string?)q["q"],
+            group: (string?)q["group"],
+            category: (string?)q["category"],
+            genre: (int?)q["genre"],
+            tag: (int?)q["tag"],
+            status: (string?)q["status"],
+            author: (string?)q["author"],
+            page: (int?)q["page"]);
+
+        Assert.Equal(term, rehydrated.SearchTerm);
+        Assert.Equal(group, rehydrated.SelectedGroupBy);
+        Assert.Equal(category, rehydrated.SelectedCategory);
+        Assert.Equal(genreId, rehydrated.SelectedGenreId);
+        Assert.Equal(tagId, rehydrated.SelectedTagId);
+        Assert.Equal(status, rehydrated.SelectedStatus);
+        Assert.Equal(author, rehydrated.SelectedAuthor);
+        Assert.Equal(page, rehydrated.CurrentPage);
+    }
+}

--- a/BookTracker.Web/Components/Pages/Books/List.razor
+++ b/BookTracker.Web/Components/Pages/Books/List.razor
@@ -43,7 +43,7 @@
                 </MudButton>
             </MudItem>
             <MudItem xs="6" Class="d-md-none">
-                <MudButton OnClick="VM.ClearFiltersAsync"
+                <MudButton OnClick="ClearFilters"
                            Variant="Variant.Outlined"
                            FullWidth="true">
                     Clear
@@ -140,7 +140,7 @@
                                          CoerceValue="true" />
                     </MudItem>
                     <MudItem xs="12" md="1" Class="d-none d-md-flex">
-                        <MudIconButton OnClick="VM.ClearFiltersAsync"
+                        <MudIconButton OnClick="ClearFilters"
                                        Icon="@Icons.Material.Filled.Clear"
                                        title="Clear filters"
                                        Color="Color.Default"
@@ -239,60 +239,107 @@
     private bool showFilters;
     private LibraryGroupBy GroupBySelected { get; set; } = LibraryGroupBy.Author;
 
+    // Filter state lives in the query string so the view is a navigable URL:
+    // drilling into a book and pressing browser Back restores the exact filtered
+    // list (the VM is Transient, so without this every return rebuilds with
+    // defaults). See BookListViewModel.ToQueryParameters / ApplyQueryParameters.
+    [SupplyParameterFromQuery(Name = "q")] public string? QueryTerm { get; set; }
+    [SupplyParameterFromQuery(Name = "group")] public string? QueryGroup { get; set; }
+    [SupplyParameterFromQuery(Name = "category")] public string? QueryCategory { get; set; }
+    [SupplyParameterFromQuery(Name = "genre")] public int? QueryGenre { get; set; }
+    [SupplyParameterFromQuery(Name = "tag")] public int? QueryTag { get; set; }
+    [SupplyParameterFromQuery(Name = "status")] public string? QueryStatus { get; set; }
+    [SupplyParameterFromQuery(Name = "author")] public string? QueryAuthor { get; set; }
+    [SupplyParameterFromQuery(Name = "page")] public int? QueryPage { get; set; }
+
+    private string? loadedSignature;
+
     protected override async Task OnInitializedAsync()
     {
-        await VM.InitializeAsync();
-        GroupBySelected = VM.SelectedGroupBy;
+        // Dropdown options are query-independent — load once for the component's life.
+        await VM.LoadFilterOptionsAsync();
     }
 
-    private async Task OnSearchTermChanged(string value)
+    protected override async Task OnParametersSetAsync()
+    {
+        // Fires on first render and on every same-component query change (filter
+        // edits NavigateTo with replace:true). Guard so we only re-query the DB
+        // when the filter signature actually changed.
+        var signature = $"{QueryTerm}|{QueryGroup}|{QueryCategory}|{QueryGenre}|{QueryTag}|{QueryStatus}|{QueryAuthor}|{QueryPage}";
+        if (signature == loadedSignature) return;
+        loadedSignature = signature;
+
+        VM.ApplyQueryParameters(QueryTerm, QueryGroup, QueryCategory, QueryGenre, QueryTag, QueryStatus, QueryAuthor, QueryPage);
+        GroupBySelected = VM.SelectedGroupBy;
+        await VM.ReloadAsync();
+    }
+
+    // Push the current VM filter state into the URL. replace:true keeps filter
+    // tweaks out of history so Back from a book returns to the last view, not
+    // through every intermediate edit. The navigation re-enters
+    // OnParametersSetAsync, which performs the actual reload.
+    private void NavigateWithState()
+    {
+        var uri = Nav.GetUriWithQueryParameters(VM.ToQueryParameters());
+        Nav.NavigateTo(uri, forceLoad: false, replace: true);
+    }
+
+    // Any filter edit resets to page 1, then serialises to the URL.
+    private void ApplyFilterChange()
+    {
+        VM.CurrentPage = 1;
+        NavigateWithState();
+    }
+
+    private void OnSearchTermChanged(string value)
     {
         // Match the legacy "type updates state, Enter triggers query" UX —
-        // we update SearchTerm on each keystroke (Immediate="true") but
-        // ApplyFiltersAsync is only called from HandleSearchKeyUp on Enter.
+        // update SearchTerm on each keystroke (Immediate="true") but only
+        // navigate (and reload) from HandleSearchKeyUp on Enter.
         VM.SearchTerm = value ?? "";
     }
 
-    private async Task HandleSearchKeyUp(KeyboardEventArgs e)
+    private void HandleSearchKeyUp(KeyboardEventArgs e)
     {
         if (e.Key == "Enter")
-            await VM.ApplyFiltersAsync();
+            ApplyFilterChange();
     }
 
-    private async Task OnGroupByChanged(LibraryGroupBy value)
+    private void OnGroupByChanged(LibraryGroupBy value)
     {
         GroupBySelected = value;
-        await VM.ChangeGroupingAsync(value);
+        VM.SelectedGroupBy = value;
+        ApplyFilterChange();
     }
 
-    private async Task OnCategoryChanged(string value)
+    private void OnCategoryChanged(string value)
     {
         VM.SelectedCategory = value ?? "";
-        await VM.ApplyFiltersAsync();
+        ApplyFilterChange();
     }
 
-    private async Task OnGenreChanged(int value)
+    private void OnGenreChanged(int value)
     {
         VM.SelectedGenreId = value;
-        await VM.ApplyFiltersAsync();
+        ApplyFilterChange();
     }
 
-    private async Task OnTagChanged(int value)
+    private void OnTagChanged(int value)
     {
         VM.SelectedTagId = value;
-        await VM.ApplyFiltersAsync();
+        ApplyFilterChange();
     }
 
-    private async Task OnStatusFilterChanged(BookStatus? value)
+    private void OnStatusFilterChanged(BookStatus? value)
     {
         VM.SelectedStatus = value;
-        await VM.ApplyFiltersAsync();
+        ApplyFilterChange();
     }
 
-    private async Task OnAuthorChanged(string value)
+    private void OnAuthorChanged(string value)
     {
         VM.SelectedAuthor = value ?? "";
-        await VM.ApplyFiltersAsync();
+        ApplyFilterChange();
     }
 
     private Task<IEnumerable<string>> SearchAuthors(string value, CancellationToken token)
@@ -306,9 +353,16 @@
                 .Take(20));
     }
 
-    private async Task OnPageChanged(int page)
+    private void OnPageChanged(int page)
     {
-        await VM.GoToPageAsync(page);
+        VM.CurrentPage = page;
+        NavigateWithState();
+    }
+
+    // Clear = navigate to the bare page; OnParametersSetAsync rehydrates defaults.
+    private void ClearFilters()
+    {
+        Nav.NavigateTo("books", forceLoad: false, replace: true);
     }
 
     private async Task OnGroupExpandChanged(bool isExpanded, string key)

--- a/BookTracker.Web/ViewModels/BookListViewModel.cs
+++ b/BookTracker.Web/ViewModels/BookListViewModel.cs
@@ -15,7 +15,7 @@ public class BookListViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
     // Flat list (used only when GroupBy == None).
     public List<BookListItem> Books { get; private set; } = [];
     public int TotalCount { get; private set; }
-    public int CurrentPage { get; private set; } = 1;
+    public int CurrentPage { get; set; } = 1;
     public int TotalPages { get; private set; }
 
     // Grouped view state. The group list is loaded up front (with counts)
@@ -57,7 +57,7 @@ public class BookListViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
         }
     }
 
-    private async Task LoadFilterOptionsAsync()
+    public async Task LoadFilterOptionsAsync()
     {
         await using var db = await dbFactory.CreateDbContextAsync();
 
@@ -474,6 +474,43 @@ public class BookListViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
         b.Works.Count,
         b.Works.SelectMany(w => w.Genres).Select(g => g.Name).Distinct().ToList(),
         b.Tags.Select(t => t.Name).ToList());
+
+    // Filter state ⇄ query string. The URL is the source of truth for the
+    // Library view: every filter, the grouping, and the flat-list page live in
+    // the query so a drill into a book + browser Back restores the exact view
+    // (the VM is Transient — without this, every return rebuilds with defaults).
+    // Defaults are omitted from the URL to keep it clean: no `group` means the
+    // default Author grouping; no `page` means page 1.
+    public Dictionary<string, object?> ToQueryParameters() => new()
+    {
+        ["q"] = string.IsNullOrWhiteSpace(SearchTerm) ? null : SearchTerm.Trim(),
+        ["group"] = SelectedGroupBy == LibraryGroupBy.Author ? null : SelectedGroupBy.ToString(),
+        ["category"] = string.IsNullOrEmpty(SelectedCategory) ? null : SelectedCategory,
+        ["genre"] = SelectedGenreId > 0 ? SelectedGenreId : (int?)null,
+        ["tag"] = SelectedTagId > 0 ? SelectedTagId : (int?)null,
+        ["status"] = SelectedStatus?.ToString(),
+        ["author"] = string.IsNullOrWhiteSpace(SelectedAuthor) ? null : SelectedAuthor.Trim(),
+        ["page"] = CurrentPage > 1 ? CurrentPage : (int?)null,
+    };
+
+    // Inverse of ToQueryParameters: hydrate the filter fields from raw query
+    // values. Unparseable / absent values fall back to the same defaults the
+    // serializer omits, so round-tripping an omitted param is lossless.
+    public void ApplyQueryParameters(
+        string? q, string? group, string? category,
+        int? genre, int? tag, string? status, string? author, int? page)
+    {
+        SearchTerm = q ?? "";
+        SelectedGroupBy = Enum.TryParse<LibraryGroupBy>(group, ignoreCase: true, out var g)
+            ? g : LibraryGroupBy.Author;
+        SelectedCategory = category ?? "";
+        SelectedGenreId = genre is > 0 ? genre.Value : 0;
+        SelectedTagId = tag is > 0 ? tag.Value : 0;
+        SelectedStatus = Enum.TryParse<BookStatus>(status, ignoreCase: true, out var s)
+            ? s : null;
+        SelectedAuthor = author ?? "";
+        CurrentPage = page is > 0 ? page.Value : 1;
+    }
 
     public async Task ApplyFiltersAsync()
     {


### PR DESCRIPTION
Library filter state (search, grouping, category, genre, tag, status, author, page) now serialises into the query string and rehydrates on load. The VM is Transient, so previously every return from a book detail rebuilt /books with default filters; now drilling into a book and pressing browser Back restores the exact filtered view. Filter edits NavigateTo with replace:true so history isn't polluted by intermediate tweaks.

PR1 of the Library navigation rework; PR2 turns group rows into drill-down links to filtered flat lists. Pure round-trip mapping (ToQueryParameters/ApplyQueryParameters) is covered by container-free unit tests.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
