### PR TITLE
feat: Work aggregate (ref-count lifecycle) + Works command handlers (PR2b)

### DIFF
--- a/BookTracker.Application/Authors/AuthorResolver.cs
+++ b/BookTracker.Application/Authors/AuthorResolver.cs
@@ -68,60 +68,7 @@ public static class AuthorResolver
             .ToList();
     }
 
-    /// <summary>
-    /// Replace Work.WorkAuthors with one Author-role join row per author
-    /// (Order ascending from 0), optionally followed by non-Author contributor
-    /// rows. Each non-Author role gets its own Order sequence (per-role) so
-    /// "first translator" and "first illustrator" both sit at Order 0 within
-    /// their role bucket. Caller is responsible for ensuring authors and
-    /// contributor people come from FindOrCreate* (so brand-new ones are
-    /// already attached to the DbContext) and for SaveChangesAsync.
-    /// Editor-only Works (e.g. dictionaries) are valid — at least one
-    /// contributor of any role must be supplied across the two lists.
-    /// </summary>
-    public static void AssignAuthors(
-        Work work,
-        IReadOnlyList<Author> authors,
-        IReadOnlyList<(Author Person, AuthorRole Role)>? additionalContributors = null)
-    {
-        var hasNonAuthor = additionalContributors is { Count: > 0 }
-            && additionalContributors.Any(c => c.Role != AuthorRole.Author);
-        if (authors.Count == 0 && !hasNonAuthor)
-        {
-            throw new ArgumentException("At least one contributor required (author, editor, or other role).", nameof(authors));
-        }
-
-        work.WorkAuthors.Clear();
-        for (var i = 0; i < authors.Count; i++)
-        {
-            work.WorkAuthors.Add(new WorkAuthor
-            {
-                Author = authors[i],
-                Order = i,
-                Role = AuthorRole.Author,
-            });
-        }
-
-        if (additionalContributors is null || additionalContributors.Count == 0) return;
-
-        // Per-role Order sequencing and (Author, Role) dedup. Reference-equality
-        // dedup on Author works because callers route every name through
-        // FindOrCreate* against the same DbContext — identical names produce
-        // identical Author instances.
-        var orderByRole = new Dictionary<AuthorRole, int>();
-        var seen = new HashSet<(Author Person, AuthorRole Role)>();
-        foreach (var (person, role) in additionalContributors)
-        {
-            if (role == AuthorRole.Author) continue;       // belongs in the main list
-            if (!seen.Add((person, role))) continue;       // duplicate (Author, Role) pair
-            var next = orderByRole.GetValueOrDefault(role, 0);
-            work.WorkAuthors.Add(new WorkAuthor
-            {
-                Author = person,
-                Order = next,
-                Role = role,
-            });
-            orderByRole[role] = next + 1;
-        }
-    }
+    // NOTE: the former AssignAuthors(work, authors, contributors) now lives on
+    // the Work aggregate as Work.AssignAuthorship (the ≥1-contributor invariant
+    // belongs on the aggregate). Resolve names here, then call work.AssignAuthorship.
 }

--- a/BookTracker.Application/Books/DeleteBook.cs
+++ b/BookTracker.Application/Books/DeleteBook.cs
@@ -1,4 +1,5 @@
 using BookTracker.Data;
+using BookTracker.Data.Models;
 using Microsoft.EntityFrameworkCore;
 
 namespace BookTracker.Application.Books;
@@ -6,7 +7,9 @@ namespace BookTracker.Application.Books;
 /// <summary>Soft-deletes a Book. The Book row survives as a tombstone
 /// (DeletedAt stamped, hidden by the global query filter) so the catalog
 /// snapshot can emit it in deletedIds[]; its Editions (and Copies via cascade)
-/// are hard-removed, and the Work/Tag join rows are cleared.</summary>
+/// are hard-removed, and its Tag joins cleared. Works are detached via the
+/// ref-count lifecycle — a Work left in no other book is orphaned and deleted,
+/// a Work still on another book survives detached.</summary>
 public sealed record DeleteBook(int BookId) : ICommand;
 
 public sealed class DeleteBookHandler(IDbContextFactory<BookTrackerDbContext> dbFactory)
