### PR TITLE
feat: Wishlist sort/grouping + Gaps progress bars and missing-pills

### DIFF
--- a/BookTracker.Mobile/Pages/SeriesGapsPage.xaml.cs
+++ b/BookTracker.Mobile/Pages/SeriesGapsPage.xaml.cs
@@ -1,5 +1,7 @@
 using BookTracker.Mobile.Cache;
 using BookTracker.Mobile.Theming;
+using Microsoft.Maui.Controls.Shapes;
+using Microsoft.Maui.Layouts;
 
 namespace BookTracker.Mobile.Pages;
 
@@ -76,6 +78,16 @@ public partial class SeriesGapsPage : ContentPage
             return;
         }
 
+        var summary = new Label
+        {
+            Text = gaps.Count == 1 ? "1 series with a gap" : $"{gaps.Count} series with gaps",
+            FontSize = 13,
+            FontAttributes = FontAttributes.Bold,
+            Margin = new Thickness(0, 0, 0, 4),
+        };
+        summary.SetThemeColor(Label.TextColorProperty, "TextMutedL", "TextMutedD");
+        GapsLayout.Children.Add(summary);
+
         foreach (var gap in gaps)
         {
             GapsLayout.Children.Add(BuildGapCard(gap));
@@ -100,19 +112,33 @@ public partial class SeriesGapsPage : ContentPage
         };
         progressLabel.SetThemeColor(Label.TextColorProperty, "TextMutedL", "TextMutedD");
 
-        var missingLabel = new Label
+        // Owned/expected as a bar — green-leather fill on a BarTrack track.
+        var bar = new ProgressBar
         {
-            Text = "Missing " + FormatMissingOrders(gap.MissingOrders),
-            FontSize = 14,
-            FontAttributes = FontAttributes.Bold,
-            LineBreakMode = LineBreakMode.WordWrap,
+            Progress = gap.ExpectedCount > 0
+                ? Math.Clamp((double)gap.OwnedCount / gap.ExpectedCount, 0, 1)
+                : 0,
+            Margin = new Thickness(0, 2, 0, 4),
         };
-        missingLabel.SetThemeColor(Label.TextColorProperty, "LeatherL", "LeatherD");
+        bar.SetThemeColor(ProgressBar.ProgressColorProperty, "GreenL", "GreenD");
+        bar.SetThemeColor(ProgressBar.BackgroundColorProperty, "BarTrackL", "BarTrackD");
+
+        var missingHeader = new Label
+        {
+            Text = "Missing",
+            FontSize = 12,
+            FontAttributes = FontAttributes.Bold,
+        };
+        missingHeader.SetThemeColor(Label.TextColorProperty, "BrassTextL", "BrassTextD");
+
+        var pills = new FlexLayout { Wrap = FlexWrap.Wrap };
+        foreach (var part in MissingParts(gap.MissingOrders))
+            pills.Add(MissingPill(part));
 
         var stack = new VerticalStackLayout
         {
             Spacing = 4,
-            Children = { nameLabel, progressLabel, missingLabel },
+            Children = { nameLabel, progressLabel, bar, missingHeader, pills },
         };
 
         // Card style supplies the themed surface + border + 8 dp radius;
@@ -125,14 +151,31 @@ public partial class SeriesGapsPage : ContentPage
         };
     }
 
-    // Compose "#2, #6" — orders prefixed with # so the row reads as
-    // ordinals. Collapses runs of three or more (#2, #3, #4 → #2-#4)
-    // so a long missing tail (a series the user is way behind on)
-    // doesn't render as a wall of numbers.
-    private static string FormatMissingOrders(IReadOnlyList<int> orders)
+    // Surface chip, brass border + brass text — the design kit's "Series #N"
+    // badge. One per missing slot, or a collapsed range for a long run.
+    private static View MissingPill(string text)
     {
-        if (orders.Count == 0) return "(none)";
+        var label = new Label { Text = text, FontSize = 12, FontAttributes = FontAttributes.Bold };
+        label.SetThemeColor(Label.TextColorProperty, "BrassTextL", "BrassTextD");
 
+        var border = new Border
+        {
+            Padding = new Thickness(8, 3),
+            Margin = new Thickness(0, 0, 6, 6),
+            Stroke = new SolidColorBrush(ThemeColors.Get("Brass")), // Brass is mode-stable
+            StrokeThickness = 1,
+            StrokeShape = new RoundRectangle { CornerRadius = 4 },
+            Content = label,
+        };
+        border.SetThemeColor(Border.BackgroundColorProperty, "SurfaceL", "SurfaceD");
+        return border;
+    }
+
+    // Missing slots as pill captions: a single "#N" per slot, but a run of
+    // three or more collapses to one "#2–#4" range pill so a series the user
+    // is far behind on doesn't render as a wall of pills.
+    private static List<string> MissingParts(IReadOnlyList<int> orders)
+    {
         var parts = new List<string>();
         int i = 0;
         while (i < orders.Count)
@@ -144,9 +187,12 @@ public partial class SeriesGapsPage : ContentPage
                 end = orders[i + 1];
                 i++;
             }
