### PR TITLE
feat: Bookshelf status sheet + SyncService + auto-sync (redesign)

### DIFF
--- a/BookTracker.Mobile/AppShell.xaml.cs
+++ b/BookTracker.Mobile/AppShell.xaml.cs
@@ -1,16 +1,21 @@
 using BookTracker.Mobile.Pages;
+using BookTracker.Mobile.Services;
 using BookTracker.Mobile.Theming;
 
 namespace BookTracker.Mobile;
 
 public partial class AppShell : Shell
 {
+    private readonly ISyncService _sync;
+    private bool _autoSyncDone;
+
     // Pages are injected (not DataTemplate-instantiated) so they get their DI
     // dependencies. Content is set eagerly — three tab pages is cheap, and
     // each still loads its data in OnAppearing when its tab is first shown.
-    public AppShell(MainPage find, WishlistPage wishlist, SeriesGapsPage gaps)
+    public AppShell(ISyncService sync, MainPage find, WishlistPage wishlist, SeriesGapsPage gaps)
     {
         InitializeComponent();
+        _sync = sync;
 
         FindTab.Content = find;
         WishlistTab.Content = wishlist;
@@ -21,6 +26,25 @@ public partial class AppShell : Shell
         FindTab.Icon = TabIcon(TablerIcons.Search);
         WishlistTab.Icon = TabIcon(TablerIcons.Star);
         GapsTab.Icon = TabIcon(TablerIcons.Books);
+    }
+
+    protected override async void OnAppearing()
+    {
+        base.OnAppearing();
+        if (_autoSyncDone) return; // once per launch, not on every resume
+        _autoSyncDone = true;
+
+        // Open the cache before any tab reads it, then auto-sync silently when
+        // we're online + already signed in (the decided default). A signed-out
+        // or offline user just gets the cached data — no prompt, no block.
+        await _sync.InitAsync();
+        await _sync.RefreshSignInAsync();
+        await _sync.RefreshMetaAsync();
+        if (_sync.IsSignedIn && _sync.IsOnline)
+        {
+            try { await _sync.SyncCatalogAsync(); }
+            catch { /* best-effort on launch — the status sheet shows errors on manual refresh */ }
+        }
     }
 
     private static FontImageSource TabIcon(string glyph) =>

--- a/BookTracker.Mobile/MainPage.xaml
+++ b/BookTracker.Mobile/MainPage.xaml
@@ -3,75 +3,47 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="BookTracker.Mobile.MainPage"
              Shell.NavBarIsVisible="False"
-             NavigationPage.HasNavigationBar="False"
              BackgroundColor="#FAF6EC">
 
-    <!-- BookTracker library palette — mirrored from
-         BookTracker.Web/Theme/BookTrackerTheme.cs so the mobile companion
-         reads as the same product as the Web app.
-
-           leather   #6B2737  primary actions
-           brass     #A67B3A  accent borders + primary in-bookshop CTA
-           parchment #FAF6EC  page background
-           surface   #F2EADB  card / panel background
-           espresso  #3E2723  header banner
-           ink       #2C2416  primary text
-           faded ink #6B5D4A  secondary text
-
-         Root page hides the system nav bar (NavigationPage.HasNavigationBar)
-         because this is the entry surface — nothing to navigate back from.
-         ScanPage keeps its nav bar so the back button is visible there. -->
+    <!-- Transitional Find tab. Auth + sync chrome moved to the status sheet
+         (behind the sync chip, top-right). PR(next) rebuilds this as the
+         unified search surface, at which point its inline hex (light-only)
+         is replaced by the design tokens. Until then it stays as-is per the
+         "don't polish doomed pages" rule. -->
 
     <Grid RowDefinitions="Auto,*">
 
-        <!-- Espresso header banner. Replaces the previous in-content
-             Headline/SubHeadline pair so the brand chrome is anchored to
-             a fixed bar rather than flowing inside the scroll view. -->
-        <VerticalStackLayout Grid.Row="0"
-                             BackgroundColor="#3E2723"
-                             Padding="24,20,24,18"
-                             Spacing="2">
-            <Label Text="Bookshelf"
-                   FontSize="24"
-                   FontAttributes="Bold"
-                   TextColor="#F2EADB" />
-            <Label Text="Offline-capable companion"
-                   FontSize="13"
-                   TextColor="#A67B3A" />
-        </VerticalStackLayout>
+        <!-- Espresso banner with a trailing tappable sync chip. -->
+        <Grid Grid.Row="0"
+              BackgroundColor="#3E2723"
+              Padding="24,20,24,18"
+              ColumnDefinitions="*,Auto"
+              ColumnSpacing="12">
+            <VerticalStackLayout Spacing="2" VerticalOptions="Center">
+                <Label Text="Bookshelf" FontSize="24" FontAttributes="Bold" TextColor="#F2EADB" />
+                <Label Text="Offline-capable companion" FontSize="13" TextColor="#A67B3A" />
+            </VerticalStackLayout>
+
+            <Border Grid.Column="1"
+                    Stroke="#A67B3A"
+                    StrokeThickness="1"
+                    BackgroundColor="#30211A"
+                    Padding="10,6"
+                    VerticalOptions="Center">
+                <Border.StrokeShape>
+                    <RoundRectangle CornerRadius="14" />
+                </Border.StrokeShape>
+                <Border.GestureRecognizers>
+                    <TapGestureRecognizer Tapped="OnSyncChipTapped" />
+                </Border.GestureRecognizers>
+                <Label x:Name="SyncChipLabel" Text="⟳ Sync" FontSize="12" TextColor="#CDA256" />
+            </Border>
+        </Grid>
 
         <ScrollView Grid.Row="1">
             <VerticalStackLayout Padding="20,24" Spacing="14">
 
-                <!-- Sign in — primary CTA when signed out. -->
-                <Button x:Name="SignInButton"
-                        Text="Sign in"
-                        Clicked="OnSignInClicked"
-                        HeightRequest="56"
-                        BackgroundColor="#6B2737"
-                        TextColor="#FAF6EC"
-                        FontSize="16"
-                        FontAttributes="Bold"
-                        CornerRadius="8"
-                        HorizontalOptions="Fill" />
-
-                <!-- Load / refresh catalog snapshot. Visible only when
-                     signed in; doubles as Refresh once the cache is
-                     populated. -->
-                <Button x:Name="LoadCatalogButton"
-                        Text="📚  Load catalog snapshot"
-                        Clicked="OnLoadCatalogClicked"
-                        HeightRequest="56"
-                        BackgroundColor="#6B2737"
-                        TextColor="#FAF6EC"
-                        FontSize="16"
-                        CornerRadius="8"
-                        HorizontalOptions="Fill"
-                        IsVisible="False" />
-
-                <!-- Scan ISBN — the in-bookshop killer action. Brass
-                     accent + slightly larger height makes it stand out
-                     over the leather-coloured CTAs above. -->
+                <!-- Scan ISBN — the in-bookshop killer action (brass). -->
                 <Button x:Name="ScanButton"
                         Text="📷  Scan ISBN"
                         Clicked="OnScanClicked"
@@ -81,13 +53,8 @@
                         FontSize="18"
                         FontAttributes="Bold"
                         CornerRadius="8"
-                        HorizontalOptions="Fill"
-                        IsVisible="False" />
+                        HorizontalOptions="Fill" />
 
-                <!-- Find by author — the at-home killer action.
-                     Same height as Sign in / Load catalog (56dp);
-                     leather treatment because it's a navigation
-                     action, not an in-bookshop CTA. -->
                 <Button x:Name="FindByAuthorButton"
                         Text="👤  Find by author"
                         Clicked="OnFindByAuthorClicked"
@@ -96,12 +63,8 @@
                         TextColor="#FAF6EC"
                         FontSize="16"
                         CornerRadius="8"
-                        HorizontalOptions="Fill"
-                        IsVisible="False" />
+                        HorizontalOptions="Fill" />
 
-                <!-- Find by title — substring search on Book.Title for
-                     the "I'm pretty sure I have something Mountain"
-                     case. Same shape as Find by author. -->
                 <Button x:Name="FindByTitleButton"
                         Text="🔍  Find by title"
                         Clicked="OnFindByTitleClicked"
@@ -110,85 +73,15 @@
                         TextColor="#FAF6EC"
                         FontSize="16"
                         CornerRadius="8"
-                        HorizontalOptions="Fill"
-                        IsVisible="False" />
+                        HorizontalOptions="Fill" />
 
-                <!-- Series gaps + Wishlist moved to bottom tabs (AppShell,
-                     PR2) — they used to live here as buttons. -->
-
-                <!-- Cache stats panel — passive info card that surfaces
-                     "what's stashed locally" so it isn't buried in
-                     StatusLabel text. Brass border on aged-parchment
-                     surface mirrors the Library list card treatment on
-                     Web. Visible whenever the cache has data, even
-                     when signed out (data persists across sign-out). -->
-                <Border x:Name="CacheStatsPanel"
-                        IsVisible="False"
-                        Stroke="#A67B3A"
-                        StrokeThickness="1"
-                        BackgroundColor="#F2EADB"
-                        Padding="16,12">
-                    <Border.StrokeShape>
-                        <RoundRectangle CornerRadius="8" />
-                    </Border.StrokeShape>
-                    <VerticalStackLayout Spacing="4">
-                        <Label Text="Cached catalog"
-                               FontSize="12"
-                               FontAttributes="Bold"
-                               TextColor="#6B2737" />
-                        <Label x:Name="CacheStatsLabel"
-                               FontSize="15"
-                               TextColor="#2C2416" />
-                        <Label x:Name="CacheSyncedAtLabel"
-                               FontSize="12"
-                               TextColor="#6B5D4A" />
-                    </VerticalStackLayout>
-                </Border>
-
-                <ActivityIndicator x:Name="Busy"
-                                   IsRunning="False"
-                                   Color="#6B2737"
-                                   HorizontalOptions="Center"
-                                   Margin="0,4,0,0" />
-
-                <!-- Status / error label. Centred, faded-ink for low
-                     emphasis; the panel above carries the real
-                     "what's true" info. -->
+                <!-- Hint when there's no cached catalogue yet. -->
                 <Label x:Name="StatusLabel"
-                       Text="Not signed in. Tap Sign in to begin."
                        FontSize="14"
                        TextColor="#6B5D4A"
                        HorizontalTextAlignment="Center"
-                       LineBreakMode="WordWrap" />
-
-                <!-- Sign out — outlined low-emphasis. Pushed down with
-                     margin so it's visually separated from primary
-                     actions. -->
-                <Button x:Name="SignOutButton"
-                        Text="Sign out"
-                        Clicked="OnSignOutClicked"
-                        HeightRequest="44"
-                        BackgroundColor="Transparent"
-                        TextColor="#6B5D4A"
-                        BorderColor="#A67B3A"
-                        BorderWidth="1"
-                        FontSize="14"
-                        CornerRadius="8"
-                        HorizontalOptions="Center"
-                        WidthRequest="160"
-                        Margin="0,32,0,0"
-                        IsVisible="False" />
-
-                <!-- Build footer — version + short SHA so it's obvious
-                     which build is on the device. Populated in code-
-                     behind from BuildInfo.DisplayString. Centred + faded
-                     ink so it's unobtrusive. -->
-                <Label x:Name="BuildFooter"
-                       FontSize="11"
-                       TextColor="#6B5D4A"
-                       HorizontalOptions="Center"
-                       HorizontalTextAlignment="Center"
-                       Margin="0,16,0,0" />
+                       LineBreakMode="WordWrap"
+                       Margin="0,8,0,0" />
 
             </VerticalStackLayout>
         </ScrollView>

--- a/BookTracker.Mobile/MainPage.xaml.cs
+++ b/BookTracker.Mobile/MainPage.xaml.cs
@@ -1,298 +1,67 @@
-using BookTracker.Mobile.Cache;
 using BookTracker.Mobile.Pages;
 using BookTracker.Mobile.Services;
 
 namespace BookTracker.Mobile;
 
+// Transitional Find tab. Auth + catalog-sync moved to ISyncService + the
+// status sheet (PR: status/auth). This page is now a thin view: the search
+// entry points + a sync chip. PR(next) replaces it with the unified FindPage.
 public partial class MainPage : ContentPage
 {
-    private readonly IAuthService _auth;
-    private readonly IApiClient _api;
-    private readonly ICatalogCache _cache;
+    private readonly ISyncService _sync;
 
-    private bool _signedIn;
-    private bool _busy;
-    // Last-known cache metadata. Refreshed on app appearing, after
-    // sign-in, and after Load catalog. RefreshUi() reads from this
-    // (sync) rather than touching the cache directly so the render
-    // path stays cheap.
-    private CacheMeta? _meta;
-
-    public MainPage(IAuthService auth, IApiClient api, ICatalogCache cache)
+    public MainPage(ISyncService sync)
     {
         InitializeComponent();
-        _auth = auth;
-        _api = api;
-        _cache = cache;
-        // Build footer — version + SHA so Drew can see which build is
-        // on the device. BuildInfo is static and computed once on
-        // first reference, so this is just a label assignment.
-        BuildFooter.Text = BuildInfo.DisplayString;
+        _sync = sync;
+        // Re-render when sign-in / connectivity / cache meta changes (e.g.
+        // after a sync from the status sheet enables the search buttons).
+        _sync.StateChanged += (_, _) => MainThread.BeginInvokeOnMainThread(RefreshUi);
         RefreshUi();
     }
 
     protected override async void OnAppearing()
     {
         base.OnAppearing();
-
-        // Open the SQLite cache for the lifetime of the app process.
-        // InitAsync is idempotent so calling on every appearing is
-        // fine — second-and-later calls return immediately.
-        var dbPath = Path.Combine(FileSystem.AppDataDirectory, "catalog.db");
-        try
-        {
-            await _cache.InitAsync(dbPath);
-        }
-        catch (Exception ex)
-        {
-            // Cache failure shouldn't block the sign-in UX; surface
-            // it as status text but let the user still try to
-            // sign in + load (the no-cache path).
-            StatusLabel.Text = $"Cache init failed: {ex.Message}";
-        }
-
-        // Refresh the meta panel regardless of sign-in state — cached
-        // catalog data outlives sign-out, so the panel should show what
-        // we actually have locally.
-        await RefreshMetaAsync();
-
-        if (await _auth.IsSignedInAsync())
-        {
-            _signedIn = true;
-            StatusLabel.Text = _meta is null
-                ? "Signed in. Tap Load catalog snapshot to begin."
-                : "Signed in.";
-        }
-
+        await _sync.InitAsync();        // idempotent — AppShell already ran it
+        await _sync.RefreshMetaAsync(); // reflect any sync that happened elsewhere
         RefreshUi();
     }
 
-    private async void OnSignInClicked(object? sender, EventArgs e)
+    private async void OnScanClicked(object? sender, EventArgs e) => await PushAsync<ScanPage>();
+    private async void OnFindByAuthorClicked(object? sender, EventArgs e) => await PushAsync<AuthorSearchPage>();
+    private async void OnFindByTitleClicked(object? sender, EventArgs e) => await PushAsync<TitleSearchPage>();
+
+    private async void OnSyncChipTapped(object? sender, TappedEventArgs e) =>
+        await StatusSheetPage.OpenAsync(Navigation);
+
+    private async Task PushAsync<TPage>() where TPage : Page
     {
-        await RunBusyAsync("Signing in…", async () =>
-        {
-            await _auth.SignInAsync();
-            _signedIn = true;
-            await RefreshMetaAsync();
-            return _meta is null
-                ? "Signed in. Tap Load catalog snapshot to begin."
-                : "Signed in.";
-        });
-    }
-
-    private async void OnLoadCatalogClicked(object? sender, EventArgs e)
-    {
-        await RunBusyAsync("Loading catalog…", async () =>
-        {
-            // Delta-sync decision tree:
-            //   1. No stored watermark → first load → full PopulateAsync.
-            //   2. Have watermark → call with ?since=<token>.
-            //      a. Response.Version matches stored Version → merge
-            //         deltas into existing cache via ApplyDeltaAsync.
-            //         Preserves CoverPath when CoverUrl unchanged so
-            //         we don't re-download thumbnails on every refresh.
-            //      b. Response.Version differs → server deploy
-            //         invalidated cache shape; fall back to full
-            //         PopulateAsync.
-            // Status text mentions delta vs full so Drew can see which
-            // path the refresh took — useful both for sanity-checking
-            // the feature and for "wait why was that so quick" intuition.
-
-            var storedToken = _meta?.LatestUpdatedAt;
-            var storedVersion = _meta?.Version;
-            var snapshot = await _api.GetCatalogSnapshotAsync(since: storedToken);
-
-            string statusSuffix;
-            if (storedToken is null)
-            {
-                await _cache.PopulateAsync(snapshot);
-                statusSuffix = "full";
-            }
-            else if (!string.Equals(snapshot.Version, storedVersion, StringComparison.Ordinal))
-            {
-                // Version moved on the server. The snapshot we just
-                // fetched is a DELTA — we sent `since=<storedToken>`
-                // so the server filtered to Books with UpdatedAt > since.
-                // Populating with it would wipe-and-rewrite the cache
-                // using only the delta-window books, leaving everything
-                // older missing locally (which we hit 2026-05-14 on the
-                // Arc D deploy — search returned only the few books
-                // changed in the deploy window). Re-fetch without the
-                // token for a true full snapshot before wiping.
-                snapshot = await _api.GetCatalogSnapshotAsync(since: null);
-                await _cache.PopulateAsync(snapshot);
-                statusSuffix = "full (version changed)";
-            }
-            else
-            {
-                await _cache.ApplyDeltaAsync(snapshot);
-                var bookChanges = snapshot.Books?.Count ?? 0;
-                var deletes = snapshot.DeletedIds?.Count ?? 0;
-                statusSuffix = bookChanges == 0 && deletes == 0
-                    ? "delta · no changes"
-                    : $"delta · {bookChanges} updated, {deletes} removed";
-            }
-
-            await RefreshMetaAsync();
-
-            // Surface the redeploy hint only when the server is
-            // genuinely lagging on the /series field — the original
-            // PR 4 NRE diagnostic kept around as a passive warning.
-            return snapshot.Series is null
-                ? $"Catalog loaded ✓ ({statusSuffix}, server lacks /series field — redeploy Web)"
-                : $"Catalog loaded ✓ ({statusSuffix})";
-        });
-    }
-
-    private async void OnSignOutClicked(object? sender, EventArgs e)
-    {
-        await RunBusyAsync("Signing out…", async () =>
-        {
-            await _auth.SignOutAsync();
-            _signedIn = false;
-            // Note: cache data is intentionally not wiped on sign-out.
-            // The stats panel keeps showing what's locally stashed.
-            return "Signed out.";
-        });
-    }
-
-    // Runs an async action with the spinner up + buttons disabled,
-    // then renders the returned status string. Catches + surfaces
-    // any exception with enough breadcrumbs to diagnose without
-    // dumping the full stack trace to the UI.
-    private async Task RunBusyAsync(string busyStatus, Func<Task<string>> action)
-    {
-        _busy = true;
-        StatusLabel.Text = busyStatus;
-        RefreshUi();
-        try
-        {
-            var result = await action();
-            StatusLabel.Text = result;
-        }
-        catch (Exception ex)
-        {
-            // For NullReferenceException the canonical message is
-            // useless ("Object reference not set..."). Capture the
-            // exception type + the first stack frame so we can see
-            // where the throw originated. Limit to ~2-3 lines so
-            // the label stays readable on a phone.
-            var topFrame = ex.StackTrace?
-                .Split('\n', StringSplitOptions.RemoveEmptyEntries)
-                .FirstOrDefault()?.Trim() ?? "(no stack)";
-            StatusLabel.Text =
-                $"Failed: {ex.GetType().Name}\n{ex.Message}\n→ {topFrame}";
-        }
-        finally
-        {
-            _busy = false;
-            RefreshUi();
-        }
-    }
-
-    private async void OnScanClicked(object? sender, EventArgs e)
-    {
-        // Resolve the page from DI so it gets ICatalogCache injected.
-        // Transient registration in MauiProgram — each navigation
-        // gets a fresh CameraBarcodeReaderView, no held-camera between
-        // visits.
-        var services = Microsoft.Maui.Controls.Application.Current?.Handler?.MauiContext?.Services
+        // Resolve transient pages from DI (fresh per push within the Find tab).
+        var services = Application.Current?.Handler?.MauiContext?.Services
             ?? throw new InvalidOperationException("ServiceProvider not available.");
-        var page = services.GetService(typeof(ScanPage)) as ScanPage
-            ?? throw new InvalidOperationException("ScanPage not registered.");
+        var page = services.GetService(typeof(TPage)) as TPage
+            ?? throw new InvalidOperationException($"{typeof(TPage).Name} not registered.");
         await Navigation.PushAsync(page);
-    }
-
-    private async void OnFindByAuthorClicked(object? sender, EventArgs e)
-    {
-        // Same DI pattern as OnScanClicked. AuthorSearchPage is
-        // transient so each visit gets fresh debounce state.
-        var services = Microsoft.Maui.Controls.Application.Current?.Handler?.MauiContext?.Services
-            ?? throw new InvalidOperationException("ServiceProvider not available.");
-        var page = services.GetService(typeof(AuthorSearchPage)) as AuthorSearchPage
-            ?? throw new InvalidOperationException("AuthorSearchPage not registered.");
-        await Navigation.PushAsync(page);
-    }
-
-    private async void OnFindByTitleClicked(object? sender, EventArgs e)
-    {
-        var services = Microsoft.Maui.Controls.Application.Current?.Handler?.MauiContext?.Services
-            ?? throw new InvalidOperationException("ServiceProvider not available.");
-        var page = services.GetService(typeof(TitleSearchPage)) as TitleSearchPage
-            ?? throw new InvalidOperationException("TitleSearchPage not registered.");
-        await Navigation.PushAsync(page);
-    }
-
-    // Series gaps + Wishlist are now bottom tabs (AppShell), not buttons on
-    // this page — their nav handlers + buttons were removed in the Shell
-    // migration (PR2). This page is the transitional Find tab until PR3
-    // rebuilds it as the unified search surface.
-
-    private async Task RefreshMetaAsync()
-    {
-        try
-        {
-            _meta = await _cache.GetMetaAsync();
-        }
-        catch
-        {
-            // GetMetaAsync only throws if the cache file is corrupt
-            // or InitAsync wasn't called — both already surfaced
-            // upstream. Treat as "no cache" here so RefreshUi keeps
-            // rendering something sensible.
-            _meta = null;
-        }
     }
 
     private void RefreshUi()
     {
-        Busy.IsRunning = _busy;
-        var hasCache = _meta is not null;
+        // Offline-first: search the cache whether or not you're signed in —
+        // the buttons need cached data, not a session.
+        var hasCache = _sync.Meta is not null;
+        ScanButton.IsEnabled = hasCache;
+        FindByAuthorButton.IsEnabled = hasCache;
+        FindByTitleButton.IsEnabled = hasCache;
 
-        // Signed-out flow: only Sign in is visible / enabled.
-        SignInButton.IsVisible = !_signedIn;
-        SignInButton.IsEnabled = !_busy && !_signedIn;
+        SyncChipLabel.Text = _sync.IsOnline
+            ? $"⟳ {SyncService.FormatAge(_sync.Meta?.SyncedAt)}"
+            : "⚠ offline";
 
-        // Signed-in flow: Load catalog + Scan + Find by author visible.
-        // Load stays visible after first load so the user can tap to
-        // refresh. Scan + Find-by-author both need cached data
-        // (otherwise both would say "not in your library").
-        LoadCatalogButton.IsVisible = _signedIn;
-        LoadCatalogButton.IsEnabled = !_busy && _signedIn;
-        ScanButton.IsVisible = _signedIn;
-        ScanButton.IsEnabled = !_busy && _signedIn && hasCache;
-        FindByAuthorButton.IsVisible = _signedIn;
-        FindByAuthorButton.IsEnabled = !_busy && _signedIn && hasCache;
-        FindByTitleButton.IsVisible = _signedIn;
-        FindByTitleButton.IsEnabled = !_busy && _signedIn && hasCache;
-
-        // Cache stats panel: passive info, only when we have data.
-        // Renders independently of signed-in state — cached data
-        // outlives sign-out.
-        CacheStatsPanel.IsVisible = hasCache;
-        if (hasCache && _meta is not null)
-        {
-            CacheStatsLabel.Text =
-                $"{_meta.BookCount:N0} books · {_meta.AuthorCount:N0} authors";
-            CacheSyncedAtLabel.Text = _meta.SyncedAt is { } syncedAt
-                ? $"Last synced {FormatSyncedAt(syncedAt)}"
-                : "Last synced (unknown)";
-        }
-
-        SignOutButton.IsVisible = _signedIn;
-        SignOutButton.IsEnabled = !_busy && _signedIn;
-    }
-
-    // Relative-time formatter for the cache stats panel.
-    // "just now / 5m ago / 2h ago / 2026-05-12 14:23". Kept inline
-    // because it's UI-only with a single use site — promoting it to
-    // a helper class would be over-engineered for one Label binding.
-    private static string FormatSyncedAt(DateTime syncedUtc)
-    {
-        var ago = DateTime.UtcNow - syncedUtc;
-        if (ago.TotalMinutes < 1) return "just now";
-        if (ago.TotalMinutes < 60) return $"{(int)ago.TotalMinutes}m ago";
-        if (ago.TotalHours < 24) return $"{(int)ago.TotalHours}h ago";
-        return syncedUtc.ToLocalTime().ToString("yyyy-MM-dd HH:mm");
+        StatusLabel.Text = hasCache
+            ? ""
+            : _sync.IsSignedIn
+                ? "No catalog cached yet — tap the sync chip, then Refresh now."
+                : "No catalog cached yet — tap the sync chip to sign in and load.";
     }
 }

--- a/BookTracker.Mobile/MauiProgram.cs
+++ b/BookTracker.Mobile/MauiProgram.cs
@@ -49,6 +49,11 @@ public static class MauiProgram
         // repeated fetches across pages reuse the same handler.
         builder.Services.AddHttpClient("covers");
 
+        // Auth + catalog-sync state, lifted out of MainPage so the status
+        // sheet, the SyncChip, and auto-sync-on-launch share one source.
+        builder.Services.AddSingleton<ISyncService, SyncService>();
+        builder.Services.AddTransient<Pages.StatusSheetPage>();
+
         // AppShell hosts the three bottom tabs; it injects the tab pages so
         // they resolve through DI (a DataTemplate ContentTemplate would try a
         // parameterless ctor and fail). Singleton — one shell per app.

--- a/BookTracker.Mobile/Pages/SeriesGapsPage.xaml
+++ b/BookTracker.Mobile/Pages/SeriesGapsPage.xaml
@@ -5,6 +5,10 @@
              Title="Series gaps"
              Style="{StaticResource Page}">
 
+    <ContentPage.ToolbarItems>
+        <ToolbarItem Text="Sync" Clicked="OnSyncClicked" />
+    </ContentPage.ToolbarItems>
+
     <!-- "Series gaps" — at-a-glance "what am I missing?" view for
          series where the user owns some but not all books. Mirror of
          the Web /shopping Card 2. Sources data from

--- a/BookTracker.Mobile/Pages/SeriesGapsPage.xaml.cs
+++ b/BookTracker.Mobile/Pages/SeriesGapsPage.xaml.cs
@@ -23,6 +23,9 @@ public partial class SeriesGapsPage : ContentPage
         await LoadGapsAsync();
     }
 
