### PR TITLE
feat(series): Series aggregate + command handlers (PR3a)

### DIFF
--- a/BookTracker.Application/Series/AddWorkToSeries.cs
+++ b/BookTracker.Application/Series/AddWorkToSeries.cs
@@ -1,0 +1,31 @@
+using BookTracker.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookTracker.Application.Series;
+
+/// <summary>Adds an existing Work to a Series from the series-management page,
+/// landing it at the end of the running order (one past the current max). Routes
+/// through the Work aggregate, which owns its series membership. Soft no-op if
+/// the Work was deleted between picking it and saving.</summary>
+public sealed record AddWorkToSeries(int SeriesId, int WorkId) : ICommand;
+
+public sealed class AddWorkToSeriesHandler(IDbContextFactory<BookTrackerDbContext> dbFactory)
+    : ICommandHandler<AddWorkToSeries>
+{
+    public async Task HandleAsync(AddWorkToSeries command, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var work = await db.Works.FindAsync([command.WorkId], ct);
+        if (work is null) return; // gone between pick + save
+
+        // Next slot = one past the highest order already in the series (1-based),
+        // so the work appends to the end. Works with a null order count as 0, so
+        // a series of all-unordered works yields 1 — matching the old VM calc.
+        var maxOrder = await db.Works
+            .Where(w => w.SeriesId == command.SeriesId)
+            .MaxAsync(w => (int?)w.SeriesOrder, ct) ?? 0;
+
+        work.AssignToSeries(command.SeriesId, maxOrder + 1, orderDisplay: null);
+        await db.SaveChangesAsync(ct);
+    }
+}

--- a/BookTracker.Application/Series/CreateSeries.cs
+++ b/BookTracker.Application/Series/CreateSeries.cs
@@ -1,0 +1,36 @@
+using BookTracker.Data;
+using BookTracker.Data.Models;
+using Microsoft.EntityFrameworkCore;
+// The feature folder is Series/, so the namespace below collides with the
+// Series *type* (unlike Works/Work, where the plural folder dodges it). Alias
+// the entity wherever its static surface is needed.
+using SeriesAggregate = BookTracker.Data.Models.Series;
+
+namespace BookTracker.Application.Series;
+
+/// <summary>Creates a new Series (or Collection). The ExpectedCount/Type
+/// invariant is enforced by the aggregate; name uniqueness by the handler.
+/// Returns the new Series' id. Throws <see cref="DomainRuleException"/> on a
+/// blank name or a duplicate name.</summary>
+public sealed record CreateSeries(
+    string Name,
+    string? Author,
+    SeriesType Type,
+    int? ExpectedCount,
+    string? Description) : ICommand<int>;
+
+public sealed class CreateSeriesHandler(IDbContextFactory<BookTrackerDbContext> dbFactory)
+    : ICommandHandler<CreateSeries, int>
+{
+    public async Task<int> HandleAsync(CreateSeries command, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        await SeriesNameGuard.EnsureUniqueAsync(db, command.Name, excludeId: null, ct);
+
+        var series = SeriesAggregate.Create(
+            command.Name, command.Author, command.Type, command.ExpectedCount, command.Description);
+        db.Series.Add(series);
+        await db.SaveChangesAsync(ct);
+        return series.Id;
+    }
+}

--- a/BookTracker.Application/Series/DeleteSeries.cs
+++ b/BookTracker.Application/Series/DeleteSeries.cs
@@ -1,0 +1,25 @@
+using BookTracker.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookTracker.Application.Series;
+
+/// <summary>Hard-deletes a Series. Its member Works (and any WishlistItems that
+/// referenced it) are detached by the database — both FKs are configured
+/// <c>ON DELETE SET NULL</c>, so the rows survive with their series link (and,
+/// for Works, the order) cleared. Idempotent: a no-op if the Series is already
+/// gone, matching the old ViewModel.</summary>
+public sealed record DeleteSeries(int SeriesId) : ICommand;
+
+public sealed class DeleteSeriesHandler(IDbContextFactory<BookTrackerDbContext> dbFactory)
+    : ICommandHandler<DeleteSeries>
+{
+    public async Task HandleAsync(DeleteSeries command, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var series = await db.Series.FindAsync([command.SeriesId], ct);
+        if (series is null) return; // already deleted — idempotent
+
+        db.Series.Remove(series);
+        await db.SaveChangesAsync(ct);
+    }
+}