@@ -18,13 +21,20 @@ public sealed class DeleteBookHandler(IDbContextFactory<BookTrackerDbContext> db
         var book = await db.Books
             .Include(b => b.Editions)
             .Include(b => b.Tags)
-            .Include(b => b.Works)
+            .Include(b => b.Works).ThenInclude(w => w.Books)   // Work ref counts
             .FirstOrDefaultAsync(b => b.Id == command.BookId, ct)
             ?? throw new NotFoundException($"Book {command.BookId} not found.");
 
-        // SoftDelete() owns the whole operation — orphan-removes the Editions
-        // (Copies cascade), clears the Work/Tag joins, stamps the tombstone.
-        // The Includes above load the children so EF tracks the removals.
+        // Detach the book's Works; any Work now in no book (ref count 0) is
+        // orphaned and deleted — the same lifecycle RemoveWorkFromBook uses, so
+        // deleting a book takes its exclusive Works with it but leaves shared ones.
+        var orphaned = new List<Work>();
+        foreach (var work in book.Works.ToList())
+            if (work.RemoveFrom(book)) orphaned.Add(work);
+        if (orphaned.Count > 0) db.Works.RemoveRange(orphaned);
+
+        // SoftDelete() orphan-removes the Editions (Copies cascade), clears the
+        // Tag joins, and stamps the tombstone.
         book.SoftDelete();
 
         await db.SaveChangesAsync(ct);

--- a/BookTracker.Application/Works/AttachWorkToBook.cs
+++ b/BookTracker.Application/Works/AttachWorkToBook.cs
@@ -1,0 +1,28 @@
+using BookTracker.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookTracker.Application.Works;
+
+/// <summary>Attaches an existing Work to a Book it also appears in. Returns the
+/// Work's title on success, or null when the book/work is gone or the Work is
+/// already on this book (soft outcomes — the search filter normally prevents the
+/// last case, but stale dialog state can leak through).</summary>
+public sealed record AttachWorkToBook(int BookId, int WorkId) : ICommand<string?>;
+
+public sealed class AttachWorkToBookHandler(IDbContextFactory<BookTrackerDbContext> dbFactory)
+    : ICommandHandler<AttachWorkToBook, string?>
+{
+    public async Task<string?> HandleAsync(AttachWorkToBook command, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var book = await db.Books.FindAsync([command.BookId], ct);
+        if (book is null) return null;
+
+        var work = await db.Works.Include(w => w.Books).FirstOrDefaultAsync(w => w.Id == command.WorkId, ct);
+        if (work is null) return null;
+
+        if (!work.AppearsIn(book)) return null; // already on this book
+        await db.SaveChangesAsync(ct);
+        return work.Title;
+    }
+}

--- a/BookTracker.Application/Works/AttachWorksToBook.cs
+++ b/BookTracker.Application/Works/AttachWorksToBook.cs
@@ -1,0 +1,113 @@
+using BookTracker.Application.Authors;
+using BookTracker.Data;
+using BookTracker.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookTracker.Application.Works;
+
+/// <summary>Attaches a batch of new + existing Works to a Book in one save — the
+/// compendium flow (a captured single-Work book turns out to be an N-story
+/// anthology). Single-author / single-genre modes apply a shared author/genre
+/// set to every new row. Returns the count of Works actually attached (already-
+/// attached existing rows are skipped silently). Throws
+/// <see cref="InvalidOperationException"/> with a user-facing message when there
+/// are no usable rows, or a new row carries a title but no contributor.</summary>
+public sealed record AttachWorksToBook(
+    int BookId,
+    IReadOnlyList<WorkRow> Rows,
+    bool SingleAuthor,
+    bool SingleGenre,
+    IReadOnlyList<string> SharedAuthors,
+    IReadOnlyList<int> SharedGenreIds) : ICommand<int>;
+
+public sealed class AttachWorksToBookHandler(IDbContextFactory<BookTrackerDbContext> dbFactory)
+    : ICommandHandler<AttachWorksToBook, int>
+{
+    public async Task<int> HandleAsync(AttachWorksToBook command, CancellationToken ct = default)
+    {
+        IReadOnlyList<string> AuthorsFor(WorkRow row) => command.SingleAuthor ? command.SharedAuthors : row.Authors;
+        IReadOnlyList<int> GenresFor(WorkRow row) => command.SingleGenre ? command.SharedGenreIds : row.GenreIds;
+
+        // Filter to rows that carry usable content. A row with a title but no
+        // contributors goes through to the per-row throw below (named so the
+        // user sees which row is the problem).
+        var orderedRows = command.Rows
+            .Where(r => r.AttachedWorkId is not null || !string.IsNullOrWhiteSpace(r.Title))
+            .ToList();
+        if (orderedRows.Count == 0)
+            throw new InvalidOperationException(
+                "Add at least one work — type a title for a new work, or pick an existing one from the dropdown.");
+
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var book = await db.Books.Include(b => b.Works).FirstOrDefaultAsync(b => b.Id == command.BookId, ct);
+        if (book is null) return 0;
+
+        var alreadyAttachedIds = book.Works.Select(w => w.Id).ToHashSet();
+        var newRows = orderedRows.Where(r => r.AttachedWorkId is null).ToList();
+        var attachIds = orderedRows
+            .Where(r => r.AttachedWorkId is int)
+            .Select(r => r.AttachedWorkId!.Value)
+            .Distinct()
+            .ToList();
+
+        // Single-pass name resolution so a person credited on multiple rows
+        // resolves to one Author entity.
+        var allNames = (command.SingleAuthor ? command.SharedAuthors : newRows.SelectMany(r => r.Authors))
+            .Concat(newRows.SelectMany(r => r.Contributors.Select(c => c.Name)));
+        var allAuthors = await AuthorResolver.FindOrCreateAllAsync(allNames, db, ct);
+        var byName = allAuthors.ToDictionary(a => a.Name, StringComparer.OrdinalIgnoreCase);
+
+        var allGenreIds = (command.SingleGenre ? command.SharedGenreIds : newRows.SelectMany(r => r.GenreIds))
+            .Distinct()
+            .ToList();
+        var genres = await CreateWorkOnBookHandler.ResolveGenresAsync(db, allGenreIds, ct);
+        var genresById = genres.ToDictionary(g => g.Id);
+
+        var attachedWorks = attachIds.Count == 0
+            ? []
+            : await db.Works.Where(w => attachIds.Contains(w.Id)).ToListAsync(ct);
+        var attachedById = attachedWorks.ToDictionary(w => w.Id);
+
+        var attachedCount = 0;
+        foreach (var row in orderedRows)
+        {
+            if (row.AttachedWorkId is int existingId)
+            {
+                if (alreadyAttachedIds.Contains(existingId)) continue;       // already on this book — silent skip
+                if (!attachedById.TryGetValue(existingId, out var existing)) continue; // deleted between pick + save
+                book.Works.Add(existing);
+                alreadyAttachedIds.Add(existingId);
+                attachedCount++;
+                continue;
+            }
+
+            var rowAuthors = AuthorsFor(row)
+                .Select(n => n?.Trim())
+                .Where(n => !string.IsNullOrEmpty(n))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Select(n => byName[n!])
+                .ToList();
+            var rowContributors = row.Contributors
+                .Where(c => !string.IsNullOrWhiteSpace(c.Name) && byName.ContainsKey(c.Name.Trim()))
+                .Select(c => (Person: byName[c.Name.Trim()], c.Role))
+                .ToList();
+            if (rowAuthors.Count == 0 && rowContributors.Count == 0)
+                throw new InvalidOperationException(
+                    $"Work \"{row.Title}\" needs at least one contributor (author, editor, or other role).");
+
+            var rowGenres = GenresFor(row)
+                .Distinct()
+                .Where(genresById.ContainsKey)
+                .Select(id => genresById[id])
+                .ToList();
+
+            var work = Work.Create(book, row.Title!, row.Subtitle, row.FirstPublished, row.Precision, rowAuthors, rowContributors);
+            work.SetGenres(rowGenres);
+            db.Works.Add(work);
+            attachedCount++;
+        }
+
+        await db.SaveChangesAsync(ct);
+        return attachedCount;
+    }
+}

--- a/BookTracker.Application/Works/CreateWorkOnBook.cs
+++ b/BookTracker.Application/Works/CreateWorkOnBook.cs
@@ -1,0 +1,53 @@
+using BookTracker.Application.Authors;
+using BookTracker.Data;
+using BookTracker.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookTracker.Application.Works;
+
+/// <summary>Creates a new Work and attaches it to a Book as its first appearance.
+/// Returns the new Work's id, or null when the book is gone or no contributor of
+/// any role was supplied (a silent no-op, matching the dialog guard).</summary>
+public sealed record CreateWorkOnBook(
+    int BookId,
+    string Title,
+    string? Subtitle,
+    IReadOnlyList<string> AuthorNames,
+    IReadOnlyList<ContributorInput> Contributors,
+    DateOnly? FirstPublished,
+    DatePrecision Precision,
+    IReadOnlyList<int> GenreIds) : ICommand<int?>;
+
+public sealed class CreateWorkOnBookHandler(IDbContextFactory<BookTrackerDbContext> dbFactory)
+    : ICommandHandler<CreateWorkOnBook, int?>
+{
+    public async Task<int?> HandleAsync(CreateWorkOnBook command, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var book = await db.Books.FindAsync([command.BookId], ct);
+        if (book is null) return null;
+
+        var authors = await AuthorResolver.FindOrCreateAllAsync(command.AuthorNames, db, ct);
+        var contributors = new List<(Author Person, AuthorRole Role)>();
+        foreach (var c in command.Contributors)
+        {
+            if (string.IsNullOrWhiteSpace(c.Name)) continue;
+            contributors.Add((await AuthorResolver.FindOrCreateAsync(c.Name, db, ct), c.Role));
+        }
+        if (authors.Count == 0 && contributors.Count == 0) return null; // nothing to credit — soft no-op
+
+        var genres = await ResolveGenresAsync(db, command.GenreIds, ct);
+        var work = Work.Create(book, command.Title, command.Subtitle,
+            command.FirstPublished, command.Precision, authors, contributors);
+        work.SetGenres(genres);
+        db.Works.Add(work);
+        await db.SaveChangesAsync(ct);
+        return work.Id;
+    }
+
+    internal static async Task<List<Genre>> ResolveGenresAsync(
+        BookTrackerDbContext db, IReadOnlyList<int> genreIds, CancellationToken ct) =>
+        genreIds.Count == 0
+            ? []
+            : await db.Genres.Where(g => genreIds.Contains(g.Id)).ToListAsync(ct);
+}

--- a/BookTracker.Application/Works/RemoveWorkFromBook.cs
+++ b/BookTracker.Application/Works/RemoveWorkFromBook.cs
@@ -1,0 +1,31 @@
+using BookTracker.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookTracker.Application.Works;
+
+/// <summary>Removes a Work from a Book. If the Work now appears in no books
+/// (orphaned) it is deleted outright — the ref-count lifecycle the Work aggregate
+/// owns. Returns the Work's title, or null when the book/work is gone or the Work
+/// wasn't on this book.</summary>
+public sealed record RemoveWorkFromBook(int BookId, int WorkId) : ICommand<string?>;
+
+public sealed class RemoveWorkFromBookHandler(IDbContextFactory<BookTrackerDbContext> dbFactory)
+    : ICommandHandler<RemoveWorkFromBook, string?>
+{
+    public async Task<string?> HandleAsync(RemoveWorkFromBook command, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var book = await db.Books.FindAsync([command.BookId], ct);
+        if (book is null) return null;
+
+        var work = await db.Works.Include(w => w.Books).FirstOrDefaultAsync(w => w.Id == command.WorkId, ct);
+        if (work is null) return null;
+        if (!work.Books.Any(b => b.Id == command.BookId)) return null; // not on this book
+
+        var title = work.Title;
+        if (work.RemoveFrom(book))      // last book removed → orphaned
+            db.Works.Remove(work);      // EF cascades WorkAuthors + clears Genre/Book joins
+        await db.SaveChangesAsync(ct);
+        return title;
+    }
+}

--- a/BookTracker.Application/Works/UpdateWork.cs
+++ b/BookTracker.Application/Works/UpdateWork.cs
@@ -1,0 +1,57 @@
+using BookTracker.Application.Authors;
+using BookTracker.Data;
+using BookTracker.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookTracker.Application.Works;
+
+/// <summary>Updates an existing Work's fields (the Work-edit dialog): title,
+/// subtitle, authorship, first-published date, series membership + order, and
+/// genres. Dates and the series-order label arrive already parsed (the VM owns
+/// the free-text parsing). Series membership targets an existing Series by id —
+/// Series entity ops live in the Series feature.</summary>
+public sealed record UpdateWork(
+    int WorkId,
+    string Title,
+    string? Subtitle,
+    IReadOnlyList<string> AuthorNames,
+    IReadOnlyList<ContributorInput> Contributors,
+    DateOnly? FirstPublished,
+    DatePrecision Precision,
+    IReadOnlyList<int> GenreIds,
+    int? SeriesId,
+    int? SeriesOrder,
+    string? SeriesOrderDisplay) : ICommand;
+
+public sealed class UpdateWorkHandler(IDbContextFactory<BookTrackerDbContext> dbFactory)
+    : ICommandHandler<UpdateWork>
+{
+    public async Task HandleAsync(UpdateWork command, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var work = await db.Works
+            .Include(w => w.WorkAuthors)
+            .Include(w => w.Genres)
+            .FirstOrDefaultAsync(w => w.Id == command.WorkId, ct)
+            ?? throw new NotFoundException($"Work {command.WorkId} not found.");
+
+        var authors = await AuthorResolver.FindOrCreateAllAsync(command.AuthorNames, db, ct);
+        var contributors = new List<(Author Person, AuthorRole Role)>();
+        foreach (var c in command.Contributors)
+        {
+            if (string.IsNullOrWhiteSpace(c.Name)) continue;
+            contributors.Add((await AuthorResolver.FindOrCreateAsync(c.Name, db, ct), c.Role));
+        }
+
+        work.UpdateDetails(command.Title, command.Subtitle);
+        work.AssignAuthorship(authors, contributors);
+        work.SetFirstPublished(command.FirstPublished, command.Precision);
+        if (command.SeriesId is int seriesId)
+            work.AssignToSeries(seriesId, command.SeriesOrder, command.SeriesOrderDisplay);
+        else
+            work.ClearSeries();
+        work.SetGenres(await CreateWorkOnBookHandler.ResolveGenresAsync(db, command.GenreIds, ct));
+
+        await db.SaveChangesAsync(ct);
+    }
+}

--- a/BookTracker.Application/Works/WorkInputs.cs
+++ b/BookTracker.Application/Works/WorkInputs.cs
@@ -1,0 +1,22 @@
+using BookTracker.Data.Models;
+
+namespace BookTracker.Application.Works;
+
+/// <summary>A non-Author contributor (editor, translator, …) on a Work, by name +
+/// role. The handler resolves the name to an Author via AuthorResolver.</summary>
+public sealed record ContributorInput(string Name, AuthorRole Role);
+
+/// <summary>One row of the "attach multiple works" compendium flow: either an
+/// existing Work to attach (<see cref="AttachedWorkId"/> set) or a new Work to
+/// create from its fields. Dates/orders arrive already parsed (the VM owns the
+/// free-text parsing). Application-side contract so no Web VM type crosses the
+/// boundary (convention C3).</summary>
+public sealed record WorkRow(
+    int? AttachedWorkId,
+    string? Title,
+    string? Subtitle,
+    DateOnly? FirstPublished,
+    DatePrecision Precision,
+    IReadOnlyList<string> Authors,
+    IReadOnlyList<ContributorInput> Contributors,
+    IReadOnlyList<int> GenreIds);

--- a/BookTracker.Data/Models/Book.cs
+++ b/BookTracker.Data/Models/Book.cs
@@ -154,18 +154,17 @@ public class Book
     }
 
     /// <summary>Soft-deletes the book: hard-removes the Editions (their Copies
