### PR TITLE
fix: Bookshelf arc-review follow-ups (F2/F3/F4/F6 + F9 hygiene)

### DIFF
--- a/BookTracker.Mobile/Pages/FindPage.xaml.cs
+++ b/BookTracker.Mobile/Pages/FindPage.xaml.cs
@@ -132,6 +132,7 @@ public partial class FindPage : ContentPage
     {
         var query = (e.NewTextValue ?? "").Trim();
         _searchCts?.Cancel();
+        _searchCts?.Dispose(); // singleton tab — don't leak a CTS per keystroke
         _searchCts = new CancellationTokenSource();
         var ct = _searchCts.Token;
 

--- a/BookTracker.Mobile/Pages/ResultPage.xaml.cs
+++ b/BookTracker.Mobile/Pages/ResultPage.xaml.cs
@@ -32,6 +32,14 @@ public partial class ResultPage : ContentPage
         await LookupAsync();
     }
 
+    protected override void OnDisappearing()
+    {
+        base.OnDisappearing();
+        // Popping mid-load: cancel the enriched-detail fetch so its UI-thread
+        // continuation doesn't mutate this (now off-stack) page.
+        _coverCts?.Cancel();
+    }
+
     private async Task LookupAsync()
     {
         StatusLabel.Text = $"Looking up {_isbn}…";

--- a/BookTracker.Mobile/Pages/StatusSheetPage.xaml.cs
+++ b/BookTracker.Mobile/Pages/StatusSheetPage.xaml.cs
@@ -29,8 +29,17 @@ public partial class StatusSheetPage : ContentPage
     protected override async void OnAppearing()
     {
         base.OnAppearing();
-        await _sync.RefreshSignInAsync();
-        await _sync.RefreshMetaAsync();
+        // async void — an unhandled throw (e.g. MSAL on RefreshSignInAsync) would
+        // crash the app, so guard and render whatever state we have.
+        try
+        {
+            await _sync.RefreshSignInAsync();
+            await _sync.RefreshMetaAsync();
+        }
+        catch (Exception ex)
+        {
+            StatusLabel.Text = $"Couldn't refresh status: {ex.GetType().Name}";
+        }
         Render();
     }
 

--- a/BookTracker.Mobile/Pages/WishlistPage.xaml.cs
+++ b/BookTracker.Mobile/Pages/WishlistPage.xaml.cs
@@ -204,8 +204,17 @@ public partial class WishlistPage : ContentPage
 
     private async Task OnBoughtAsync(int itemId)
     {
-        await _cache.MarkBoughtLocallyAsync(itemId);
-        await LoadFromCacheAsync();
+        // Fired from an async-void click lambda — an unhandled throw here would
+        // tear down the process, so a cache-write failure must surface, not crash.
+        try
+        {
+            await _cache.MarkBoughtLocallyAsync(itemId);
+            await LoadFromCacheAsync();
+        }
+        catch (Exception ex)
+        {
+            StatusLabel.Text = $"Couldn't mark as bought: {ex.GetType().Name}";
+        }
     }
 
     private async void OnRefreshClicked(object? sender, EventArgs e)

--- a/BookTracker.Mobile/Resources/Styles/Colors.xaml
+++ b/BookTracker.Mobile/Resources/Styles/Colors.xaml
@@ -64,7 +64,6 @@
     <Color x:Key="SurfaceL">#F2EADB</Color>     <Color x:Key="SurfaceD">#30211A</Color>
     <Color x:Key="HeaderL">#3E2723</Color>      <Color x:Key="HeaderD">#2A1A13</Color>
     <Color x:Key="InputBgL">#FAF6EC</Color>     <Color x:Key="InputBgD">#2A2018</Color>
-    <Color x:Key="CoverTileL">#3E2723</Color>   <Color x:Key="CoverTileD">#1A130D</Color>
     <Color x:Key="CoverMissL">#E2D8C4</Color>   <Color x:Key="CoverMissD">#1A130D</Color>
 
     <!-- Text -->
@@ -105,6 +104,5 @@
     <!-- Sync states -->
     <Color x:Key="OnlineBgL">#E8F1E4</Color>    <Color x:Key="OnlineBgD">#1B3320</Color>
     <Color x:Key="OnlineTxL">#4F6B3D</Color>    <Color x:Key="OnlineTxD">#8DB36E</Color>
-    <Color x:Key="InfoTxL">#3A6B7A</Color>      <Color x:Key="InfoTxD">#7FB3C0</Color>
     <Color x:Key="ChipBgL">#EFE4CC</Color>      <Color x:Key="ChipBgD">#30211A</Color>
 </ResourceDictionary>

--- a/BookTracker.Mobile/Services/SyncService.cs
+++ b/BookTracker.Mobile/Services/SyncService.cs
@@ -36,6 +36,7 @@ public sealed class SyncService : ISyncService
     private readonly IAuthService _auth;
     private readonly IApiClient _api;
     private readonly ICatalogCache _cache;
+    private readonly SemaphoreSlim _syncGate = new(1, 1);
     private bool _initialised;
 
     public SyncService(IAuthService auth, IApiClient api, ICatalogCache cache)
@@ -98,47 +99,67 @@ public sealed class SyncService : ISyncService
 
     public async Task<string> SyncCatalogAsync()
     {
-        // Delta-sync decision tree (lifted verbatim from the old
-        // MainPage.OnLoadCatalogClicked):
-        //   1. No watermark → first load → full PopulateAsync.
-        //   2. Have watermark → GET ?since=<token>.
-        //      a. Version matches → merge deltas via ApplyDeltaAsync.
-        //      b. Version differs → server deploy invalidated cache shape;
-        //         re-fetch WITHOUT the token for a true full snapshot before
-        //         wiping (else a delta-window populate drops everything older).
-        var storedToken = Meta?.LatestUpdatedAt;
-        var storedVersion = Meta?.Version;
-        var snapshot = await _api.GetCatalogSnapshotAsync(since: storedToken);
+        // One sync at a time — launch auto-sync (AppShell) and a manual Refresh
+        // (status sheet) must not both write the cache concurrently. A second
+        // caller backs off rather than interleaving PopulateAsync/ApplyDeltaAsync.
+        if (!await _syncGate.WaitAsync(0))
+            return "Sync already in progress…";
+        try
+        {
+            // Delta-sync decision tree (lifted verbatim from the old
+            // MainPage.OnLoadCatalogClicked):
+            //   1. No watermark → first load → full PopulateAsync.
+            //   2. Have watermark → GET ?since=<token>.
+            //      a. Version matches → merge deltas via ApplyDeltaAsync.
+            //      b. Version differs → server deploy invalidated cache shape;
+            //         re-fetch WITHOUT the token for a true full snapshot before
+            //         wiping (else a delta-window populate drops everything older).
+            var storedToken = Meta?.LatestUpdatedAt;
+            var storedVersion = Meta?.Version;
+            var snapshot = await _api.GetCatalogSnapshotAsync(since: storedToken);
 
-        string statusSuffix;
-        if (storedToken is null)
-        {
-            await _cache.PopulateAsync(snapshot);
-            statusSuffix = "full";
-        }
-        else if (!string.Equals(snapshot.Version, storedVersion, StringComparison.Ordinal))
-        {
-            snapshot = await _api.GetCatalogSnapshotAsync(since: null);
-            await _cache.PopulateAsync(snapshot);
-            statusSuffix = "full (version changed)";
-        }
-        else
-        {
-            await _cache.ApplyDeltaAsync(snapshot);
-            var bookChanges = snapshot.Books?.Count ?? 0;
-            var deletes = snapshot.DeletedIds?.Count ?? 0;
-            statusSuffix = bookChanges == 0 && deletes == 0
-                ? "delta · no changes"
-                : $"delta · {bookChanges} updated, {deletes} removed";
-        }
+            string statusSuffix;
+            if (storedToken is null)
+            {
+                await _cache.PopulateAsync(snapshot);
+                statusSuffix = "full";
+            }
+            else if (!string.Equals(snapshot.Version, storedVersion, StringComparison.Ordinal))
+            {
+                snapshot = await _api.GetCatalogSnapshotAsync(since: null);
+                await _cache.PopulateAsync(snapshot);
+                statusSuffix = "full (version changed)";
+            }
+            else
+            {
+                await _cache.ApplyDeltaAsync(snapshot);
+                var bookChanges = snapshot.Books?.Count ?? 0;
+                var deletes = snapshot.DeletedIds?.Count ?? 0;
+                statusSuffix = bookChanges == 0 && deletes == 0
+                    ? "delta · no changes"
+                    : $"delta · {bookChanges} updated, {deletes} removed";
+            }
 
-        await RefreshMetaAsync();
-        return snapshot.Series is null
-            ? $"Synced ✓ ({statusSuffix}, server lacks /series field — redeploy Web)"
-            : $"Synced ✓ ({statusSuffix})";
+            await RefreshMetaAsync();
+            return snapshot.Series is null
+                ? $"Synced ✓ ({statusSuffix}, server lacks /series field — redeploy Web)"
+                : $"Synced ✓ ({statusSuffix})";
+        }
+        finally
+        {
+            _syncGate.Release();
+        }
     }
 
-    private void Raise() => StateChanged?.Invoke(this, EventArgs.Empty);
+    // OnConnectivityChanged fires on a non-UI thread, so marshal here once —
+    // every StateChanged subscriber can then touch UI without its own guard.
+    private void Raise()
+    {
+        if (MainThread.IsMainThread)
+            StateChanged?.Invoke(this, EventArgs.Empty);
+        else
+            MainThread.BeginInvokeOnMainThread(() => StateChanged?.Invoke(this, EventArgs.Empty));
+    }
 
     /// <summary>Relative-time label for a last-synced timestamp:
     /// "never" / "just now" / "5m ago" / "2h ago" / "2026-05-12 14:23".

--- a/BookTracker.Mobile/Theming/TablerIcons.cs
+++ b/BookTracker.Mobile/Theming/TablerIcons.cs
@@ -16,20 +16,10 @@ public static class TablerIcons
 {
     private static string G(int codepoint) => char.ConvertFromUtf32(codepoint);
 
+    // Only the three tab-bar glyphs are in use — the redesign settled on text
+    // and emoji affordances elsewhere. The full font is bundled, so add a line
+    // here (with its upstream \eXXXX codepoint) when a surface actually needs one.
     public static readonly string Search = G(0xEB1C);
-    public static readonly string Barcode = G(0xEBC6);
     public static readonly string Star = G(0xEB2E);
     public static readonly string Books = G(0xEFF2);
-    public static readonly string Book = G(0xEA39);
-    public static readonly string User = G(0xEB4D);
-    public static readonly string Refresh = G(0xEB13);
-    public static readonly string Wifi = G(0xEB52);
-    public static readonly string WifiOff = G(0xECFA);
-    public static readonly string ArrowsSort = G(0xEB5A);
-    public static readonly string ChevronRight = G(0xEA61);
-    public static readonly string ChevronLeft = G(0xEA60);
-    public static readonly string Logout = G(0xEBA8);
-    public static readonly string Plus = G(0xEB0B);
-    public static readonly string X = G(0xEB55);
-    public static readonly string DotsVertical = G(0xEA94);
 }


### PR DESCRIPTION
Correctness:
- F2 WishlistPage.OnBoughtAsync: wrap in try/catch — it runs from an
  async-void click lambda, so a cache-write failure was an unhandled
  exception that crashed the app instead of showing an error.
- F3 SyncService.SyncCatalogAsync: SemaphoreSlim(1,1) try-acquire gate so
  launch auto-sync and a manual Refresh can't write the cache concurrently
  (a second caller backs off with "Sync already in progress…").
- F4 StatusSheetPage.OnAppearing: try/catch around RefreshSignInAsync — an
  MSAL throw on an async-void lifecycle method would otherwise crash.
- F6 SyncService.Raise: marshal to the UI thread once (connectivity changes
  fire off-thread), so every StateChanged subscriber is safe without its own
  guard.

Hygiene (F9):
- ResultPage: add OnDisappearing → _coverCts.Cancel() so the existing
  cancellation guards actually fire when popping mid-load.
- FindPage: dispose the prior _searchCts before replacing (singleton tab,
  was leaking one per keystroke).
- TablerIcons: drop the 13 unused glyph constants (only Search/Star/Books
  are referenced).
- Colors.xaml: remove unused token pairs CoverTileL/D and InfoTxL/D
  (GreenL/D kept — used in Styles.xaml).

Builds (MAUI Android, 0 warnings).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