--- a/BookTracker.Application/Series/RemoveWorkFromSeries.cs
+++ b/BookTracker.Application/Series/RemoveWorkFromSeries.cs
@@ -1,0 +1,25 @@
+using BookTracker.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookTracker.Application.Series;
+
+/// <summary>Removes a Work from its Series (the series-management page). Routes
+/// through the Work aggregate's ClearSeries, which drops the series link, the
+/// order, AND the display label — the old ViewModel left a dangling
+/// SeriesOrderDisplay (e.g. "4.5") behind on a removed work; clearing it here is
+/// the deliberate consistency fix. Soft no-op if the Work is already gone.</summary>
+public sealed record RemoveWorkFromSeries(int WorkId) : ICommand;
+
+public sealed class RemoveWorkFromSeriesHandler(IDbContextFactory<BookTrackerDbContext> dbFactory)
+    : ICommandHandler<RemoveWorkFromSeries>
+{
+    public async Task HandleAsync(RemoveWorkFromSeries command, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var work = await db.Works.FindAsync([command.WorkId], ct);
+        if (work is null) return;
+
+        work.ClearSeries();
+        await db.SaveChangesAsync(ct);
+    }
+}

--- a/BookTracker.Application/Series/SeriesNameGuard.cs
+++ b/BookTracker.Application/Series/SeriesNameGuard.cs
@@ -1,0 +1,27 @@
+using BookTracker.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookTracker.Application.Series;
+
+/// <summary>
+/// Enforces the one cross-row Series invariant the aggregate can't see on its
+/// own: <c>Series.Name</c> is unique (a filtered unique index backs it). Lifted
+/// out of the database's raw constraint violation into a user-safe
+/// <see cref="DomainRuleException"/> so create/rename collisions surface as a
+/// friendly snackbar instead of a 500. Shared by the create + update handlers.
+/// </summary>
+internal static class SeriesNameGuard
+{
+    public static async Task EnsureUniqueAsync(
+        BookTrackerDbContext db, string name, int? excludeId, CancellationToken ct)
+    {
+        var trimmed = (name ?? string.Empty).Trim();
+        if (trimmed.Length == 0) return; // the aggregate owns the required-name rule
+
+        var lower = trimmed.ToLower();
+        var clashes = await db.Series
+            .AnyAsync(s => s.Name.ToLower() == lower && (excludeId == null || s.Id != excludeId), ct);
+        if (clashes)
+            throw new DomainRuleException($"A series named “{trimmed}” already exists.");
+    }
+}

--- a/BookTracker.Application/Series/SetWorkSeriesOrder.cs
+++ b/BookTracker.Application/Series/SetWorkSeriesOrder.cs
@@ -1,0 +1,25 @@
+using BookTracker.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookTracker.Application.Series;
+
+/// <summary>Repositions a Work within its current series (the inline order edit
+/// on the series page). The free-text label ("4.5") arrives already parsed into
+/// an integer sort key + optional display override — the VM owns the parsing,
+/// matching <c>UpdateWork</c>. Membership is untouched. Soft no-op if the Work is
+/// gone.</summary>
+public sealed record SetWorkSeriesOrder(int WorkId, int? Order, string? OrderDisplay) : ICommand;
+
+public sealed class SetWorkSeriesOrderHandler(IDbContextFactory<BookTrackerDbContext> dbFactory)
+    : ICommandHandler<SetWorkSeriesOrder>
+{
+    public async Task HandleAsync(SetWorkSeriesOrder command, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var work = await db.Works.FindAsync([command.WorkId], ct);
+        if (work is null) return;
+
+        work.SetSeriesOrder(command.Order, command.OrderDisplay);
+        await db.SaveChangesAsync(ct);
+    }
+}