-    /// cascade), clears the Work/Tag join rows, and stamps the tombstone. The
-    /// husk row survives, hidden by the global query filter, so the delta-sync
-    /// endpoint can emit it in <c>deletedIds[]</c>. The handler need only load
-    /// the children (so EF tracks the removals) and save.</summary>
+    /// cascade), clears the Tag join rows, and stamps the tombstone. The husk row
+    /// survives, hidden by the global query filter, so the delta-sync endpoint can
+    /// emit it in <c>deletedIds[]</c>. Works are NOT touched here — they're a
+    /// shared aggregate with a ref-count lifecycle, so DeleteBookHandler detaches
+    /// them and deletes any that become orphaned.</summary>
     public void SoftDelete()
     {
         // Severing the required Book→Edition relationship orphan-deletes each
         // Edition (and its Copies cascade at the DB level) — same mechanism
-        // RemoveCopy already relies on. Keeps the whole soft-delete on the
-        // aggregate rather than splitting it with the handler.
+        // RemoveCopy already relies on.
         Editions.Clear();
-        Works.Clear();
         Tags.Clear();
         DeletedAt = DateTime.UtcNow;
     }

--- a/BookTracker.Data/Models/Work.cs
+++ b/BookTracker.Data/Models/Work.cs
@@ -56,4 +56,120 @@ public class Work
     public string? SeriesOrderDisplay { get; set; }
 
     public List<Book> Books { get; set; } = [];