+    private async void OnSyncClicked(object? sender, EventArgs e) =>
+        await StatusSheetPage.OpenAsync(Navigation);
+
     private async Task LoadGapsAsync()
     {
         GapsLayout.Children.Clear();

--- a/BookTracker.Mobile/Pages/StatusSheetPage.xaml
+++ b/BookTracker.Mobile/Pages/StatusSheetPage.xaml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="BookTracker.Mobile.Pages.StatusSheetPage"
+             Style="{StaticResource Page}"
+             Title="Sync &amp; account">
+
+    <!-- Modal sheet behind the SyncChip: the home for sync detail + account.
+         Replaces the auth/sync/cache chrome that used to live on MainPage.
+         Offline-first: sign-in lives here (you sign in only to refresh) — it
+         does NOT gate the tabs. -->
+    <ScrollView>
+        <VerticalStackLayout Padding="20" Spacing="16">
+
+            <Grid ColumnDefinitions="*,Auto" VerticalOptions="Center">
+                <Label Text="Sync &amp; account"
+                       FontSize="24"
+                       FontAttributes="Bold"
+                       VerticalOptions="Center"
+                       TextColor="{AppThemeBinding Light={StaticResource TextL}, Dark={StaticResource TextD}}" />
+                <Button Grid.Column="1"
+                        Text="Close"
+                        Clicked="OnCloseClicked"
+                        Style="{StaticResource OutlinedButton}"
+                        WidthRequest="90" />
+            </Grid>
+
+            <Label x:Name="ConnectivityLabel"
+                   FontSize="14"
+                   FontAttributes="Bold" />
+
+            <Border Style="{StaticResource Card}">
+                <VerticalStackLayout Spacing="4">
+                    <Label Text="Cached catalog"
+                           FontSize="12"
+                           FontAttributes="Bold"
+                           TextColor="{AppThemeBinding Light={StaticResource LeatherL}, Dark={StaticResource LeatherD}}" />
+                    <Label x:Name="StatsLabel"
+                           FontSize="15"
+                           TextColor="{AppThemeBinding Light={StaticResource TextL}, Dark={StaticResource TextD}}" />
+                    <Label x:Name="SyncedAtLabel"
+                           FontSize="12"
+                           TextColor="{AppThemeBinding Light={StaticResource TextMutedL}, Dark={StaticResource TextMutedD}}" />
+                </VerticalStackLayout>
+            </Border>
+
+            <ActivityIndicator x:Name="Busy"
+                               IsRunning="False"
+                               HorizontalOptions="Center"
+                               Color="{AppThemeBinding Light={StaticResource LeatherL}, Dark={StaticResource LeatherD}}" />
+
+            <Label x:Name="StatusLabel"
+                   FontSize="13"
+                   HorizontalTextAlignment="Center"
+                   LineBreakMode="WordWrap"
+                   TextColor="{AppThemeBinding Light={StaticResource TextMutedL}, Dark={StaticResource TextMutedD}}" />
+
+            <Button x:Name="RefreshButton"
+                    Text="Refresh now"
+                    Clicked="OnRefreshClicked"
+                    Style="{StaticResource PrimaryButton}" />
+
+            <Button x:Name="AuthButton"
+                    Clicked="OnAuthClicked"
+                    Style="{StaticResource OutlinedButton}"
+                    HorizontalOptions="Center"
+                    WidthRequest="160"
+                    Margin="0,8,0,0" />
+
+            <Label x:Name="BuildFooter"
+                   FontSize="11"
+                   HorizontalTextAlignment="Center"
+                   HorizontalOptions="Center"
+                   Margin="0,16,0,0"
+                   TextColor="{AppThemeBinding Light={StaticResource TextMutedL}, Dark={StaticResource TextMutedD}}" />
+
+        </VerticalStackLayout>
+    </ScrollView>
+</ContentPage>

--- a/BookTracker.Mobile/Pages/StatusSheetPage.xaml.cs
+++ b/BookTracker.Mobile/Pages/StatusSheetPage.xaml.cs
@@ -1,0 +1,110 @@
+using BookTracker.Mobile.Services;
+using BookTracker.Mobile.Theming;
+
+namespace BookTracker.Mobile.Pages;
+
+public partial class StatusSheetPage : ContentPage
+{
+    private readonly ISyncService _sync;
+    private bool _busy;
+
+    public StatusSheetPage(ISyncService sync)
+    {
+        InitializeComponent();
+        _sync = sync;
+        BuildFooter.Text = BuildInfo.DisplayString;
+    }
+
+    /// <summary>Resolves the sheet from DI and presents it modally — the single
+    /// entry point every tab's sync affordance calls.</summary>
+    public static async Task OpenAsync(INavigation nav)
+    {
+        var services = Application.Current?.Handler?.MauiContext?.Services
+            ?? throw new InvalidOperationException("ServiceProvider not available.");
+        var sheet = services.GetService(typeof(StatusSheetPage)) as StatusSheetPage
+            ?? throw new InvalidOperationException("StatusSheetPage not registered.");
+        await nav.PushModalAsync(sheet);
+    }
+
+    protected override async void OnAppearing()
+    {
+        base.OnAppearing();
+        await _sync.RefreshSignInAsync();
+        await _sync.RefreshMetaAsync();
+        Render();
+    }
+
+    private void Render()
+    {
+        Busy.IsRunning = _busy;
+
+        ConnectivityLabel.Text = _sync.IsOnline ? "● Online" : "● Offline";
+        ConnectivityLabel.SetThemeColor(Label.TextColorProperty,
+            _sync.IsOnline ? "OnlineTxL" : "MissTagTxL",
+            _sync.IsOnline ? "OnlineTxD" : "MissTagTxD");
+
+        var meta = _sync.Meta;
+        if (meta is not null)
+        {
+            StatsLabel.Text = $"{meta.BookCount:N0} books · {meta.AuthorCount:N0} authors";
+            SyncedAtLabel.Text = $"Last synced {SyncService.FormatAge(meta.SyncedAt)}";
+        }
+        else
+        {
+            StatsLabel.Text = "No catalog cached yet.";
+            SyncedAtLabel.Text = _sync.IsSignedIn
+                ? "Tap Refresh now to load your library."
+                : "Sign in, then Refresh, to load your library.";
+        }
+
+        // Refresh needs an authenticated session + connectivity.
+        RefreshButton.IsEnabled = !_busy && _sync.IsSignedIn && _sync.IsOnline;
+        AuthButton.Text = _sync.IsSignedIn ? "Sign out" : "Sign in";
+        AuthButton.IsEnabled = !_busy;
+    }
+
+    private async void OnRefreshClicked(object? sender, EventArgs e) =>
+        await RunBusyAsync("Syncing…", () => _sync.SyncCatalogAsync());
+
+    private async void OnAuthClicked(object? sender, EventArgs e) =>
+        await RunBusyAsync(_sync.IsSignedIn ? "Signing out…" : "Signing in…", async () =>
+        {
+            if (_sync.IsSignedIn)
+            {
+                await _sync.SignOutAsync();
+                return "Signed out. Cached data is kept.";
+            }
+            await _sync.SignInAsync();
+            return _sync.Meta is null
+                ? "Signed in. Tap Refresh now to load your library."
+                : "Signed in.";
+        });
+
+    private async void OnCloseClicked(object? sender, EventArgs e) =>
+        await Navigation.PopModalAsync();
+
+    // Spinner up + buttons disabled while the action runs, then render the
+    // returned status line. Mirrors the old MainPage.RunBusyAsync diagnostics.
+    private async Task RunBusyAsync(string busyStatus, Func<Task<string>> action)
+    {
+        _busy = true;
+        StatusLabel.Text = busyStatus;
+        Render();
+        try
+        {
+            StatusLabel.Text = await action();
+        }
+        catch (Exception ex)
+        {
+            var topFrame = ex.StackTrace?
+                .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+                .FirstOrDefault()?.Trim() ?? "(no stack)";
+            StatusLabel.Text = $"Failed: {ex.GetType().Name}\n{ex.Message}\n→ {topFrame}";
+        }
+        finally
+        {
+            _busy = false;
+            Render();
+        }
+    }
+}

--- a/BookTracker.Mobile/Pages/WishlistPage.xaml
+++ b/BookTracker.Mobile/Pages/WishlistPage.xaml
@@ -5,6 +5,10 @@
              Title="Wishlist"
              Style="{StaticResource Page}">
 
+    <ContentPage.ToolbarItems>
+        <ToolbarItem Text="Sync" Clicked="OnSyncClicked" />
+    </ContentPage.ToolbarItems>
+
     <!-- Wishlist — books Drew is looking for. Backs the in-shop
          "what am I trying to buy?" use case that the Web /wishlist
          page captures. Read from the offline cache; refresh button

--- a/BookTracker.Mobile/Pages/WishlistPage.xaml.cs
+++ b/BookTracker.Mobile/Pages/WishlistPage.xaml.cs
@@ -26,6 +26,9 @@ public partial class WishlistPage : ContentPage
         await LoadFromCacheAsync();
     }
 
