### PR TITLE
fix: harden Library query-state handling (TD-3, TD-4, TD-5)

### DIFF
--- a/BookTracker.Tests/ViewModels/BookListViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/BookListViewModelTests.cs
@@ -200,6 +200,26 @@ public class BookListViewModelTests
     }
 
     [Fact]
+    public async Task FlatList_PageBeyondRange_ClampsToLastPage()
+    {
+        // A page number past the end (e.g. a stale bookmarked ?page=5 after the
+        // library shrank) clamps to the last page. The page then writes the
+        // corrected value back into the URL (handled in List.razor).
+        var factory = new TestDbContextFactory();
+        await SeedSampleLibraryAsync(factory); // 4 books → 1 page
+
+        var vm = new BookListViewModel(factory)
+        {
+            SelectedGroupBy = LibraryGroupBy.None,
+            CurrentPage = 5,
+        };
+        await vm.InitializeAsync();
+
+        Assert.Equal(1, vm.TotalPages);
+        Assert.Equal(1, vm.CurrentPage);
+    }
+
+    [Fact]
     public async Task FlatList_AuthorFilter_IncludesAliasRollup()
     {
         // Drilling an Author group lands on the flat list filtered by the

--- a/BookTracker.Web/Components/Pages/Books/List.razor
+++ b/BookTracker.Web/Components/Pages/Books/List.razor
@@ -252,7 +252,10 @@
     [SupplyParameterFromQuery(Name = "author")] public string? QueryAuthor { get; set; }
     [SupplyParameterFromQuery(Name = "page")] public int? QueryPage { get; set; }
 
-    private string? loadedSignature;
+    // The query values last applied to the VM. A value tuple compares
+    // element-wise, so (unlike a delimited string) no filter value containing
+    // the delimiter can collide into a false "unchanged".
+    private (string?, string?, string?, int?, int?, int?, string?, string?, int?)? appliedQuery;
 
     protected override async Task OnInitializedAsync()
     {
@@ -263,15 +266,23 @@
     protected override async Task OnParametersSetAsync()
     {
         // Fires on first render and on every same-component query change (filter
-        // edits NavigateTo with replace:true). Guard so we only re-query the DB
-        // when the filter signature actually changed.
-        var signature = $"{QueryTerm}|{QueryGroup}|{QueryCategory}|{QueryGenre}|{QueryTag}|{QuerySeries}|{QueryStatus}|{QueryAuthor}|{QueryPage}";
-        if (signature == loadedSignature) return;
-        loadedSignature = signature;
+        // edits NavigateTo with replace:true). Skip the DB reload when the query
+        // is unchanged from what we last applied.
+        var incoming = (QueryTerm, QueryGroup, QueryCategory, QueryGenre, QueryTag, QuerySeries, QueryStatus, QueryAuthor, QueryPage);
+        if (incoming == appliedQuery) return;
+        appliedQuery = incoming;
 
         VM.ApplyQueryParameters(QueryTerm, QueryGroup, QueryCategory, QueryGenre, QueryTag, QuerySeries, QueryStatus, QueryAuthor, QueryPage);
         GroupBySelected = VM.SelectedGroupBy;
         await VM.ReloadAsync();
+
+        // Keep the URL the source of truth: if the requested page was clamped
+        // (the result set shrank), write the corrected page back so a refresh or
+        // Back doesn't re-request an out-of-range page every time.
+        if (VM.SelectedGroupBy == LibraryGroupBy.None && VM.CurrentPage != (QueryPage ?? 1))
+        {
+            NavigateWithState();
+        }
     }
 
     // Push the current VM filter state into the URL. replace:true keeps filter

--- a/BookTracker.Web/ViewModels/BookListViewModel.cs
+++ b/BookTracker.Web/ViewModels/BookListViewModel.cs
@@ -418,9 +418,9 @@ public class BookListViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
         ["q"] = string.IsNullOrWhiteSpace(SearchTerm) ? null : SearchTerm.Trim(),
         ["group"] = SelectedGroupBy == LibraryGroupBy.Author ? null : SelectedGroupBy.ToString(),
         ["category"] = string.IsNullOrEmpty(SelectedCategory) ? null : SelectedCategory,
-        ["genre"] = SelectedGenreId != 0 ? SelectedGenreId : (int?)null,
+        ["genre"] = SentinelToQuery(SelectedGenreId),
         ["tag"] = SelectedTagId > 0 ? SelectedTagId : (int?)null,
-        ["series"] = SelectedSeriesId != 0 ? SelectedSeriesId : (int?)null,
+        ["series"] = SentinelToQuery(SelectedSeriesId),
         ["status"] = SelectedStatus?.ToString(),
         ["author"] = string.IsNullOrWhiteSpace(SelectedAuthor) ? null : SelectedAuthor.Trim(),
         ["page"] = CurrentPage > 1 ? CurrentPage : (int?)null,
@@ -437,14 +437,21 @@ public class BookListViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory
         SelectedGroupBy = Enum.TryParse<LibraryGroupBy>(group, ignoreCase: true, out var g)
             ? g : LibraryGroupBy.Author;
         SelectedCategory = category ?? "";
-        SelectedGenreId = genre is -1 or > 0 ? genre.Value : 0;
+        SelectedGenreId = SentinelFromQuery(genre);
         SelectedTagId = tag is > 0 ? tag.Value : 0;
-        SelectedSeriesId = series is -1 or > 0 ? series.Value : 0;
+        SelectedSeriesId = SentinelFromQuery(series);
         SelectedStatus = Enum.TryParse<BookStatus>(status, ignoreCase: true, out var s)
             ? s : null;
         SelectedAuthor = author ?? "";
         CurrentPage = page is > 0 ? page.Value : 1;
     }
+
+    // Sentinel ⇄ query for the genre/series filters: 0 = "all" (omitted from the
+    // URL); -1 = the "uncategorised" bucket ("(no genre)" / "(no series)"); > 0 =
+    // a specific id. One rule, named once per direction rather than inlined at
+    // each call site. (Tag has no uncategorised bucket, so it stays `> 0`.)
+    private static int? SentinelToQuery(int value) => value != 0 ? value : null;
+    private static int SentinelFromQuery(int? value) => value is -1 or > 0 ? value.Value : 0;
 
     // Build the query parameters for drilling a group row into a flat, filtered
     // book list: carry the current filters forward, switch to the flat list,

--- a/docs/TECH-DEBT.md
+++ b/docs/TECH-DEBT.md
@@ -20,9 +20,6 @@ Each item notes where it came from so the context is recoverable.
 | # | Area | Item | Why it matters | Size |
 |---|---|---|---|---|
 | TD-2 | Library / scale | **`BookQueryWithIncludes` eager-loads four collection navigations in one query** (`Tags`, `Works→Genres`, `Works→WorkAuthors→Author`) — a cartesian-explosion shape that wants `AsSplitQuery()`. Also flagged: the grouped-sort correlated `.Min()` subqueries and FK-index coverage. | Makes every Library load heavier than necessary; bites harder toward the 3000+ copy target. Best handled as part of a `/scale-audit` pass rather than piecemeal — that skill targets exactly this. | M |
-| TD-3 | Library / correctness | **`loadedSignature` is a `\|`-delimited concat of raw query values** (`List.razor` `OnParametersSetAsync`). A search term or author name containing `\|` could collide into a false "unchanged" signature and skip a needed reload. | Low-probability stale-list bug; also every new filter param must be hand-added to the concat with no compiler help. Replace with a structured/ordinal comparison of the `ToQueryParameters` dict (or hash it). | S |
-| TD-4 | Library / correctness | **`LoadBooksAsync` clamps `CurrentPage` in-VM without re-navigating.** URL says `page=5`, data shrinks to 2 pages → VM shows page 2 but the URL still says 5, breaking the "URL is the source of truth" invariant PR1 established. | Harmless today (re-clamps on refresh) but a latent desync. Fix: clamp before capturing `loadedSignature`, or issue a `replace:true` nav with the corrected page. | S |
-| TD-5 | Library / cleanup | **The genre/series `-1` / `>0` / `0` sentinel rule is encoded three times** in three dialects across `ApplyFilters`, `ToQueryParameters`, and `ApplyQueryParameters` (and `tag` uses `>0` while genre/series use `!=0`). | Adding a filter dimension or a second sentinel means editing the same rule in three places; an inconsistency round-trips to the URL but silently no-ops in the query, with no compile error. Consider a small shared helper. | S |
 
 ## Accepted — deliberately not fixing (for now)
 
@@ -37,6 +34,9 @@ Each item notes where it came from so the context is recoverable.
 | # | Item | Resolution |
 |---|---|---|
 | TD-1 | Remove dead accordion machinery in `BookListViewModel` | Done 2026-06-12. Deleted `ToggleGroupAsync`, `LoadGroupBooksAsync`, `ApplyGroupFilter`, `LoadedGroups`, `ExpandedGroupKeys`, the `GroupBooks` record, and `PatchLoadedItem`'s group loop — plus three page-action helpers the URL rework had orphaned (`ChangeGroupingAsync`, `GoToPageAsync`, `ClearFiltersAsync`). The four `ToggleGroupAsync_*` tests were retargeted onto the flat-list path (two converted, two removed as redundant/obsolete). One deliberate behaviour drop recorded as TD-A3. |
+| TD-3 | `loadedSignature` `\|`-delimited string could collide | Done 2026-06-12. Replaced the delimited-string change-detection in `List.razor` `OnParametersSetAsync` with a value-tuple of the query params (element-wise equality — no delimiter to collide on, and a new param is a compile-time tuple change). |
+| TD-4 | `CurrentPage` clamp desynced from the URL | Done 2026-06-12. After a flat-list reload, if `CurrentPage` was clamped (result set shrank), the page now writes the corrected page back via `replace:true` nav, keeping the URL the source of truth. VM clamp covered by `FlatList_PageBeyondRange_ClampsToLastPage`. |
+| TD-5 | Genre/series sentinel rule triplicated | Done 2026-06-12. Extracted `SentinelToQuery`/`SentinelFromQuery` helpers on the VM; `ToQueryParameters`/`ApplyQueryParameters` now call them instead of inlining the `-1`/`0`/`>0` rule in two dialects. (`ApplyFilters` keeps its per-dimension predicates — a different concern — but the rule is named once.) |
 
 ---
 


### PR DESCRIPTION
TD-3: replace the |-delimited loadedSignature change-detection with a value-tuple of the query params, so a filter value containing | can't collide into a false 'unchanged' and skip a reload.

TD-4: after a flat-list reload, if CurrentPage was clamped because the result set shrank, write the corrected page back to the URL (replace:true) so a stale ?page= doesn't desync the URL from the view. Adds a clamp test.

TD-5: extract SentinelToQuery/SentinelFromQuery helpers for the genre/series -1/0/>0 rule instead of inlining it in two dialects across ToQueryParameters/ApplyQueryParameters. TECH-DEBT.md updated (TD-3/4/5 resolved).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