+
+    // --- Aggregate behaviour -------------------------------------------------
+    // A Work is the durable creative unit; it OWNS its Book↔Work membership and
+    // self-manages its lifecycle by ref count. Invariant: a Work appears in at
+    // least one Book — it's created with its first book (the factory below) and
+    // is orphaned (the caller deletes it) when its last book is removed. The
+    // authorship invariant (≥1 contributor) lives on AssignAuthorship.
+    // See docs/BACKEND-REFACTOR-DESIGN.md. (Collection setters stay public until
+    // the C7 lock-down.)
+
+    /// <summary>Creates a Work attached to its first Book (ref count starts at 1),
+    /// with title, optional subtitle/date, and authorship. Title is required;
+    /// authorship needs ≥1 contributor.</summary>
+    public static Work Create(
+        Book firstBook,
+        string title,
+        string? subtitle,
+        DateOnly? firstPublished,
+        DatePrecision firstPublishedPrecision,
+        IReadOnlyList<Author> authors,
+        IReadOnlyList<(Author Person, AuthorRole Role)>? contributors = null)
+    {
+        var work = new Work();
+        work.UpdateDetails(title, subtitle);
+        work.SetFirstPublished(firstPublished, firstPublishedPrecision);
+        work.AssignAuthorship(authors, contributors);
+        work.Books.Add(firstBook);
+        return work;
+    }
+
+    public void UpdateDetails(string title, string? subtitle)
+    {
+        if (string.IsNullOrWhiteSpace(title))
+            throw new DomainRuleException("Title is required.");
+        Title = title.Trim();
+        Subtitle = subtitle.TrimToNull();
+    }
+
+    public void SetFirstPublished(DateOnly? date, DatePrecision precision)
+    {
+        FirstPublishedDate = date;
+        FirstPublishedDatePrecision = precision;
+    }
+
+    /// <summary>Associates this Work with another Book it also appears in. No-op
+    /// if already associated. Returns true when newly attached.</summary>
+    public bool AppearsIn(Book book)
+    {
+        if (Books.Any(b => b.Id == book.Id)) return false;
+        Books.Add(book);
+        return true;
+    }
+
+    /// <summary>Removes this Work from a Book. Returns true when the Work now
+    /// appears in no books (orphaned) and the caller should delete it.</summary>
+    public bool RemoveFrom(Book book)
+    {
+        var existing = Books.FirstOrDefault(b => b.Id == book.Id);
+        if (existing is not null) Books.Remove(existing);
+        return Books.Count == 0;
+    }
+
+    public void SetGenres(IReadOnlyList<Genre> genres)
+    {
+        Genres.Clear();
+        foreach (var g in genres) Genres.Add(g);
+    }
+
+    public void AssignToSeries(int seriesId, int? order, string? orderDisplay)
+    {
+        SeriesId = seriesId;
+        SeriesOrder = order;
+        SeriesOrderDisplay = orderDisplay;
+    }
+
+    public void ClearSeries()
+    {
+        SeriesId = null;
+        SeriesOrder = null;
+        SeriesOrderDisplay = null;
+    }
+
+    /// <summary>Rebuilds WorkAuthors: one Author-role row per author (Order 0+),
+    /// then per-role contributor rows (each role its own Order sequence). Requires
+    /// ≥1 contributor across both lists — editor-only Works (dictionaries) are
+    /// valid. Authors/contributors must already be attached to the context
+    /// (resolve via AuthorResolver first). Was AuthorResolver.AssignAuthors.</summary>
+    public void AssignAuthorship(
+        IReadOnlyList<Author> authors,
+        IReadOnlyList<(Author Person, AuthorRole Role)>? additionalContributors = null)
+    {
+        var hasNonAuthor = additionalContributors is { Count: > 0 }
+            && additionalContributors.Any(c => c.Role != AuthorRole.Author);
+        if (authors.Count == 0 && !hasNonAuthor)
+            throw new DomainRuleException("A work needs at least one contributor (author, editor, or other role).");
+
+        WorkAuthors.Clear();
+        for (var i = 0; i < authors.Count; i++)
+            WorkAuthors.Add(new WorkAuthor { Author = authors[i], Order = i, Role = AuthorRole.Author });
+
+        if (additionalContributors is null || additionalContributors.Count == 0) return;
+
+        // Per-role Order sequencing + (Author, Role) dedup. Reference dedup works
+        // because callers route every name through FindOrCreate* against one
+        // context, so identical names are the same Author instance.
+        var orderByRole = new Dictionary<AuthorRole, int>();
+        var seen = new HashSet<(Author Person, AuthorRole Role)>();
+        foreach (var (person, role) in additionalContributors)
+        {
+            if (role == AuthorRole.Author) continue;
+            if (!seen.Add((person, role))) continue;
+            var next = orderByRole.GetValueOrDefault(role, 0);
+            WorkAuthors.Add(new WorkAuthor { Author = person, Order = next, Role = role });
+            orderByRole[role] = next + 1;
+        }
+    }
 }

--- a/BookTracker.Tests/Application/Books/BookCommandHandlersTests.cs
+++ b/BookTracker.Tests/Application/Books/BookCommandHandlersTests.cs
@@ -259,6 +259,30 @@ public class BookCommandHandlersTests
     }
 
     [Fact]