+    private async void OnSyncClicked(object? sender, EventArgs e) =>
+        await StatusSheetPage.OpenAsync(Navigation);
+
     private async Task LoadFromCacheAsync()
     {
         try

--- a/BookTracker.Mobile/Services/SyncService.cs
+++ b/BookTracker.Mobile/Services/SyncService.cs
@@ -1,0 +1,155 @@
+using BookTracker.Mobile.Cache;
+using Microsoft.Maui.Networking;
+using Microsoft.Maui.Storage;
+
+namespace BookTracker.Mobile.Services;
+
+/// <summary>
+/// Owns the app's auth + catalog-sync state and operations, lifted out of
+/// MainPage so the status sheet, the ambient SyncChip, and auto-sync-on-launch
+/// all share one source of truth. Singleton — one sync state per app process.
+/// Raises <see cref="StateChanged"/> whenever sign-in, connectivity, or cache
+/// meta changes so headers/sheets can re-render.
+/// </summary>
+public interface ISyncService
+{
+    /// <summary>Last-known cache metadata (book/author counts, last-synced,
+    /// watermark). Null until <see cref="RefreshMetaAsync"/> runs / no cache.</summary>
+    CacheMeta? Meta { get; }
+    bool IsSignedIn { get; }
+    bool IsOnline { get; }
+    event EventHandler? StateChanged;
+
+    /// <summary>Opens the SQLite cache. Idempotent — safe to call repeatedly.</summary>
+    Task InitAsync();
+    Task<bool> RefreshSignInAsync();
+    Task SignInAsync();
+    Task SignOutAsync();
+    /// <summary>Runs the catalog delta-sync (full / delta / version-changed
+    /// decision tree) and refreshes <see cref="Meta"/>. Returns a status line.</summary>
+    Task<string> SyncCatalogAsync();
+    Task RefreshMetaAsync();
+}
+
+public sealed class SyncService : ISyncService
+{
+    private readonly IAuthService _auth;
+    private readonly IApiClient _api;
+    private readonly ICatalogCache _cache;
+    private bool _initialised;
+
+    public SyncService(IAuthService auth, IApiClient api, ICatalogCache cache)
+    {
+        _auth = auth;
+        _api = api;
+        _cache = cache;
+        IsOnline = Connectivity.Current.NetworkAccess == NetworkAccess.Internet;
+        Connectivity.Current.ConnectivityChanged += OnConnectivityChanged;
+    }
+
+    public CacheMeta? Meta { get; private set; }
+    public bool IsSignedIn { get; private set; }
+    public bool IsOnline { get; private set; }
+    public event EventHandler? StateChanged;
+
+    private void OnConnectivityChanged(object? sender, ConnectivityChangedEventArgs e)
+    {
+        IsOnline = e.NetworkAccess == NetworkAccess.Internet;
+        Raise();
+    }
+
+    public async Task InitAsync()
+    {
+        if (_initialised) return;
+        var dbPath = Path.Combine(FileSystem.AppDataDirectory, "catalog.db");
+        await _cache.InitAsync(dbPath);
+        _initialised = true;
+    }
+
+    public async Task<bool> RefreshSignInAsync()
+    {
+        IsSignedIn = await _auth.IsSignedInAsync();
+        Raise();
+        return IsSignedIn;
+    }
+
+    public async Task SignInAsync()
+    {
+        await _auth.SignInAsync();
+        IsSignedIn = true;
+        Raise();
+    }
+
+    public async Task SignOutAsync()
+    {
+        await _auth.SignOutAsync();
+        IsSignedIn = false;
+        // Cache data is intentionally NOT wiped — it outlives sign-out so the
+        // offline surfaces keep working.
+        Raise();
+    }
+
+    public async Task RefreshMetaAsync()
+    {
+        try { Meta = await _cache.GetMetaAsync(); }
+        catch { Meta = null; } // corrupt / un-init'd cache — render as "no cache".
+        Raise();
+    }
+
+    public async Task<string> SyncCatalogAsync()
+    {
+        // Delta-sync decision tree (lifted verbatim from the old
+        // MainPage.OnLoadCatalogClicked):
+        //   1. No watermark → first load → full PopulateAsync.
+        //   2. Have watermark → GET ?since=<token>.
+        //      a. Version matches → merge deltas via ApplyDeltaAsync.
+        //      b. Version differs → server deploy invalidated cache shape;
+        //         re-fetch WITHOUT the token for a true full snapshot before
+        //         wiping (else a delta-window populate drops everything older).
+        var storedToken = Meta?.LatestUpdatedAt;
+        var storedVersion = Meta?.Version;
+        var snapshot = await _api.GetCatalogSnapshotAsync(since: storedToken);
+
+        string statusSuffix;
+        if (storedToken is null)
+        {
+            await _cache.PopulateAsync(snapshot);
+            statusSuffix = "full";
+        }
+        else if (!string.Equals(snapshot.Version, storedVersion, StringComparison.Ordinal))
+        {
+            snapshot = await _api.GetCatalogSnapshotAsync(since: null);
+            await _cache.PopulateAsync(snapshot);
+            statusSuffix = "full (version changed)";
+        }
+        else
+        {
+            await _cache.ApplyDeltaAsync(snapshot);
+            var bookChanges = snapshot.Books?.Count ?? 0;
+            var deletes = snapshot.DeletedIds?.Count ?? 0;
+            statusSuffix = bookChanges == 0 && deletes == 0
+                ? "delta · no changes"
+                : $"delta · {bookChanges} updated, {deletes} removed";
+        }
+
+        await RefreshMetaAsync();
+        return snapshot.Series is null
+            ? $"Synced ✓ ({statusSuffix}, server lacks /series field — redeploy Web)"
+            : $"Synced ✓ ({statusSuffix})";
+    }
+
+    private void Raise() => StateChanged?.Invoke(this, EventArgs.Empty);
+
+    /// <summary>Relative-time label for a last-synced timestamp:
+    /// "never" / "just now" / "5m ago" / "2h ago" / "2026-05-12 14:23".
+    /// Shared by the status sheet + the SyncChip.</summary>
+    public static string FormatAge(DateTime? syncedUtc)
+    {
+        if (syncedUtc is not { } utc) return "never";
+        var ago = DateTime.UtcNow - utc;
+        if (ago.TotalMinutes < 1) return "just now";
+        if (ago.TotalMinutes < 60) return $"{(int)ago.TotalMinutes}m ago";
+        if (ago.TotalHours < 24) return $"{(int)ago.TotalHours}h ago";
+        return utc.ToLocalTime().ToString("yyyy-MM-dd HH:mm");
+    }
+}


### PR DESCRIPTION
Extracts the auth + catalog-sync chrome out of MainPage into a shared service
and a modal status sheet, so the Find rework can cleanly replace MainPage next.
Offline-first: sign-in lives in the sheet (you sign in only to refresh) — it
does NOT gate the tabs; a signed-out user with a cached catalogue keeps working.

- Services/SyncService.cs (ISyncService, singleton): owns IsSignedIn / IsOnline
  (Connectivity) / Meta + InitAsync / SignIn / SignOut / RefreshMeta and
  SyncCatalogAsync (the full/delta/version-changed decision tree, lifted
  verbatim from MainPage.OnLoadCatalogClicked — now the single copy). Raises
  StateChanged so headers/sheets re-render. Shared FormatAge helper.
- Pages/StatusSheetPage: modal — connectivity, cached-catalog stats,
  last-synced, Refresh now, Sign in/out, build/version. Born token-based +
  dark. Static OpenAsync is the one entry point every tab calls.
- AppShell: auto-sync on launch (once) — InitAsync + sign-in check, then a
  silent delta sync when online + signed-in (the decided default). Also
  guarantees the cache is opened before any tab reads it.
- MainPage trimmed to a thin view over ISyncService: removed the
  sign-in/load/sign-out buttons, cache panel, build footer + the duplicate
  sync logic; kept Scan / author / title (now enabled by cache presence, not
  sign-in — offline-first) + a tappable sync chip → status sheet.
- Wishlist + Gaps: a "Sync" ToolbarItem → the same sheet.

SyncChip scope note: the brief's rich per-tab chip (age text in each header)
is simplified for now — the Find tab shows the age chip; Wishlist/Gaps get a
"Sync" toolbar button. The full header chip lands when those headers are
reworked (flagged to revisit, per the agreed "revisit if fiddly").

Builds (MAUI Android). On-device: sync chip / Sync toolbar opens the sheet;
sign in/out + Refresh now work; auto-sync fires on launch; search buttons
enable once a catalogue is cached; dark mode on the new sheet.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