--- a/BookTracker.Application/Series/UpdateSeries.cs
+++ b/BookTracker.Application/Series/UpdateSeries.cs
@@ -1,0 +1,35 @@
+using BookTracker.Data;
+using BookTracker.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookTracker.Application.Series;
+
+/// <summary>Updates an existing Series' editable details (name, author, type,
+/// expected count, description). The ExpectedCount/Type invariant is enforced by
+/// the aggregate; name uniqueness by the handler (excluding this row). Throws
+/// <see cref="NotFoundException"/> if the Series is gone,
+/// <see cref="DomainRuleException"/> on a blank or duplicate name.</summary>
+public sealed record UpdateSeries(
+    int SeriesId,
+    string Name,
+    string? Author,
+    SeriesType Type,
+    int? ExpectedCount,
+    string? Description) : ICommand;
+
+public sealed class UpdateSeriesHandler(IDbContextFactory<BookTrackerDbContext> dbFactory)
+    : ICommandHandler<UpdateSeries>
+{
+    public async Task HandleAsync(UpdateSeries command, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var series = await db.Series.FindAsync([command.SeriesId], ct)
+            ?? throw new NotFoundException($"Series {command.SeriesId} not found.");
+
+        await SeriesNameGuard.EnsureUniqueAsync(db, command.Name, excludeId: command.SeriesId, ct);
+
+        series.UpdateDetails(
+            command.Name, command.Author, command.Type, command.ExpectedCount, command.Description);
+        await db.SaveChangesAsync(ct);
+    }
+}

--- a/BookTracker.Data/Models/Series.cs
+++ b/BookTracker.Data/Models/Series.cs
@@ -32,4 +32,36 @@ public class Series
     // A Christie short-story collection (Book) doesn't belong to the
     // Poirot series — its constituent Stories (Works) do.
     public List<Work> Works { get; set; } = [];
+
+    // --- Aggregate behaviour -------------------------------------------------
+    // Series is a thin aggregate: no shared m2m, no ref-count lifecycle (Work
+    // owns the Work↔Series link via Work.AssignToSeries/ClearSeries). Its one
+    // invariant is the ExpectedCount/Type pairing below — a target count only
+    // means anything for an ordered Series, never a loose Collection. Cross-row
+    // rules the entity can't see (name uniqueness) live in the handlers.
+    // Deletion is FK-driven (Work.SeriesId is ON DELETE SET NULL), so there's no
+    // delete method here. See docs/BACKEND-REFACTOR-DESIGN.md.
+
+    /// <summary>Creates a Series with its details applied (and the
+    /// ExpectedCount/Type invariant enforced). Name is required.</summary>
+    public static Series Create(string name, string? author, SeriesType type, int? expectedCount, string? description)
+    {
+        var series = new Series();
+        series.UpdateDetails(name, author, type, expectedCount, description);
+        return series;
+    }
+
+    /// <summary>Applies the editable details. A target <paramref name="expectedCount"/>
+    /// is only retained for an ordered <see cref="SeriesType.Series"/> — a
+    /// Collection has no meaningful count, so it's nulled regardless of input.</summary>
+    public void UpdateDetails(string name, string? author, SeriesType type, int? expectedCount, string? description)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            throw new DomainRuleException("Series name is required.");
+        Name = name.Trim();
+        Author = author.TrimToNull();
+        Type = type;
+        ExpectedCount = type == SeriesType.Series ? expectedCount : null;
+        Description = description.TrimToNull();
+    }
 }

--- a/BookTracker.Data/Models/Work.cs
+++ b/BookTracker.Data/Models/Work.cs
@@ -138,6 +138,15 @@ public class Work
         SeriesOrderDisplay = null;
     }
 
