### PR TITLE
refactor: relocate AuthorResolver to the application layer (PR2a)

### DIFF
--- a/BookTracker.Application/Authors/AuthorResolver.cs
+++ b/BookTracker.Application/Authors/AuthorResolver.cs
@@ -2,7 +2,7 @@ using BookTracker.Data;
 using BookTracker.Data.Models;
 using Microsoft.EntityFrameworkCore;
 
-namespace BookTracker.Web.Services;
+namespace BookTracker.Application.Authors;
 
 // Find-or-create entry point used at every Work save site to map the
 // user-entered author-name string to an Author entity. Drew picked
@@ -11,11 +11,11 @@ namespace BookTracker.Web.Services;
 // via the /authors page (mark one as alias of another) or via the
 // follow-up merge UI (TODO.md).
 //
-// Multi-author cutover (PR1 of #14): the batch helpers below take a list
-// of names and produce ordered Author entities + WorkAuthor join rows.
-// Save sites still set Work.Author to the lead (legacy compat) AND
-// populate Work.WorkAuthors with all authors; PR2 will drop Work.AuthorId
-// and switch reads to the join.
+// Lives in the application layer (relocated from Web in the back-end
+// refactor) so command handlers can resolve authors without reaching up
+// into Web. Web ViewModels that still create Works directly (Add / Bulk Add)
+// reference it here until they migrate. Find-or-create has the same
+// check-then-insert race as PublisherResolver — see TECH-DEBT TD-15.
 public static class AuthorResolver
 {
     public static async Task<Author> FindOrCreateAsync(string name, BookTrackerDbContext db, CancellationToken ct = default)

--- a/BookTracker.Tests/Services/AuthorResolverTests.cs
+++ b/BookTracker.Tests/Services/AuthorResolverTests.cs
@@ -1,5 +1,5 @@
+using BookTracker.Application.Authors;
 using BookTracker.Data.Models;
-using BookTracker.Web.Services;
 
 namespace BookTracker.Tests.Services;
 

--- a/BookTracker.Web/ViewModels/BookAddViewModel.cs
+++ b/BookTracker.Web/ViewModels/BookAddViewModel.cs
@@ -1,3 +1,4 @@
+using BookTracker.Application.Authors;
 using BookTracker.Data;
 using BookTracker.Data.Models;
 using BookTracker.Web.Services;

--- a/BookTracker.Web/ViewModels/BookDetailViewModel.cs
+++ b/BookTracker.Web/ViewModels/BookDetailViewModel.cs
@@ -1,4 +1,5 @@
 using BookTracker.Application;
+using BookTracker.Application.Authors;
 using BookTracker.Application.Books;
 using BookTracker.Data;
 using BookTracker.Data.Models;

--- a/BookTracker.Web/ViewModels/BulkAddViewModel.cs
+++ b/BookTracker.Web/ViewModels/BulkAddViewModel.cs
@@ -1,3 +1,4 @@
+using BookTracker.Application.Authors;
 using BookTracker.Data;
 using BookTracker.Data.Models;
 using BookTracker.Web.Services;

--- a/BookTracker.Web/ViewModels/WishlistViewModel.cs
+++ b/BookTracker.Web/ViewModels/WishlistViewModel.cs
@@ -1,3 +1,4 @@
+using BookTracker.Application.Authors;
 using BookTracker.Data;
 using BookTracker.Data.Models;
 using BookTracker.Shared.Catalog;

--- a/BookTracker.Web/ViewModels/WorkEditDialogViewModel.cs
+++ b/BookTracker.Web/ViewModels/WorkEditDialogViewModel.cs
@@ -1,3 +1,4 @@
+using BookTracker.Application.Authors;
 using BookTracker.Data;
 using BookTracker.Data.Models;
 using BookTracker.Web.Services;


### PR DESCRIPTION
Pure move, no behaviour change: AuthorResolver goes from BookTracker.Web/Services to BookTracker.Application/Authors so the upcoming Works command handlers can resolve authors without reaching up into Web. Only depends on Data types, so the move is clean.

Callers (BookDetail/WorkEdit/BookAdd/BulkAdd/Wishlist VMs + AuthorResolverTests) get the new using; BulkAdd.razor only names it in a comment, so it's untouched. Full suite: 558 passed, 1 skipped — unchanged from before the move.

Next (PR2b): AssignAuthors' logic moves onto the Work aggregate as AssignAuthorship, and the Works handlers build on this.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