+    public async Task DeleteBook_deletesExclusiveWorks_butKeepsSharedOnes()
+    {
+        int bookA, exclusiveId, sharedId;
+        await using (var db = _factory.CreateDbContext())
+        {
+            var exclusive = new Work { Title = "Exclusive", WorkAuthors = { new WorkAuthor { Author = new Author { Name = "X" }, Order = 0, Role = AuthorRole.Author } } };
+            var shared = new Work { Title = "Shared", WorkAuthors = { new WorkAuthor { Author = new Author { Name = "Y" }, Order = 0, Role = AuthorRole.Author } } };
+            var a = new Book { Title = "A", Works = { exclusive, shared } };
+            var b = new Book { Title = "B", Works = { shared } };
+            db.Books.AddRange(a, b);
+            await db.SaveChangesAsync();
+            bookA = a.Id; exclusiveId = exclusive.Id; sharedId = shared.Id;
+        }
+
+        await new DeleteBookHandler(_factory).HandleAsync(new DeleteBook(bookA));
+
+        await using var verify = _factory.CreateDbContext();
+        Assert.Null(await verify.Works.FindAsync(exclusiveId)); // orphaned → deleted with the book
+        var survivor = await verify.Works.Include(w => w.Books).FirstOrDefaultAsync(w => w.Id == sharedId);
+        Assert.NotNull(survivor);          // still on book B → survives
+        Assert.Single(survivor!.Books);
+    }
+
+    [Fact]
     public async Task SetEditionCover_persists()
     {
         var id = await SeedBookAsync();

--- a/BookTracker.Tests/Application/Works/WorkCommandHandlersTests.cs
+++ b/BookTracker.Tests/Application/Works/WorkCommandHandlersTests.cs
@@ -1,0 +1,208 @@
+using BookTracker.Application;
+using BookTracker.Application.Works;
+using BookTracker.Data.Models;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace BookTracker.Tests;
+
+// Integration tests for the Works command handlers against the SQL container.
+[Trait("Category", TestCategories.Integration)]
+public class WorkCommandHandlersTests
+{
+    private readonly TestDbContextFactory _factory = new();
+
+    private async Task<(int bookId, int workId)> SeedBookWithWorkAsync(string title = "Mort")
+    {
+        await using var db = _factory.CreateDbContext();
+        var work = new Work
+        {
+            Title = title,
+            WorkAuthors = { new WorkAuthor { Author = new Author { Name = "Pratchett" }, Order = 0, Role = AuthorRole.Author } },
+        };
+        var book = new Book { Title = "Book", Works = { work } };
+        db.Books.Add(book);
+        await db.SaveChangesAsync();
+        return (book.Id, work.Id);
+    }
+
+    private async Task<int> SeedBareBookAsync(string title = "Bare")
+    {
+        await using var db = _factory.CreateDbContext();
+        var book = new Book { Title = title };
+        db.Books.Add(book);
+        await db.SaveChangesAsync();
+        return book.Id;
+    }
+
+    [Fact]
+    public async Task AttachWorkToBook_attachesExistingWork_toASecondBook()
+    {
+        var (_, workId) = await SeedBookWithWorkAsync("Shared Story");
+        var targetBook = await SeedBareBookAsync("Compendium");
+
+        var title = await new AttachWorkToBookHandler(_factory).HandleAsync(new AttachWorkToBook(targetBook, workId));
+
+        Assert.Equal("Shared Story", title);
+        await using var db = _factory.CreateDbContext();
+        var work = await db.Works.Include(w => w.Books).FirstAsync(w => w.Id == workId);
+        Assert.Equal(2, work.Books.Count); // now on both books
+    }
+
+    [Fact]
+    public async Task AttachWorkToBook_alreadyOnBook_returnsNull()
+    {
+        var (bookId, workId) = await SeedBookWithWorkAsync();
+        var result = await new AttachWorkToBookHandler(_factory).HandleAsync(new AttachWorkToBook(bookId, workId));
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task RemoveWorkFromBook_exclusiveWork_deletesIt()
+    {
+        var (bookId, workId) = await SeedBookWithWorkAsync();
+
+        var title = await new RemoveWorkFromBookHandler(_factory).HandleAsync(new RemoveWorkFromBook(bookId, workId));
+
+        Assert.Equal("Mort", title);
+        await using var db = _factory.CreateDbContext();
+        Assert.Null(await db.Works.FindAsync(workId)); // orphaned → deleted
+    }
+
+    [Fact]
+    public async Task RemoveWorkFromBook_sharedWork_keepsItOnTheOtherBook()
+    {
+        int bookA, workId;
+        await using (var db = _factory.CreateDbContext())
+        {
+            var work = new Work
+            {
+                Title = "Shared",
+                WorkAuthors = { new WorkAuthor { Author = new Author { Name = "A" }, Order = 0, Role = AuthorRole.Author } },
+            };
+            var a = new Book { Title = "A", Works = { work } };
+            var b = new Book { Title = "B", Works = { work } };
+            db.Books.AddRange(a, b);
+            await db.SaveChangesAsync();
+            bookA = a.Id; workId = work.Id;
+        }
+
+        await new RemoveWorkFromBookHandler(_factory).HandleAsync(new RemoveWorkFromBook(bookA, workId));
+
+        await using var verify = _factory.CreateDbContext();
+        var survivor = await verify.Works.Include(w => w.Books).FirstOrDefaultAsync(w => w.Id == workId);
+        Assert.NotNull(survivor);              // not orphaned — survives
+        Assert.Single(survivor!.Books);
+    }
+
+    [Fact]
+    public async Task CreateWorkOnBook_createsWorkAttachedWithAuthorAndGenre()
+    {
+        var bookId = await SeedBareBookAsync();
+        int genreId;
+        await using (var db = _factory.CreateDbContext())
+        {
+            var g = new Genre { Name = "Fantasy" };
+            db.Genres.Add(g);
+            await db.SaveChangesAsync();
+            genreId = g.Id;
+        }
+
+        var workId = await new CreateWorkOnBookHandler(_factory).HandleAsync(new CreateWorkOnBook(
+            bookId, "New Story", "A Subtitle", ["Brand New Author"], [],
+            new DateOnly(2001, 1, 1), DatePrecision.Year, [genreId]));
+
+        Assert.NotNull(workId);
+        await using var verify = _factory.CreateDbContext();
+        var work = await verify.Works
+            .Include(w => w.Books)
+            .Include(w => w.WorkAuthors).ThenInclude(wa => wa.Author)
+            .Include(w => w.Genres)
+            .FirstAsync(w => w.Id == workId);
+        Assert.Equal("New Story", work.Title);
+        Assert.Contains(work.Books, b => b.Id == bookId);          // born attached
+        Assert.Equal("Brand New Author", work.WorkAuthors.Single().Author.Name);
+        Assert.Contains(work.Genres, g => g.Id == genreId);
+    }
+
+    [Fact]
+    public async Task CreateWorkOnBook_noContributors_returnsNull_andCreatesNothing()
+    {
+        var bookId = await SeedBareBookAsync();
+
+        var workId = await new CreateWorkOnBookHandler(_factory).HandleAsync(new CreateWorkOnBook(
+            bookId, "Orphan", null, [], [], null, DatePrecision.Day, []));
+
+        Assert.Null(workId);
+        await using var db = _factory.CreateDbContext();
+        Assert.Empty(db.Works);
+    }
+
+    [Fact]
+    public async Task UpdateWork_persistsTitleAuthorAndSeries()
+    {
+        var (_, workId) = await SeedBookWithWorkAsync();
+        int seriesId;
+        await using (var db = _factory.CreateDbContext())
+        {
+            var s = new Series { Name = "Discworld", Type = SeriesType.Series };
+            db.Series.Add(s);
+            await db.SaveChangesAsync();
+            seriesId = s.Id;
+        }
+
+        await new UpdateWorkHandler(_factory).HandleAsync(new UpdateWork(
+            workId, "Mort (revised)", null, ["Terry Pratchett"], [],
+            null, DatePrecision.Day, [], seriesId, 4, null));
+
+        await using var verify = _factory.CreateDbContext();
+        var work = await verify.Works.Include(w => w.WorkAuthors).ThenInclude(wa => wa.Author).FirstAsync(w => w.Id == workId);
+        Assert.Equal("Mort (revised)", work.Title);
+        Assert.Equal("Terry Pratchett", work.WorkAuthors.Single().Author.Name);
+        Assert.Equal(seriesId, work.SeriesId);
+        Assert.Equal(4, work.SeriesOrder);
+    }
+
+    [Fact]
+    public async Task UpdateWork_missing_throwsNotFound()
+    {
+        await Assert.ThrowsAsync<NotFoundException>(() =>
+            new UpdateWorkHandler(_factory).HandleAsync(new UpdateWork(
+                424242, "x", null, ["A"], [], null, DatePrecision.Day, [], null, null, null)));
+    }
+
+    [Fact]
+    public async Task AttachWorksToBook_mixOfNewAndExisting_attachesAll()
+    {
+        var (_, existingWorkId) = await SeedBookWithWorkAsync("Apt Pupil");
+        var targetBook = await SeedBareBookAsync("Four Past Midnight");
+
+        var rows = new List<WorkRow>
+        {
+            new(null, "The Library Policeman", null, null, DatePrecision.Day, ["Stephen King"], [], []),
+            new(existingWorkId, "Apt Pupil", null, null, DatePrecision.Day, [], [], []),
+        };
+
+        var count = await new AttachWorksToBookHandler(_factory).HandleAsync(
+            new AttachWorksToBook(targetBook, rows, SingleAuthor: false, SingleGenre: false, SharedAuthors: [], SharedGenreIds: []));
+
+        Assert.Equal(2, count);
+        await using var db = _factory.CreateDbContext();
+        var book = await db.Books.Include(b => b.Works).FirstAsync(b => b.Id == targetBook);
+        Assert.Equal(2, book.Works.Count);
+        Assert.Contains(book.Works, w => w.Id == existingWorkId);
+        Assert.Contains(book.Works, w => w.Title == "The Library Policeman");
+    }
+
+    [Fact]
+    public async Task AttachWorksToBook_allBlankRows_throwsUserFacing()
+    {
+        var bookId = await SeedBareBookAsync();
+        var rows = new List<WorkRow> { new(null, "   ", null, null, DatePrecision.Day, [], [], []) };
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            new AttachWorksToBookHandler(_factory).HandleAsync(
+                new AttachWorksToBook(bookId, rows, false, false, [], [])));
+        Assert.Contains("at least one work", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/BookTracker.Tests/Domain/BookAggregateTests.cs
+++ b/BookTracker.Tests/Domain/BookAggregateTests.cs
@@ -151,20 +151,24 @@ public class BookAggregateTests
     }
 
     [Fact]
-    public void SoftDelete_clearsJoinsAndStampsTombstone()
+    public void SoftDelete_clearsTagsAndEditionsAndStampsTombstone_butLeavesWorksToTheHandler()
     {
         var book = new Book
         {
             Title = "X",
             Works = { new Work { Title = "W" } },
             Tags = { new Tag { Name = "t" } },
+            Editions = { new Edition { Copies = { new Copy() } } },
         };
 
         book.SoftDelete();
 
-        Assert.Empty(book.Works);
         Assert.Empty(book.Tags);
+        Assert.Empty(book.Editions);
         Assert.NotNull(book.DeletedAt);
+        // Works are a shared, ref-counted aggregate — SoftDelete leaves them; the
+        // DeleteBookHandler detaches and orphan-deletes them.
+        Assert.Single(book.Works);
     }
 
     [Fact]

--- a/BookTracker.Tests/Domain/WorkAggregateTests.cs
+++ b/BookTracker.Tests/Domain/WorkAggregateTests.cs
@@ -1,0 +1,212 @@
+using BookTracker.Data;
+using BookTracker.Data.Models;
+using Xunit;
+
+namespace BookTracker.Tests;
+
+// Pure domain unit tests for the Work aggregate — no EF, no container. Covers the
+// ref-count relationship (Create/AppearsIn/RemoveFrom), the field methods, and
+// AssignAuthorship (the authorship-building logic that moved off AuthorResolver).
+[Trait("Category", TestCategories.Unit)]
+public class WorkAggregateTests
+{
+    // --- Lifecycle / relationship -------------------------------------------
+
+    [Fact]
+    public void Create_bornAttachedToFirstBook_withFieldsAndAuthorship()
+    {
+        var book = new Book { Id = 1, Title = "B" };
+        var author = new Author { Name = "Le Guin" };
+
+        var work = Work.Create(book, "  A Wizard of Earthsea  ", "  ", new DateOnly(1968, 1, 1), DatePrecision.Year, [author]);
+
+        Assert.Equal("A Wizard of Earthsea", work.Title);
+        Assert.Null(work.Subtitle); // blank → null
+        Assert.Equal(new DateOnly(1968, 1, 1), work.FirstPublishedDate);
+        Assert.Equal(DatePrecision.Year, work.FirstPublishedDatePrecision);
+        Assert.Single(work.Books);
+        Assert.Same(book, work.Books[0]);          // ref count starts at 1
+        var wa = Assert.Single(work.WorkAuthors);
+        Assert.Equal(AuthorRole.Author, wa.Role);
+        Assert.Same(author, wa.Author);
+    }
+
+    [Fact]
+    public void Create_blankTitle_throws()
+    {
+        var book = new Book { Id = 1 };
+        Assert.Throws<DomainRuleException>(() =>
+            Work.Create(book, "  ", null, null, DatePrecision.Day, [new Author { Name = "A" }]));
+    }
+
+    [Fact]
+    public void Create_noContributors_throws()
+    {
+        var book = new Book { Id = 1 };
+        Assert.Throws<DomainRuleException>(() =>
+            Work.Create(book, "T", null, null, DatePrecision.Day, []));
+    }
+
+    [Fact]
+    public void AppearsIn_addsBook_andIsIdempotent()
+    {
+        var b1 = new Book { Id = 1 };
+        var b2 = new Book { Id = 2 };
+        var work = Work.Create(b1, "T", null, null, DatePrecision.Day, [new Author { Name = "A" }]);
+
+        Assert.True(work.AppearsIn(b2));
+        Assert.Equal(2, work.Books.Count);
+        Assert.False(work.AppearsIn(b2)); // already there → no-op
+        Assert.Equal(2, work.Books.Count);
+    }
+
+    [Fact]
+    public void RemoveFrom_lastBook_reportsOrphaned()
+    {
+        var b1 = new Book { Id = 1 };
+        var work = Work.Create(b1, "T", null, null, DatePrecision.Day, [new Author { Name = "A" }]);
+
+        var orphaned = work.RemoveFrom(b1);
+
+        Assert.True(orphaned);          // ref count hit 0
+        Assert.Empty(work.Books);
+    }
+
+    [Fact]
+    public void RemoveFrom_whenOnOtherBooks_isNotOrphaned()
+    {
+        var b1 = new Book { Id = 1 };
+        var b2 = new Book { Id = 2 };
+        var work = Work.Create(b1, "T", null, null, DatePrecision.Day, [new Author { Name = "A" }]);
+        work.AppearsIn(b2);
+
+        var orphaned = work.RemoveFrom(b1);
+
+        Assert.False(orphaned);
+        Assert.Single(work.Books);
+        Assert.Equal(2, work.Books[0].Id);
+    }
+
+    // --- Field methods -------------------------------------------------------
+
+    [Fact]
+    public void UpdateDetails_blankTitle_throws()
+    {
+        var work = new Work { Title = "old" };
+        Assert.Throws<DomainRuleException>(() => work.UpdateDetails("   ", null));
+    }
+
+    [Fact]
+    public void AssignToSeries_then_ClearSeries()
+    {
+        var work = new Work { Title = "T" };
+        work.AssignToSeries(7, 4, "4.5");
+        Assert.Equal(7, work.SeriesId);
+        Assert.Equal(4, work.SeriesOrder);
+        Assert.Equal("4.5", work.SeriesOrderDisplay);
+
+        work.ClearSeries();
+        Assert.Null(work.SeriesId);
+        Assert.Null(work.SeriesOrder);
+        Assert.Null(work.SeriesOrderDisplay);
+    }
+
+    [Fact]
+    public void SetGenres_replacesTheCollection()
+    {
+        var work = new Work { Title = "T", Genres = { new Genre { Id = 1, Name = "Old" } } };
+        var fantasy = new Genre { Id = 2, Name = "Fantasy" };
+        work.SetGenres([fantasy]);
+        Assert.Single(work.Genres);
+        Assert.Same(fantasy, work.Genres[0]);
+    }
+
+    // --- AssignAuthorship (moved from AuthorResolver.AssignAuthors) ----------
+
+    [Fact]
+    public void AssignAuthorship_writesAuthorsWithOrder()
+    {
+        var work = new Work { Title = "Relic" };
+        var preston = new Author { Name = "Preston" };
+        var child = new Author { Name = "Child" };
+
+        work.AssignAuthorship([preston, child]);
+
+        Assert.Equal(2, work.WorkAuthors.Count);
+        Assert.Same(preston, work.WorkAuthors[0].Author);
+        Assert.Equal(0, work.WorkAuthors[0].Order);
+        Assert.Same(child, work.WorkAuthors[1].Author);
+        Assert.Equal(1, work.WorkAuthors[1].Order);
+    }
+
+    [Fact]
+    public void AssignAuthorship_noContributors_throwsDomainRule()
+    {
+        var work = new Work { Title = "x" };
+        Assert.Throws<DomainRuleException>(() => work.AssignAuthorship([]));
+        Assert.Throws<DomainRuleException>(() => work.AssignAuthorship([], additionalContributors: []));
+    }
+
+    [Fact]
+    public void AssignAuthorship_editorOnly_isValid()
+    {
+        var work = new Work { Title = "Oxford Companion to Wine" };
+        var robinson = new Author { Name = "Jancis Robinson" };
+
+        work.AssignAuthorship([], [(robinson, AuthorRole.Editor)]);
+
+        var sole = Assert.Single(work.WorkAuthors);
+        Assert.Equal(AuthorRole.Editor, sole.Role);
+        Assert.Same(robinson, sole.Author);
+        Assert.Equal(0, sole.Order);
+    }
+
+    [Fact]
+    public void AssignAuthorship_contributorsGetPerRoleOrderFromZero()
+    {
+        var work = new Work { Title = "The Hobbit" };
+        var tolkien = new Author { Name = "Tolkien" };
+        var sergio = new Author { Name = "Sergio Cariello" };
+        var mauss = new Author { Name = "Doug Mauss" };
+
+        work.AssignAuthorship([tolkien], [(sergio, AuthorRole.Illustrator), (mauss, AuthorRole.Editor)]);
+
+        Assert.Equal(3, work.WorkAuthors.Count);
+        Assert.Equal(0, work.WorkAuthors.Single(wa => wa.Role == AuthorRole.Author).Order);
+        Assert.Equal(0, work.WorkAuthors.Single(wa => wa.Role == AuthorRole.Illustrator).Order);
+        Assert.Equal(0, work.WorkAuthors.Single(wa => wa.Role == AuthorRole.Editor).Order);
+    }
+
+    [Fact]
+    public void AssignAuthorship_allowsSamePersonInMultipleRoles()
+    {
+        var work = new Work { Title = "The Hobbit" };
+        var tolkien = new Author { Name = "Tolkien" };
+
+        work.AssignAuthorship([tolkien], [(tolkien, AuthorRole.Illustrator)]);
+
+        Assert.Equal(2, work.WorkAuthors.Count);
+        Assert.Contains(work.WorkAuthors, wa => wa.Role == AuthorRole.Author && wa.Author == tolkien);
+        Assert.Contains(work.WorkAuthors, wa => wa.Role == AuthorRole.Illustrator && wa.Author == tolkien);
+    }
+
+    [Fact]
+    public void AssignAuthorship_dedupsContributorPairsWithinRole_andSkipsAuthorRole()
+    {
+        var work = new Work { Title = "x" };
+        var asimov = new Author { Name = "Asimov" };
+        var pohl = new Author { Name = "Pohl" };
+
+        work.AssignAuthorship([asimov],
+        [
+            (pohl, AuthorRole.Editor),
+            (pohl, AuthorRole.Editor),       // duplicate (person, role) → one row
+            (pohl, AuthorRole.Translator),   // different role → kept
+            (asimov, AuthorRole.Author),     // Role=Author in contributors → skipped
+        ]);
+
+        Assert.Single(work.WorkAuthors, wa => wa.Author == pohl && wa.Role == AuthorRole.Editor);
+        Assert.Single(work.WorkAuthors, wa => wa.Author == pohl && wa.Role == AuthorRole.Translator);
+        Assert.Single(work.WorkAuthors, wa => wa.Role == AuthorRole.Author); // just asimov, no dupe
+    }
+}

--- a/BookTracker.Tests/Services/AuthorResolverTests.cs
+++ b/BookTracker.Tests/Services/AuthorResolverTests.cs
@@ -3,6 +3,9 @@ using BookTracker.Data.Models;
 
 namespace BookTracker.Tests.Services;
 
+// AuthorResolver's own surface: name parsing + find-or-create. The authorship-
+// building tests (formerly AssignAuthors) moved to WorkAggregateTests when that
+// logic became Work.AssignAuthorship.
 [Trait("Category", TestCategories.Integration)]
 public class AuthorResolverTests
 {
@@ -65,148 +68,5 @@ public class AuthorResolverTests
         // blank entry is dropped.
         Assert.Single(authors);
         Assert.Equal("Tolkien", authors[0].Name);
-    }
-
-    [Fact]
-    public async Task AssignAuthors_DualWritesLeadAndJoinWithOrder()
-    {
-        // Direct unit test of the helper — independent of the surrounding
-        // VM save paths so a regression in AssignAuthors surfaces here.
-        await using var db = _factory.CreateDbContext();
-        var preston = new Author { Name = "Preston" };
-        var child = new Author { Name = "Child" };
-        db.Authors.AddRange(preston, child);
-
-        var work = new Work { Title = "Relic" };
-
-        AuthorResolver.AssignAuthors(work, [preston, child]);
-
-        Assert.Equal(2, work.WorkAuthors.Count);
-        Assert.Equal(preston, work.WorkAuthors[0].Author);
-        Assert.Equal(0, work.WorkAuthors[0].Order);
-        Assert.Equal(child, work.WorkAuthors[1].Author);
-        Assert.Equal(1, work.WorkAuthors[1].Order);
-    }
-
-    [Fact]
-    public void AssignAuthors_NoAuthorsAndNoContributors_Throws()
-    {
-        // Editor-only Works are legal (dictionaries, anthologies), but a Work
-        // with zero contributors of any role is not.
-        var work = new Work { Title = "x" };
-        Assert.Throws<ArgumentException>(() => AuthorResolver.AssignAuthors(work, []));
-        Assert.Throws<ArgumentException>(() =>
-            AuthorResolver.AssignAuthors(work, [], additionalContributors: []));
-    }
-
-    [Fact]
-    public void AssignAuthors_EditorOnly_NoAuthors_WritesContributorRow()
-    {
-        // Dictionary / Oxford Companion case — no Author, just an Editor.
-        // Previously rejected; the relax in 2026-05-24 made this legal.
-        var work = new Work { Title = "Oxford Companion to Wine" };
-        var robinson = new Author { Name = "Jancis Robinson" };
-
-        AuthorResolver.AssignAuthors(
-            work,
-            authors: [],
-            additionalContributors: [(robinson, AuthorRole.Editor)]);
-
-        var sole = Assert.Single(work.WorkAuthors);
-        Assert.Equal(AuthorRole.Editor, sole.Role);
-        Assert.Equal(robinson, sole.Author);
-        Assert.Equal(0, sole.Order);
-    }
-
-    [Fact]
-    public void AssignAuthors_appends_contributors_with_per_role_order_starting_at_zero()
-    {
-        var work = new Work { Title = "The Hobbit" };
-        var tolkien = new Author { Name = "Tolkien" };
-        var sergio = new Author { Name = "Sergio Cariello" };
-        var mauss  = new Author { Name = "Doug Mauss" };
-
-        AuthorResolver.AssignAuthors(
-            work,
-            authors: [tolkien],
-            additionalContributors:
-            [
-                (sergio, AuthorRole.Illustrator),
-                (mauss,  AuthorRole.Editor),
-            ]);
-
-        // 1 Author row + 2 non-Author rows = 3 total.
-        Assert.Equal(3, work.WorkAuthors.Count);
-
-        var author = work.WorkAuthors.Single(wa => wa.Role == AuthorRole.Author);
-        Assert.Equal(tolkien, author.Author);
-        Assert.Equal(0, author.Order);
-
-        var illustrator = work.WorkAuthors.Single(wa => wa.Role == AuthorRole.Illustrator);
-        Assert.Equal(sergio, illustrator.Author);
-        Assert.Equal(0, illustrator.Order); // per-role Order resets to 0
-
-        var editor = work.WorkAuthors.Single(wa => wa.Role == AuthorRole.Editor);
-        Assert.Equal(mauss, editor.Author);
-        Assert.Equal(0, editor.Order); // per-role Order resets to 0
-    }
-
-    [Fact]
-    public void AssignAuthors_allows_same_person_in_multiple_roles()
-    {
-        // Tolkien is both Author and Illustrator on *The Hobbit* — the
-        // composite PK (WorkId, AuthorId, Role) makes this legal, and the
-        // resolver should write both rows.
-        var work = new Work { Title = "The Hobbit" };
-        var tolkien = new Author { Name = "Tolkien" };
-
-        AuthorResolver.AssignAuthors(
-            work,
-            authors: [tolkien],
-            additionalContributors: [(tolkien, AuthorRole.Illustrator)]);
-
-        Assert.Equal(2, work.WorkAuthors.Count);
-        Assert.Contains(work.WorkAuthors, wa => wa.Role == AuthorRole.Author && wa.Author == tolkien);
-        Assert.Contains(work.WorkAuthors, wa => wa.Role == AuthorRole.Illustrator && wa.Author == tolkien);
-    }
-
-    [Fact]
-    public void AssignAuthors_dedups_contributor_pairs_within_role()
-    {
-        // Same (Person, Role) pair appearing twice — should write one row.
-        var work = new Work { Title = "x" };
-        var asimov = new Author { Name = "Asimov" };
-        var pohl = new Author { Name = "Pohl" };
-
-        AuthorResolver.AssignAuthors(
-            work,
-            authors: [asimov],
-            additionalContributors:
-            [
-                (pohl, AuthorRole.Editor),
-                (pohl, AuthorRole.Editor), // duplicate of above
-                (pohl, AuthorRole.Translator), // different role, kept
-            ]);
-
-        Assert.Single(work.WorkAuthors, wa => wa.Author == pohl && wa.Role == AuthorRole.Editor);
-        Assert.Single(work.WorkAuthors, wa => wa.Author == pohl && wa.Role == AuthorRole.Translator);
-    }
-
-    [Fact]
-    public void AssignAuthors_skips_contributors_with_role_author()
-    {
-        // Role=Author in the contributors list is a no-op (belongs in the
-        // main authors list). The resolver silently skips so callers don't
-        // accidentally double-write the lead author.
-        var work = new Work { Title = "x" };
-        var asimov = new Author { Name = "Asimov" };
-
-        AuthorResolver.AssignAuthors(
-            work,
-            authors: [asimov],
-            additionalContributors: [(asimov, AuthorRole.Author)]);
-
-        Assert.Single(work.WorkAuthors);
-        Assert.Equal(AuthorRole.Author, work.WorkAuthors[0].Role);
     }
 }

--- a/BookTracker.Web/ViewModels/BookAddViewModel.cs
+++ b/BookTracker.Web/ViewModels/BookAddViewModel.cs
@@ -605,7 +605,7 @@ public class BookAddViewModel(
                         FirstPublishedDatePrecision = rowFirstPub.Precision,
                         Genres = rowGenres,
                     };
-                    AuthorResolver.AssignAuthors(w, rowAuthors, rowContributors);
+                    w.AssignAuthorship(rowAuthors, rowContributors);
                     works.Add(w);
                 }
             }