+    /// <summary>Repositions this Work within its current series — the integer sort
+    /// key plus an optional display override ("4.5") — without changing which
+    /// series it belongs to. Used by the manage-series-from-the-series-page flow.</summary>
+    public void SetSeriesOrder(int? order, string? orderDisplay)
+    {
+        SeriesOrder = order;
+        SeriesOrderDisplay = orderDisplay;
+    }
+
     /// <summary>Rebuilds WorkAuthors: one Author-role row per author (Order 0+),
     /// then per-role contributor rows (each role its own Order sequence). Requires
     /// ≥1 contributor across both lists — editor-only Works (dictionaries) are

--- a/BookTracker.Tests/Application/Series/SeriesCommandHandlersTests.cs
+++ b/BookTracker.Tests/Application/Series/SeriesCommandHandlersTests.cs
@@ -1,0 +1,236 @@
+using BookTracker.Application;
+using BookTracker.Application.Series;
+using BookTracker.Data.Models;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace BookTracker.Tests;
+
+// Integration tests for the Series command handlers against the SQL container.
+[Trait("Category", TestCategories.Integration)]
+public class SeriesCommandHandlersTests
+{
+    private readonly TestDbContextFactory _factory = new();
+
+    private async Task<int> SeedSeriesAsync(string name = "Discworld", SeriesType type = SeriesType.Series)
+    {
+        await using var db = _factory.CreateDbContext();
+        var s = new Series { Name = name, Type = type };
+        db.Series.Add(s);
+        await db.SaveChangesAsync();
+        return s.Id;
+    }
+
+    private async Task<int> SeedWorkAsync(string title, int? seriesId = null, int? order = null, string? orderDisplay = null)
+    {
+        await using var db = _factory.CreateDbContext();
+        var work = new Work
+        {
+            Title = title,
+            WorkAuthors = { new WorkAuthor { Author = new Author { Name = $"Author of {title}" }, Order = 0, Role = AuthorRole.Author } },
+            SeriesId = seriesId,
+            SeriesOrder = order,
+            SeriesOrderDisplay = orderDisplay,
+        };
+        db.Books.Add(new Book { Title = title, Works = { work } });
+        await db.SaveChangesAsync();
+        return work.Id;
+    }
+
+    // --- CreateSeries --------------------------------------------------------
+
+    [Fact]
+    public async Task CreateSeries_persistsFields_andReturnsId()
+    {
+        var id = await new CreateSeriesHandler(_factory).HandleAsync(
+            new CreateSeries("Foundation", "Isaac Asimov", SeriesType.Series, 7, "Psychohistory."));
+
+        await using var db = _factory.CreateDbContext();
+        var saved = await db.Series.FindAsync(id);
+        Assert.NotNull(saved);
+        Assert.Equal("Foundation", saved!.Name);
+        Assert.Equal("Isaac Asimov", saved.Author);
+        Assert.Equal(7, saved.ExpectedCount);
+        Assert.Equal("Psychohistory.", saved.Description);
+    }
+
+    [Fact]
+    public async Task CreateSeries_collection_dropsExpectedCount()
+    {
+        var id = await new CreateSeriesHandler(_factory).HandleAsync(
+            new CreateSeries("Hercule Poirot", null, SeriesType.Collection, 33, null));
+
+        await using var db = _factory.CreateDbContext();
+        var saved = await db.Series.FindAsync(id);
+        Assert.Null(saved!.ExpectedCount);
+    }
+
+    [Fact]
+    public async Task CreateSeries_duplicateName_throwsDomainRule()
+    {
+        await SeedSeriesAsync("Discworld");
+
+        await Assert.ThrowsAsync<BookTracker.Data.DomainRuleException>(() =>
+            new CreateSeriesHandler(_factory).HandleAsync(
+                new CreateSeries("discworld", null, SeriesType.Series, null, null))); // case-insensitive clash
+    }
+
+    [Fact]
+    public async Task CreateSeries_blankName_throwsDomainRule()
+    {
+        await Assert.ThrowsAsync<BookTracker.Data.DomainRuleException>(() =>
+            new CreateSeriesHandler(_factory).HandleAsync(
+                new CreateSeries("   ", null, SeriesType.Series, null, null)));
+    }
+
+    // --- UpdateSeries --------------------------------------------------------
+
+    [Fact]
+    public async Task UpdateSeries_updatesFields()
+    {
+        var id = await SeedSeriesAsync("Old Name");
+
+        await new UpdateSeriesHandler(_factory).HandleAsync(
+            new UpdateSeries(id, "New Name", "New Author", SeriesType.Series, 9, "desc"));
+
+        await using var db = _factory.CreateDbContext();
+        var saved = await db.Series.FindAsync(id);
+        Assert.Equal("New Name", saved!.Name);
+        Assert.Equal("New Author", saved.Author);
+        Assert.Equal(9, saved.ExpectedCount);
+    }
+
+    [Fact]
+    public async Task UpdateSeries_renameToOwnName_isAllowed()
+    {
+        var id = await SeedSeriesAsync("Keep");
+
+        // Same name (this row) + a new author — the uniqueness guard excludes self.
+        await new UpdateSeriesHandler(_factory).HandleAsync(
+            new UpdateSeries(id, "Keep", "Added Author", SeriesType.Series, null, null));
+
+        await using var db = _factory.CreateDbContext();
+        Assert.Equal("Added Author", (await db.Series.FindAsync(id))!.Author);
+    }
+
+    [Fact]
+    public async Task UpdateSeries_renameOntoAnother_throwsDomainRule()
+    {
+        await SeedSeriesAsync("Alpha");
+        var bId = await SeedSeriesAsync("Beta");
+
+        await Assert.ThrowsAsync<BookTracker.Data.DomainRuleException>(() =>
+            new UpdateSeriesHandler(_factory).HandleAsync(
+                new UpdateSeries(bId, "Alpha", null, SeriesType.Series, null, null)));
+    }
+
+    [Fact]
+    public async Task UpdateSeries_missing_throwsNotFound()
+    {
+        await Assert.ThrowsAsync<NotFoundException>(() =>
+            new UpdateSeriesHandler(_factory).HandleAsync(
+                new UpdateSeries(424242, "x", null, SeriesType.Series, null, null)));
+    }
+
+    // --- DeleteSeries --------------------------------------------------------
+
+    [Fact]
+    public async Task DeleteSeries_removesSeries_andSetNullsMemberWorks()
+    {
+        var seriesId = await SeedSeriesAsync();
+        var workId = await SeedWorkAsync("Mort", seriesId, order: 4);
+
+        await new DeleteSeriesHandler(_factory).HandleAsync(new DeleteSeries(seriesId));
+
+        await using var db = _factory.CreateDbContext();
+        Assert.Null(await db.Series.FindAsync(seriesId));   // gone
+        var work = await db.Works.FindAsync(workId);
+        Assert.NotNull(work);                                // work survives
+        Assert.Null(work!.SeriesId);                         // link cleared by FK SetNull
+    }
+
+    [Fact]
+    public async Task DeleteSeries_missing_isNoOp()
+    {
+        // No throw — idempotent, matching the old ViewModel.
+        await new DeleteSeriesHandler(_factory).HandleAsync(new DeleteSeries(999999));
+    }
+
+    // --- AddWorkToSeries -----------------------------------------------------
+
+    [Fact]
+    public async Task AddWorkToSeries_firstWork_getsOrderOne()
+    {
+        var seriesId = await SeedSeriesAsync();
+        var workId = await SeedWorkAsync("Guards! Guards!");
+
+        await new AddWorkToSeriesHandler(_factory).HandleAsync(new AddWorkToSeries(seriesId, workId));
+
+        await using var db = _factory.CreateDbContext();
+        var work = await db.Works.FindAsync(workId);
+        Assert.Equal(seriesId, work!.SeriesId);
+        Assert.Equal(1, work.SeriesOrder);
+    }
+
+    [Fact]
+    public async Task AddWorkToSeries_appendsAfterHighestOrder()
+    {
+        var seriesId = await SeedSeriesAsync();
+        await SeedWorkAsync("Colour of Magic", seriesId, order: 1);
+        await SeedWorkAsync("The Light Fantastic", seriesId, order: 2);
+        var newWorkId = await SeedWorkAsync("Equal Rites");
+
+        await new AddWorkToSeriesHandler(_factory).HandleAsync(new AddWorkToSeries(seriesId, newWorkId));
+
+        await using var db = _factory.CreateDbContext();
+        Assert.Equal(3, (await db.Works.FindAsync(newWorkId))!.SeriesOrder);
+    }
+
+    [Fact]
+    public async Task AddWorkToSeries_missingWork_isNoOp()
+    {
+        var seriesId = await SeedSeriesAsync();
+        await new AddWorkToSeriesHandler(_factory).HandleAsync(new AddWorkToSeries(seriesId, 999999));
+    }
+
+    // --- RemoveWorkFromSeries ------------------------------------------------
+
+    [Fact]
+    public async Task RemoveWorkFromSeries_clearsLinkOrderAndDisplay()
+    {
+        var seriesId = await SeedSeriesAsync();
+        var workId = await SeedWorkAsync("Edgedancer", seriesId, order: 4, orderDisplay: "4.5");
+
+        await new RemoveWorkFromSeriesHandler(_factory).HandleAsync(new RemoveWorkFromSeries(workId));
+
+        await using var db = _factory.CreateDbContext();
+        var work = await db.Works.FindAsync(workId);
+        Assert.Null(work!.SeriesId);
+        Assert.Null(work.SeriesOrder);
+        Assert.Null(work.SeriesOrderDisplay);   // the consistency fix — no dangling "4.5"
+    }
+
+    [Fact]
+    public async Task RemoveWorkFromSeries_missingWork_isNoOp()
+    {
+        await new RemoveWorkFromSeriesHandler(_factory).HandleAsync(new RemoveWorkFromSeries(999999));
+    }
+
+    // --- SetWorkSeriesOrder --------------------------------------------------
+
+    [Fact]
+    public async Task SetWorkSeriesOrder_updatesOrder_keepsMembership()
+    {
+        var seriesId = await SeedSeriesAsync();
+        var workId = await SeedWorkAsync("Words of Radiance", seriesId, order: 2);
+
+        await new SetWorkSeriesOrderHandler(_factory).HandleAsync(
+            new SetWorkSeriesOrder(workId, 4, "4.5"));
+
+        await using var db = _factory.CreateDbContext();
+        var work = await db.Works.FindAsync(workId);
+        Assert.Equal(seriesId, work!.SeriesId);   // still in the series
+        Assert.Equal(4, work.SeriesOrder);
+        Assert.Equal("4.5", work.SeriesOrderDisplay);
+    }
+}

