### PR TITLE
feat: scaffold BookTracker.Application layer (PR0 code)

### DIFF
--- a/BookTracker.Application/BookTracker.Application.csproj
+++ b/BookTracker.Application/BookTracker.Application.csproj
@@ -1,0 +1,42 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Application layer for Bookcase — the single seam between the Blazor
+    host (BookTracker.Web: pages, ViewModels, API endpoints) and the
+    persistence/aggregate layer (BookTracker.Data).
+
+    Owns command + query handlers and read-model DTOs, organised into
+    one folder per feature (Books/, Works/, Series/, ...). See
+    docs/BACKEND-REFACTOR-DESIGN.md for the binding conventions (C1-C9)
+    and the arc plan.
+
+    The point of making this a separate PROJECT rather than a folder is
+    the compiler-enforced seam: Web depends on Application, Application
+    depends on Data — Web cannot reach a DbContext across it except at
+    the composition root. That bounded blast radius is the headline goal.
+
+    EF Core surface (DbContext, Include, AsNoTracking, ...) flows in
+    transitively via the BookTracker.Data reference, which carries
+    Microsoft.EntityFrameworkCore.SqlServer as a public package ref.
+  -->
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- DI extension surface so the host calls one AddApplicationLayer()
+         and every handler self-registers from inside this project. -->
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Aggregates + DbContext live here; Application loads/saves them. -->
+    <ProjectReference Include="..\BookTracker.Data\BookTracker.Data.csproj" />
+    <!-- Wire-format DTOs reused as read-model shapes where they already fit
+         (e.g. the catalog snapshot). -->
+    <ProjectReference Include="..\BookTracker.Shared\BookTracker.Shared.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/BookTracker.Application/DependencyInjection.cs
+++ b/BookTracker.Application/DependencyInjection.cs
@@ -1,0 +1,27 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace BookTracker.Application;
+
+/// <summary>
+/// Single registration entry point for the application layer. The Blazor host
+/// calls <see cref="AddApplicationLayer"/> once; every command/query handler
+/// registers itself from inside this project so adding a feature never touches
+/// <c>ProgramSetup.cs</c> (convention C2 — a feature is one self-contained folder).
+/// </summary>
+public static class DependencyInjection
+{
+    /// <summary>
+    /// Registers the application-layer handlers with the DI container.
+    /// </summary>
+    /// <remarks>
+    /// Empty in PR0 — the scaffold proves the project + DI wiring compile and
+    /// run green before any behaviour rides on top. Handlers land here from the
+    /// Book pilot (PR1) onward. The registration strategy (per-handler vs a
+    /// marker-interface assembly scan) is an open question to settle in PR1;
+    /// see docs/BACKEND-REFACTOR-DESIGN.md.
+    /// </remarks>
+    public static IServiceCollection AddApplicationLayer(this IServiceCollection services)
+    {
+        return services;
+    }
+}

--- a/BookTracker.Web/BookTracker.Web.csproj
+++ b/BookTracker.Web/BookTracker.Web.csproj
@@ -25,6 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\BookTracker.Application\BookTracker.Application.csproj" />
     <ProjectReference Include="..\BookTracker.Data\BookTracker.Data.csproj" />
     <ProjectReference Include="..\BookTracker.Shared\BookTracker.Shared.csproj" />
   </ItemGroup>

--- a/BookTracker.Web/ProgramSetup.cs
+++ b/BookTracker.Web/ProgramSetup.cs
@@ -1,3 +1,4 @@
+using BookTracker.Application;
 using BookTracker.Data;
 using BookTracker.Data.Interceptors;
 using BookTracker.Web.Api;
@@ -122,6 +123,11 @@ public static class ProgramSetup
         });
 
         builder.Services.AddTransient<SeriesMatchService>();
+
+        // Application layer (command/query handlers). Handlers self-register from
+        // inside BookTracker.Application; this host only calls the one extension.
+        // See docs/BACKEND-REFACTOR-DESIGN.md.
+        builder.Services.AddApplicationLayer();
 
         builder.Services.AddScoped<ICatalogSnapshotService, CatalogSnapshotService>();
         builder.Services.AddScoped<IWishlistSnapshotService, WishlistSnapshotService>();

--- a/BookTracker.slnx
+++ b/BookTracker.slnx
@@ -14,6 +14,7 @@
     no MAUI workload required, so they build + test on standard CI
     runners.
   -->
+  <Project Path="BookTracker.Application/BookTracker.Application.csproj" />
   <Project Path="BookTracker.Data/BookTracker.Data.csproj" />
   <Project Path="BookTracker.Mobile.Cache/BookTracker.Mobile.Cache.csproj" />
   <Project Path="BookTracker.Mobile.Cache.Tests/BookTracker.Mobile.Cache.Tests.csproj" />


### PR DESCRIPTION
Empty application-layer project wired into the solution and DI, no behaviour change. The compiler-enforced seam the refactor arc rides on: Web -> Application -> Data. AddApplicationLayer() is the single host call; handlers self-register from inside the project from PR1 onward. See docs/BACKEND-REFACTOR-DESIGN.md.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
