### PR TITLE
refactor: adopt UpdateWork in WorkEditDialogViewModel (PR2d)

### DIFF
--- a/BookTracker.Tests/ViewModels/WorkEditDialogViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/WorkEditDialogViewModelTests.cs
@@ -11,7 +11,7 @@ public class WorkEditDialogViewModelTests
     public async Task InitializeAsync_MissingId_MarksNotFound()
     {
         var factory = new TestDbContextFactory();
-        var vm = new WorkEditDialogViewModel(factory);
+        var vm = new WorkEditDialogViewModel(factory, TestDispatcher.For(factory));
 
         await vm.InitializeAsync(999);
 
@@ -41,7 +41,7 @@ public class WorkEditDialogViewModelTests
             workId = work.Id;
         }
 
-        var vm = new WorkEditDialogViewModel(factory);
+        var vm = new WorkEditDialogViewModel(factory, TestDispatcher.For(factory));
         await vm.InitializeAsync(workId);
 
         Assert.False(vm.NotFound);
@@ -71,7 +71,7 @@ public class WorkEditDialogViewModelTests
             workId = work.Id;
         }
 
-        var vm = new WorkEditDialogViewModel(factory);
+        var vm = new WorkEditDialogViewModel(factory, TestDispatcher.For(factory));
         await vm.InitializeAsync(workId);
         vm.Title = "  Mort  ";
         vm.Subtitle = "A Discworld Novel";
@@ -105,7 +105,7 @@ public class WorkEditDialogViewModelTests
             existingAuthorId = a1.Id;
         }
 
-        var vm = new WorkEditDialogViewModel(factory);
+        var vm = new WorkEditDialogViewModel(factory, TestDispatcher.For(factory));
         await vm.InitializeAsync(workId);
         vm.AuthorNames = ["Terry Pratchett"];
         await vm.SaveAsync();
@@ -129,7 +129,7 @@ public class WorkEditDialogViewModelTests
             workId = work.Id;
         }
 
-        var vm = new WorkEditDialogViewModel(factory);
+        var vm = new WorkEditDialogViewModel(factory, TestDispatcher.For(factory));
         await vm.InitializeAsync(workId);
         vm.AuthorNames = ["Brand New Author"];
         await vm.SaveAsync();
@@ -158,7 +158,7 @@ public class WorkEditDialogViewModelTests
             workId = work.Id;
         }
 
-        var vm = new WorkEditDialogViewModel(factory);
+        var vm = new WorkEditDialogViewModel(factory, TestDispatcher.For(factory));
         await vm.InitializeAsync(workId);
         vm.SelectedSeriesId = null;
         await vm.SaveAsync();
@@ -190,7 +190,7 @@ public class WorkEditDialogViewModelTests
             fantasyId = fantasy.Id;
         }
 
-        var vm = new WorkEditDialogViewModel(factory);
+        var vm = new WorkEditDialogViewModel(factory, TestDispatcher.For(factory));
         await vm.InitializeAsync(workId);
 
         Assert.Single(vm.SelectedGenreIds);
@@ -222,7 +222,7 @@ public class WorkEditDialogViewModelTests
             horrorId = horror.Id;
         }
 
-        var vm = new WorkEditDialogViewModel(factory);
+        var vm = new WorkEditDialogViewModel(factory, TestDispatcher.For(factory));
         await vm.InitializeAsync(workId);
         // Swap selection: drop Fantasy, add Horror.
         vm.SelectedGenreIds = [horrorId];
@@ -251,7 +251,7 @@ public class WorkEditDialogViewModelTests
             workId = work.Id;
         }
 
-        var vm = new WorkEditDialogViewModel(factory);
+        var vm = new WorkEditDialogViewModel(factory, TestDispatcher.For(factory));
         await vm.InitializeAsync(workId);
         var results = (await vm.SearchAuthorsAsync("Pratch", CancellationToken.None)).ToList();
 

--- a/BookTracker.Web/Components/Shared/WorkEditDialog.razor
+++ b/BookTracker.Web/Components/Shared/WorkEditDialog.razor
@@ -3,6 +3,7 @@
    series + order, and genres (via MudGenrePicker — PR B). *@
 
 @inject WorkEditDialogViewModel VM
+@inject ISnackbar Snackbar
 
 <MudDialog>
     <DialogContent>