--- a/BookTracker.Tests/Domain/SeriesAggregateTests.cs
+++ b/BookTracker.Tests/Domain/SeriesAggregateTests.cs
@@ -1,0 +1,84 @@
+using BookTracker.Data;
+using BookTracker.Data.Models;
+using Xunit;
+
+namespace BookTracker.Tests;
+
+// Pure domain unit tests for the Series aggregate — no EF, no container. Covers
+// the Create factory + UpdateDetails, and the one invariant the entity owns: a
+// target ExpectedCount only sticks for an ordered Series, never a Collection.
+[Trait("Category", TestCategories.Unit)]
+public class SeriesAggregateTests
+{
+    [Fact]
+    public void Create_appliesDetails_andTrims()
+    {
+        var series = Series.Create("  Discworld  ", "  Terry Pratchett  ", SeriesType.Series, 41, "  A flat world.  ");
+
+        Assert.Equal("Discworld", series.Name);
+        Assert.Equal("Terry Pratchett", series.Author);
+        Assert.Equal(SeriesType.Series, series.Type);
+        Assert.Equal(41, series.ExpectedCount);
+        Assert.Equal("A flat world.", series.Description);
+    }
+
+    [Fact]
+    public void Create_blankOptionalFields_becomeNull()
+    {
+        var series = Series.Create("Foundation", "   ", SeriesType.Series, null, "  ");
+
+        Assert.Null(series.Author);
+        Assert.Null(series.Description);
+        Assert.Null(series.ExpectedCount);
+    }
+
+    [Fact]
+    public void Create_blankName_throws()
+    {
+        Assert.Throws<DomainRuleException>(() =>
+            Series.Create("   ", null, SeriesType.Series, null, null));
+    }
+
+    [Fact]
+    public void Create_collectionWithExpectedCount_nullsTheCount()
+    {
+        // A Collection has no meaningful target count — it's dropped regardless of input.
+        var series = Series.Create("Hercule Poirot", null, SeriesType.Collection, 33, null);
+
+        Assert.Equal(SeriesType.Collection, series.Type);
+        Assert.Null(series.ExpectedCount);
+    }
+
+    [Fact]
+    public void UpdateDetails_overwritesAllFields()
+    {
+        var series = Series.Create("Old Name", "Old Author", SeriesType.Series, 5, "old");
+
+        series.UpdateDetails("New Name", "New Author", SeriesType.Series, 9, "new");
+
+        Assert.Equal("New Name", series.Name);
+        Assert.Equal("New Author", series.Author);
+        Assert.Equal(9, series.ExpectedCount);
+        Assert.Equal("new", series.Description);
+    }
+
+    [Fact]
+    public void UpdateDetails_seriesToCollection_dropsExpectedCount()
+    {
+        var series = Series.Create("Switcheroo", null, SeriesType.Series, 7, null);
+
+        series.UpdateDetails("Switcheroo", null, SeriesType.Collection, 7, null);
+
+        Assert.Equal(SeriesType.Collection, series.Type);
+        Assert.Null(series.ExpectedCount);
+    }
+
+    [Fact]
+    public void UpdateDetails_blankName_throws()
+    {
+        var series = Series.Create("Has A Name", null, SeriesType.Series, null, null);
+
+        Assert.Throws<DomainRuleException>(() =>
+            series.UpdateDetails("  ", null, SeriesType.Series, null, null));
+    }
+}