@@ -626,7 +626,7 @@ public class BookAddViewModel(
                     FirstPublishedDatePrecision = firstPub.Precision,
                     Genres = selectedGenres,
                 };
-                AuthorResolver.AssignAuthors(work, authors, contributors);
+                work.AssignAuthorship(authors, contributors);
 
                 // Attach to the accepted series, if any. AcceptedSeriesId points at
                 // an existing local Series row; AcceptedSeriesName (without an Id)

--- a/BookTracker.Web/ViewModels/BookDetailViewModel.cs
+++ b/BookTracker.Web/ViewModels/BookDetailViewModel.cs
@@ -356,7 +356,7 @@ public class BookDetailViewModel(
             FirstPublishedDatePrecision = firstPub.Precision,
             Genres = genres,
         };
-        AuthorResolver.AssignAuthors(work, authors, resolvedContributors);
+        work.AssignAuthorship(authors, resolvedContributors);
 
         book.Works.Add(work);
         await db.SaveChangesAsync();
@@ -498,7 +498,7 @@ public class BookDetailViewModel(
                 FirstPublishedDatePrecision = rowFirstPub.Precision,
                 Genres = rowGenres,
             };
-            AuthorResolver.AssignAuthors(work, rowAuthors, rowContributors);
+            work.AssignAuthorship(rowAuthors, rowContributors);
             book.Works.Add(work);
             attachedCount++;
         }