@@ -99,6 +100,10 @@
         {
             await VM.SaveAsync();
             MudDialog.Close(DialogResult.Ok(true));
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Couldn't save: {ex.Message}", Severity.Error);
         }
         finally
         {

--- a/BookTracker.Web/ViewModels/WorkEditDialogViewModel.cs
+++ b/BookTracker.Web/ViewModels/WorkEditDialogViewModel.cs
@@ -1,4 +1,5 @@
-using BookTracker.Application.Authors;
+using BookTracker.Application;
+using BookTracker.Application.Works;
 using BookTracker.Data;
 using BookTracker.Data.Models;
 using BookTracker.Web.Services;
@@ -10,7 +11,9 @@ namespace BookTracker.Web.ViewModels;
 // Work's title, subtitle, author (find-or-create with typeahead), first
 // published date (PartialDateParser), series membership + order, and
 // genres (via MudGenrePicker — PR B).
-public class WorkEditDialogViewModel(IDbContextFactory<BookTrackerDbContext> dbFactory)
+public class WorkEditDialogViewModel(
+    IDbContextFactory<BookTrackerDbContext> dbFactory,
+    IDispatcher dispatcher)
 {
     public bool NotFound { get; private set; }
     public int WorkId { get; private set; }
@@ -95,49 +98,28 @@ public class WorkEditDialogViewModel(IDbContextFactory<BookTrackerDbContext> dbF
     {
         if (NotFound || string.IsNullOrWhiteSpace(Title) || AuthorNames.All(string.IsNullOrWhiteSpace)) return;
 
-        await using var db = await dbFactory.CreateDbContextAsync();
-        var work = await db.Works
-            .Include(w => w.WorkAuthors).ThenInclude(wa => wa.Author)
-            .Include(w => w.Genres)
-            .FirstOrDefaultAsync(w => w.Id == WorkId);
-        if (work is null) return;
-
-        work.Title = Title.Trim();
-        work.Subtitle = string.IsNullOrWhiteSpace(Subtitle) ? null : Subtitle.Trim();
-
-        var authors = await AuthorResolver.FindOrCreateAllAsync(AuthorNames, db);
-        var contributors = new List<(Author Person, AuthorRole Role)>();
-        foreach (var entry in Contributors)
-        {
-            if (string.IsNullOrWhiteSpace(entry.Name)) continue;
-            var person = await AuthorResolver.FindOrCreateAsync(entry.Name, db);
-            contributors.Add((person, entry.Role));
-        }
-        if (authors.Count == 0 && contributors.Count == 0) return;
-        work.AssignAuthorship(authors, contributors);
-
         var parsed = PartialDateParser.TryParse(FirstPublishedDate) ?? PartialDate.Empty;
-        work.FirstPublishedDate = parsed.Date;
-        work.FirstPublishedDatePrecision = parsed.Precision;
-
-        work.SeriesId = SelectedSeriesId;
+        int? seriesOrder = null;
+        string? seriesOrderDisplay = null;
         if (SelectedSeriesId.HasValue)
-        {
-            (work.SeriesOrder, work.SeriesOrderDisplay) = SeriesOrderParser.Parse(SeriesOrderInput);
-        }
-        else
-        {
-            work.SeriesOrder = null;
-            work.SeriesOrderDisplay = null;
-        }
+            (seriesOrder, seriesOrderDisplay) = SeriesOrderParser.Parse(SeriesOrderInput);
 
-        // Reconcile Genres to match the selection. Load requested genres
-        // by id and replace the work's collection.
-        var desired = await db.Genres.Where(g => SelectedGenreIds.Contains(g.Id)).ToListAsync();
-        work.Genres.Clear();
-        foreach (var g in desired) work.Genres.Add(g);
+        var contributorInputs = Contributors
+            .Where(c => !string.IsNullOrWhiteSpace(c.Name))
+            .Select(c => new ContributorInput(c.Name, c.Role))
+            .ToList();
 
-        await db.SaveChangesAsync();
+        try
+        {
+            await dispatcher.Send(new UpdateWork(
+                WorkId, Title, Subtitle, AuthorNames, contributorInputs,
+                parsed.Date, parsed.Precision, SelectedGenreIds,
+                SelectedSeriesId, seriesOrder, seriesOrderDisplay));
+        }
+        catch (NotFoundException)
+        {
+            // Work deleted between opening the dialog and saving — no-op.
+        }
     }
 
     public record SeriesOption(int Id, string Name, SeriesType Type);


### PR DESCRIPTION
The work-edit dialog now dispatches UpdateWork instead of inline EF. The VM keeps its guards + the free-text parsing (date via PartialDateParser, series-order via SeriesOrderParser) and maps contributors to the Application ContributorInput record, then dispatches; the handler resolves authors, applies the field methods, and reconciles genres/series. NotFoundException is swallowed (dialog isn't page-wrapped).

Also hardened WorkEditDialog.razor's save wrapper with catch+snackbar (inject ISnackbar) to match the Book-pilot dialogs from the arc review — it was the last save dialog on try/finally with no catch.

VM signatures unchanged; the 8 WorkEditDialog tests pass through the new path (behaviour-preserving), incl. author find-or-create reuse and clear-series-clears-order. Full suite: 577 passed, 1 skipped. This completes PR2 (the Work feature) — all Work writes on existing books now route through the dispatcher; the Add flows stay deferred.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