### PR DESCRIPTION
Lift the Series write surface behind the Application layer, mirroring the Book (PR1) and Work (PR2) spine. No page changes yet — the /series ViewModel still uses its direct-EF methods; PR3b rewires it to dispatch.

Aggregate (BookTracker.Data):

- Series.Create + UpdateDetails — own the ExpectedCount/Type invariant (a target count is nulled for a Collection), lifted out of SeriesEditViewModel.SaveAsync.

- Work.SetSeriesOrder — reposition within the current series without touching membership (the inline order edit).

Handlers (BookTracker.Application/Series): CreateSeries, UpdateSeries, DeleteSeries + the three work-membership commands (AddWorkToSeries, RemoveWorkFromSeries, SetWorkSeriesOrder), which route through the Work aggregate that owns the Work<->Series link.

- SeriesNameGuard turns the unique-index collision into a friendly DomainRuleException on create/rename (the cross-row rule the entity can't see).

- DeleteSeries stays idempotent; member Works/WishlistItems are detached by the FK's ON DELETE SET NULL, so no orphan loop.

- RemoveWorkFromSeries now also clears SeriesOrderDisplay (ClearSeries) — the old VM left a dangling '4.5' label on a removed work; deliberate consistency fix.

Note: the Series/ feature namespace collides with the Series type (unlike Works/Work, where the plural dodges it) — aliased the entity in CreateSeries.cs.

Tests: 7 aggregate unit + 16 handler integration, all green.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