--- a/BookTracker.Web/ViewModels/BulkAddViewModel.cs
+++ b/BookTracker.Web/ViewModels/BulkAddViewModel.cs
@@ -216,7 +216,7 @@ public class BulkAddViewModel(
             Subtitle = row.Subtitle,
         };
         // Dual-write: Work.Author = lead (legacy compat); Work.WorkAuthors = all.
-        AuthorResolver.AssignAuthors(work, authors);
+        work.AssignAuthorship(authors);
 
         // Series attachment if the user accepted the suggestion on this row.
         // Mirrors BookAddViewModel.SaveAsync: existing local series wins via

--- a/BookTracker.Web/ViewModels/WishlistViewModel.cs
+++ b/BookTracker.Web/ViewModels/WishlistViewModel.cs
@@ -523,7 +523,7 @@ public class WishlistViewModel(
 
         var author = await AuthorResolver.FindOrCreateAsync(item.Author, db);
         var work = new Work { Title = item.Title };
-        AuthorResolver.AssignAuthors(work, [author]);
+        work.AssignAuthorship([author]);
         var book = new Book
         {
             Title = item.Title,

--- a/BookTracker.Web/ViewModels/WorkEditDialogViewModel.cs
+++ b/BookTracker.Web/ViewModels/WorkEditDialogViewModel.cs
@@ -114,7 +114,7 @@ public class WorkEditDialogViewModel(IDbContextFactory<BookTrackerDbContext> dbF
             contributors.Add((person, entry.Role));
         }
         if (authors.Count == 0 && contributors.Count == 0) return;
-        AuthorResolver.AssignAuthors(work, authors, contributors);
+        work.AssignAuthorship(authors, contributors);
 
         var parsed = PartialDateParser.TryParse(FirstPublishedDate) ?? PartialDate.Empty;
         work.FirstPublishedDate = parsed.Date;


### PR DESCRIPTION
Makes Work a rich aggregate that OWNS its Book<->Work relationship and self-manages its lifecycle by ref count (Drew's call at the API-shape review): a Work is born attached to its first book (Work.Create), gains/loses books via AppearsIn/RemoveFrom, and is orphaned (deleted) when its last book is removed. AuthorResolver.AssignAuthors' logic moves onto the aggregate as Work.AssignAuthorship (the >=1-contributor invariant belongs there); all 7 callers repointed (the formerly-scattered helper).

Five Works handlers in BookTracker.Application/Works: AttachWorkToBook, RemoveWorkFromBook, CreateWorkOnBook, UpdateWork, and the compendium batch AttachWorksToBook (mixed new/existing rows, single-author/genre modes). Commands carry Application-side ContributorInput/WorkRow records (C3) and structured dates/orders (the VM parses).

DeleteBook now honours the ref count: deleting a book takes its EXCLUSIVE works with it but leaves shared ones (fixing a latent inconsistency where DeleteBook orphaned works while RemoveWorkFromBook deleted them). SoftDelete no longer touches Works.

Tests: WorkAggregateTests (unit — lifecycle + the AssignAuthorship tests moved off AuthorResolver) + WorkCommandHandlersTests (integration) + a DeleteBook orphan-cleanup test. Full suite: 577 passed, 1 skipped. No UI adoption yet (PR2c/2d).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