-            parts.Add(end - start >= 2 ? $"#{start}-#{end}" : end == start ? $"#{start}" : $"#{start}, #{end}");
+            if (end - start + 1 >= 3)
+                parts.Add($"#{start}–#{end}");
+            else
+                for (int n = start; n <= end; n++) parts.Add($"#{n}");
             i++;
         }
-        return string.Join(", ", parts);
+        return parts;
     }
 }

--- a/BookTracker.Mobile/Pages/WishlistPage.xaml
+++ b/BookTracker.Mobile/Pages/WishlistPage.xaml
@@ -23,7 +23,7 @@
 
          Child page — system nav bar visible for back navigation. -->
 
-    <Grid RowDefinitions="Auto,Auto,Auto,*" Padding="20,16,20,0">
+    <Grid RowDefinitions="Auto,Auto,Auto,Auto,*" Padding="20,16,20,0">
 
         <Button x:Name="RefreshButton"
                 Grid.Row="0"
@@ -52,7 +52,20 @@
                LineBreakMode="WordWrap"
                Margin="0,8,0,0" />
 
-        <ScrollView Grid.Row="3" Margin="0,12,0,0">
+        <!-- Sort segment (Priority / Author / Series) — shown only with items.
+             Default Priority (with High/Medium/Low group headers). -->
+        <Grid x:Name="SortSegment"
+              Grid.Row="3"
+              Padding="0,12,0,0"
+              ColumnDefinitions="*,*,*"
+              ColumnSpacing="8"
+              IsVisible="False">
+            <Button x:Name="SortPriorityButton" Text="Priority" Clicked="OnSortPriority" HeightRequest="40" CornerRadius="8" FontSize="13" />
+            <Button x:Name="SortAuthorButton" Grid.Column="1" Text="Author" Clicked="OnSortAuthor" HeightRequest="40" CornerRadius="8" FontSize="13" />
+            <Button x:Name="SortSeriesButton" Grid.Column="2" Text="Series" Clicked="OnSortSeries" HeightRequest="40" CornerRadius="8" FontSize="13" />
+        </Grid>
+
+        <ScrollView Grid.Row="4" Margin="0,12,0,0">
             <VerticalStackLayout x:Name="ItemsLayout"
                                  Spacing="8"
                                  Padding="0,0,0,20" />

--- a/BookTracker.Mobile/Pages/WishlistPage.xaml.cs
+++ b/BookTracker.Mobile/Pages/WishlistPage.xaml.cs
@@ -12,12 +12,17 @@ public partial class WishlistPage : ContentPage
     private readonly IApiClient _api;
     private readonly IHttpClientFactory _httpFactory;
 
+    private IReadOnlyList<WishlistItemSnapshot> _items = [];
+    private enum Sort { Priority, Author, Series }
+    private Sort _sort = Sort.Priority;
+
     public WishlistPage(ICatalogCache cache, IApiClient api, IHttpClientFactory httpFactory)
     {
         InitializeComponent();
         _cache = cache;
         _api = api;
         _httpFactory = httpFactory;
+        UpdateSortButtons();
     }
 
     protected override async void OnAppearing()
@@ -33,27 +38,108 @@ public partial class WishlistPage : ContentPage
     {
         try
         {
-            var items = await _cache.GetWishlistAsync();
-            RenderItems(items);
+            _items = await _cache.GetWishlistAsync();
+            Render();
         }
         catch (Exception ex)
         {
+            _items = [];
+            SortSegment.IsVisible = false;
             StatusLabel.Text = $"Couldn't read cached wishlist: {ex.GetType().Name}";
         }
     }
 
-    private void RenderItems(IReadOnlyList<WishlistItemSnapshot> items)
+    private void OnSortPriority(object? sender, EventArgs e) { _sort = Sort.Priority; UpdateSortButtons(); Render(); }
+    private void OnSortAuthor(object? sender, EventArgs e) { _sort = Sort.Author; UpdateSortButtons(); Render(); }
+    private void OnSortSeries(object? sender, EventArgs e) { _sort = Sort.Series; UpdateSortButtons(); Render(); }
+
+    private void Render()
     {
         ItemsLayout.Children.Clear();
-        if (items.Count == 0)
+        SortSegment.IsVisible = _items.Count > 0;
+
+        if (_items.Count == 0)
         {
             StatusLabel.Text = "Wishlist empty. Tap Refresh wishlist to pull from the server, or add books from Bookcase web.";
             return;
         }
-        StatusLabel.Text = $"{items.Count} {(items.Count == 1 ? "book" : "books")} on your wishlist.";
-        foreach (var item in items)
+        StatusLabel.Text = $"{_items.Count} {(_items.Count == 1 ? "book" : "books")} on your wishlist.";
+
+        switch (_sort)
         {
-            ItemsLayout.Children.Add(BuildItemRow(item));
+            case Sort.Priority:
+                // High → Medium → Low(/other) buckets, each titled, rows by title.
+                foreach (var (label, inBucket) in PriorityBuckets)
+                {
+                    var rows = _items.Where(inBucket)
+                        .OrderBy(i => i.Title, StringComparer.OrdinalIgnoreCase)
+                        .ToList();
+                    if (rows.Count == 0) continue;
+                    ItemsLayout.Children.Add(GroupHeader(label));
+                    foreach (var it in rows) ItemsLayout.Children.Add(BuildItemRow(it));
+                }
+                break;
+
+            case Sort.Author:
+                foreach (var it in _items
+                    .OrderBy(i => i.Author, StringComparer.OrdinalIgnoreCase)
+                    .ThenBy(i => i.Title, StringComparer.OrdinalIgnoreCase))
+                    ItemsLayout.Children.Add(BuildItemRow(it));
+                break;
+
+            case Sort.Series:
+                // Series members first, grouped by series and in reading order;
+                // standalone wishlist entries fall to the end, by title.
+                foreach (var it in _items
+                    .OrderBy(i => i.SeriesId is null)
+                    .ThenBy(i => i.SeriesId ?? int.MaxValue)
+                    .ThenBy(i => i.SeriesOrder ?? int.MaxValue)
+                    .ThenBy(i => i.Title, StringComparer.OrdinalIgnoreCase))
+                    ItemsLayout.Children.Add(BuildItemRow(it));
+                break;
+        }
+    }
+
+    // High / Medium / everything-else (Low). "Low" catches any other server
+    // priority string so no row is silently dropped.
+    private static readonly (string Label, Func<WishlistItemSnapshot, bool> InBucket)[] PriorityBuckets =
+    [
+        ("High", i => i.Priority == "High"),
+        ("Medium", i => i.Priority == "Medium"),
+        ("Low", i => i.Priority != "High" && i.Priority != "Medium"),
+    ];
+
+    private Label GroupHeader(string text)
+    {
+        var label = new Label
+        {
+            Text = text,
+            FontSize = 12,
+            FontAttributes = FontAttributes.Bold,
+            Margin = new Thickness(0, 8, 0, 0),
+        };
+        label.SetThemeColor(Label.TextColorProperty, "BrassTextL", "BrassTextD");
+        return label;
+    }
+
+    private void UpdateSortButtons()
+    {
+        Style(SortPriorityButton, _sort == Sort.Priority);
+        Style(SortAuthorButton, _sort == Sort.Author);
+        Style(SortSeriesButton, _sort == Sort.Series);
+
+        static void Style(Button b, bool active)
+        {
+            if (active)
+            {
+                b.BackgroundColor = ThemeColors.Get("Brass");
+                b.TextColor = ThemeColors.Get("InkOnBrass");
+            }
+            else
+            {
+                b.SetThemeColor(Button.BackgroundColorProperty, "SurfaceL", "SurfaceD");
+                b.SetThemeColor(Button.TextColorProperty, "TextMutedL", "TextMutedD");
+            }
         }
     }
 


### PR DESCRIPTION
Wishlist (§6):
- Add a Priority / Author / Series sort segment (default Priority, the decided
  default). Priority view groups under High / Medium / Low headers; Author and
  Series are flat sorts (Series groups members in reading order, standalones
  last). Sort re-renders from the cached list — no re-query.

Gaps (§7):
- Summary line "N series with gaps".
- Each card gains a ProgressBar (green-leather fill on a BarTrack track) and
  renders missing volumes as brass pills instead of a text line — single "#N"
  pills, with runs of 3+ collapsing to one "#2–#4" range pill. (Interquels
  never reach MissingOrders at the data layer, so no numbered-slot risk.)

Builds (MAUI Android, 0 warnings).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
