### PR TITLE
refactor(read-models): move Wishlist reads to query handlers (PR6b-5)

### DIFF
--- a/BookTracker.Application/Wishlist/GetSeriesGaps.cs
+++ b/BookTracker.Application/Wishlist/GetSeriesGaps.cs
@@ -1,0 +1,120 @@
+using BookTracker.Application.Formatting;
+using BookTracker.Data;
+using BookTracker.Data.Models;
+using BookTracker.Shared.Catalog;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookTracker.Application.Wishlist;
+
+// Read-model for the /wishlist series-gaps section. Relocated verbatim from
+// WishlistViewModel.LoadSeriesGapsAsync in PR6b-5. Two shapes in one read:
+//   Gaps       — structured series (ExpectedCount set) with missing numbered slots.
+//   OpenSeries — open-ended series (no ExpectedCount) the user owns ≥1 book in.
+public sealed record GetSeriesGaps : IQuery<SeriesGapsResult>;
+
+public record SeriesGapsResult(
+    IReadOnlyList<SeriesGap> Gaps,
+    IReadOnlyList<OpenSeries> OpenSeries);
+
+public record SeriesGap(
+    int SeriesId, string SeriesName, string? Author,
+    int OwnedCount, int ExpectedCount,
+    List<int> MissingPositions,
+    List<OwnedSeriesBook> OwnedBooks);
+
+public record OwnedSeriesBook(int Id, string Title, string? SeriesOrderLabel);
+
+// Series with no ExpectedCount where the user owns at least one Work.
+// HighestOwnedOrder seeds the "Add next N missing" flow (0 when no Works carry
+// a SeriesOrder yet). OwnedOrders is the full owned set so the suggestion can
+// skip already-owned slots when computing the next-N range.
+public record OpenSeries(
+    int SeriesId,
+    string SeriesName,
+    string? Author,
+    int OwnedCount,
+    int HighestOwnedOrder,
+    IReadOnlyList<int> OwnedOrders);
+
+public sealed class GetSeriesGapsHandler(IDbContextFactory<BookTrackerDbContext> dbFactory)
+    : IQueryHandler<GetSeriesGaps, SeriesGapsResult>
+{
+    public async Task<SeriesGapsResult> HandleAsync(GetSeriesGaps query, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+
+        // Structured series with a known expected count where we're missing works.
+        // Series → Works → Books gives us the parent book(s) to link to.
+        var incompleteSeries = await db.Series
+            .Include(s => s.Works).ThenInclude(w => w.Books)
+            .Where(s => s.Type == SeriesType.Series && s.ExpectedCount != null)
+            .ToListAsync(ct);
+
+        var gaps = incompleteSeries
+            .Select(s =>
+            {
+                // Only true numbered volumes occupy a slot (shared rule —
+                // SeriesSlots.OccupiesNumberedSlot). A floored interquel ("4.5",
+                // SeriesOrderDisplay set) must not count as owning slot #4, or
+                // the real #4 gap is silently hidden.
+                var ownedPositions = s.Works
+                    .Where(w => SeriesSlots.OccupiesNumberedSlot(w.SeriesOrder, w.SeriesOrderDisplay))
+                    .Select(w => w.SeriesOrder!.Value)
+                    .Where(o => o <= s.ExpectedCount!.Value)
+                    .ToHashSet();
+
+                var missing = new List<int>();
+                for (int i = 1; i <= s.ExpectedCount!.Value; i++)
+                {
+                    if (!ownedPositions.Contains(i))
+                        missing.Add(i);
+                }
+
+                return new SeriesGap(
+                    s.Id,
+                    s.Name,
+                    s.Author,
+                    ownedPositions.Count,
+                    s.ExpectedCount.Value,
+                    missing,
+                    s.Works.OrderBy(w => w.SeriesOrder ?? int.MaxValue)
+                        .Select(w => new OwnedSeriesBook(
+                            w.Books.FirstOrDefault()?.Id ?? 0,
+                            w.Title,
+                            SeriesOrderParser.Format(w.SeriesOrder, w.SeriesOrderDisplay)))
+                        .ToList());
+            })
+            .Where(g => g.MissingPositions.Count > 0)
+            .OrderBy(g => g.SeriesName)
+            .ToList();
+
+        // Open-ended series — no ExpectedCount, but the user owns at least one
+        // numbered book. Highest-owned-order seeds the suggestion; series with
+        // all-null SeriesOrder still surface (HighestOwnedOrder=0).
+        var openSeries = await db.Series
+            .Include(s => s.Works)
+            .Where(s => s.Type == SeriesType.Series && s.ExpectedCount == null && s.Works.Any())
+            .ToListAsync(ct);
+
+        var open = openSeries
+            .OrderBy(s => s.Name)
+            .Select(s =>
+            {
+                var orders = s.Works
+                    .Where(w => w.SeriesOrder.HasValue)
+                    .Select(w => w.SeriesOrder!.Value)
+                    .OrderBy(n => n)
+                    .ToList();
+                return new OpenSeries(
+                    s.Id,
+                    s.Name,
+                    s.Author,
+                    s.Works.Count,
+                    orders.Count == 0 ? 0 : orders.Max(),
+                    orders);
+            })
+            .ToList();
+
+        return new SeriesGapsResult(gaps, open);
+    }
+}

--- a/BookTracker.Application/Wishlist/GetWishlist.cs
+++ b/BookTracker.Application/Wishlist/GetWishlist.cs
@@ -1,0 +1,33 @@
+using BookTracker.Data;
+using BookTracker.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookTracker.Application.Wishlist;
+
+// Read-model for the /wishlist list. Relocated from
+// WishlistViewModel.LoadWishlistAsync in PR6b-5. Rows ordered by priority
+// (high first) then title.
+public sealed record GetWishlist : IQuery<IReadOnlyList<WishlistRow>>;
+
+public record WishlistRow(
+    int Id, string Title, string Author, WishlistPriority Priority,
+    string? Isbn, string? CoverUrl, string? SeriesName, int? SeriesOrder);
+
+public sealed class GetWishlistHandler(IDbContextFactory<BookTrackerDbContext> dbFactory)
+    : IQueryHandler<GetWishlist, IReadOnlyList<WishlistRow>>
+{
+    public async Task<IReadOnlyList<WishlistRow>> HandleAsync(GetWishlist query, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        return await db.WishlistItems
+            .Include(w => w.Series)
+            .OrderByDescending(w => w.Priority)
+            .ThenBy(w => w.Title)
+            .Select(w => new WishlistRow(
+                w.Id, w.Title, w.Author, w.Priority, w.Isbn,
+                w.CoverUrl,
+                w.Series != null ? w.Series.Name : null,
+                w.SeriesOrder))
+            .ToListAsync(ct);
+    }
+}

--- a/BookTracker.Application/Wishlist/GetWishlistDuplicate.cs
+++ b/BookTracker.Application/Wishlist/GetWishlistDuplicate.cs
@@ -1,0 +1,34 @@
+using BookTracker.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookTracker.Application.Wishlist;
+
+// Read-model behind the wishlist search's duplicate badge. Relocated from
+// WishlistViewModel.FindDuplicateMatchesAsync in PR6b-5. For a given ISBN,
+// reports whether it's already owned (any Edition.Isbn) and/or already on the
+// wishlist (legacy single Isbn column OR the WishlistItemIsbn table). Doesn't
+// block Add — just tells the user before they click.
+public sealed record GetWishlistDuplicate(string Isbn) : IQuery<WishlistDuplicate>;
+
+public record WishlistDuplicate(int? OwnedBookId, int? WishlistedItemId);
+
+public sealed class GetWishlistDuplicateHandler(IDbContextFactory<BookTrackerDbContext> dbFactory)
+    : IQueryHandler<GetWishlistDuplicate, WishlistDuplicate>
+{
+    public async Task<WishlistDuplicate> HandleAsync(GetWishlistDuplicate query, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+
+        var ownedBookId = await db.Editions
+            .Where(e => e.Isbn == query.Isbn)
+            .Select(e => (int?)e.BookId)
+            .FirstOrDefaultAsync(ct);
+
+        var wishlistedItemId = await db.WishlistItems
+            .Where(w => w.Isbn == query.Isbn || w.Isbns.Any(i => i.Isbn == query.Isbn))
+            .Select(w => (int?)w.Id)
+            .FirstOrDefaultAsync(ct);
+
+        return new WishlistDuplicate(ownedBookId, wishlistedItemId);
+    }
+}

--- a/BookTracker.Tests/ViewModels/WishlistViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/WishlistViewModelTests.cs
@@ -14,7 +14,7 @@ public class WishlistViewModelTests
     private readonly IBookLookupService _lookup = Substitute.For<IBookLookupService>();
 
     private WishlistViewModel CreateVm() =>
-        new(_factory, _lookup, TestDispatcher.For(_factory), NullLogger<WishlistViewModel>.Instance);
+        new(_lookup, TestDispatcher.For(_factory), NullLogger<WishlistViewModel>.Instance);
 
     [Fact]
     public async Task SearchAsync_IsbnShapedQuery_CallsIsbnLookupAndPopulatesSingleCandidate()

--- a/BookTracker.Web/Components/Pages/Wishlist/Index.razor
+++ b/BookTracker.Web/Components/Pages/Wishlist/Index.razor
@@ -1,5 +1,6 @@
 @page "/wishlist"
 @page "/shopping"
+@using BookTracker.Application.Wishlist
 @inject WishlistViewModel VM
 @inject NavigationManager Nav
 
@@ -513,7 +514,7 @@
         }
     }
 
-    private async Task AddNextOpenSeriesAsync(WishlistViewModel.OpenSeries open)
+    private async Task AddNextOpenSeriesAsync(OpenSeries open)
     {
         var n = GetOpenN(open.SeriesId);
         if (n <= 0) return;
@@ -571,7 +572,7 @@
         await VM.AddCandidateAsync(candidate);
     }
 
-    private async Task BoughtAsync(WishlistViewModel.WishlistRow item)
+    private async Task BoughtAsync(WishlistRow item)
     {
         var bookId = await VM.MarkAsBoughtAsync(item);
         if (bookId.HasValue)

--- a/BookTracker.Web/ViewModels/WishlistViewModel.cs
+++ b/BookTracker.Web/ViewModels/WishlistViewModel.cs
@@ -1,11 +1,7 @@
 using BookTracker.Application;
 using BookTracker.Application.Wishlist;
-using BookTracker.Data;
 using BookTracker.Data.Models;
-using BookTracker.Shared.Catalog;
 using BookTracker.Web.Services;
-using Microsoft.EntityFrameworkCore;
-using BookTracker.Application.Formatting;
 
 namespace BookTracker.Web.ViewModels;
 
@@ -24,7 +20,6 @@ namespace BookTracker.Web.ViewModels;
 // The "Do I have this?" search that lived here pre-2026-05-25 was
 // deleted in PR A — duplicate of /bookshop's scan + Bookshelf ScanPage.
 public class WishlistViewModel(
-    IDbContextFactory<BookTrackerDbContext> dbFactory,
     IBookLookupService lookup,
     IDispatcher dispatcher,
     ILogger<WishlistViewModel> logger)
@@ -86,7 +81,7 @@ public class WishlistViewModel(
                     // tells them before they click. Text-search candidates
                     // don't get this check (no ISBN to match against).
                     var (ownedBookId, wishlistedItemId) =
-                        await FindDuplicateMatchesAsync(cleaned, ct);
+                        await dispatcher.Query(new GetWishlistDuplicate(cleaned), ct);
 
                     SearchCandidates = [new WishlistCandidate(
                         Title: hit.Title,
@@ -161,7 +156,7 @@ public class WishlistViewModel(
                 if (hit is not null)
                 {
                     var (ownedBookId, wishlistedItemId) =
-                        await FindDuplicateMatchesAsync(cleaned, ct);
+                        await dispatcher.Query(new GetWishlistDuplicate(cleaned), ct);
                     SearchCandidates = [new WishlistCandidate(
                         Title: hit.Title,
                         Author: hit.Author,
@@ -202,29 +197,6 @@ public class WishlistViewModel(
             Searching = false;
             SearchedOnce = true;
         }
-    }
-
-    /// <summary>Returns (existing Book.Id if owned, existing WishlistItem.Id
-    /// if wishlisted) for the given ISBN, or (null, null) for neither.
-    /// Owned check hits Edition.Isbn (filtered-unique index → seek). Wishlist
-    /// check unions the legacy single column with the new WishlistItemIsbn
-    /// table so both shapes of wishlist row are caught.</summary>
-    private async Task<(int? OwnedBookId, int? WishlistedItemId)> FindDuplicateMatchesAsync(
-        string isbn, CancellationToken ct)
-    {
-        await using var db = await dbFactory.CreateDbContextAsync(ct);
-
-        var ownedBookId = await db.Editions
-            .Where(e => e.Isbn == isbn)
-            .Select(e => (int?)e.BookId)
-            .FirstOrDefaultAsync(ct);
-
-        var wishlistedItemId = await db.WishlistItems
-            .Where(w => w.Isbn == isbn || w.Isbns.Any(i => i.Isbn == isbn))
-            .Select(w => (int?)w.Id)
-            .FirstOrDefaultAsync(ct);
-
-        return (ownedBookId, wishlistedItemId);
     }
 
     public void ClearSearch()
@@ -274,83 +246,9 @@ public class WishlistViewModel(
 
     public async Task LoadSeriesGapsAsync()
     {
-        await using var db = await dbFactory.CreateDbContextAsync();
-
-        // Structured series with a known expected count where we're missing works.
-        // Series → Works → Books gives us the parent book(s) to link to.
-        var incompleteSeries = await db.Series
-            .Include(s => s.Works).ThenInclude(w => w.Books)
-            .Where(s => s.Type == SeriesType.Series && s.ExpectedCount != null)
-            .ToListAsync();
-
-        SeriesGaps = incompleteSeries
-            .Select(s =>
-            {
-                // Only true numbered volumes occupy a slot (shared rule —
-                // SeriesSlots.OccupiesNumberedSlot). A floored interquel ("4.5",
-                // SeriesOrderDisplay set) must not count as owning slot #4, or
-                // the real #4 gap is silently hidden.
-                var ownedPositions = s.Works
-                    .Where(w => SeriesSlots.OccupiesNumberedSlot(w.SeriesOrder, w.SeriesOrderDisplay))
-                    .Select(w => w.SeriesOrder!.Value)
-                    .Where(o => o <= s.ExpectedCount!.Value)
-                    .ToHashSet();
-
-                var missing = new List<int>();
-                for (int i = 1; i <= s.ExpectedCount!.Value; i++)
-                {
-                    if (!ownedPositions.Contains(i))
-                        missing.Add(i);
-                }
-
-                return new SeriesGap(
-                    s.Id,
-                    s.Name,
-                    s.Author,
-                    ownedPositions.Count,
-                    s.ExpectedCount.Value,
-                    missing,
-                    s.Works.OrderBy(w => w.SeriesOrder ?? int.MaxValue)
-                        .Select(w => new OwnedSeriesBook(
-                            w.Books.FirstOrDefault()?.Id ?? 0,
-                            w.Title,
-                            SeriesOrderParser.Format(w.SeriesOrder, w.SeriesOrderDisplay)))
-                        .ToList());
-            })
-            .Where(g => g.MissingPositions.Count > 0)
-            .OrderBy(g => g.SeriesName)
-            .ToList();
-
-        // Open-ended series — no ExpectedCount, but the user owns at
-        // least one numbered book. Drive the "add next N missing" flow
-        // on /wishlist. Highest-owned-order seeds the suggestion ("you
-        // own up to #7, add the next 10?"); series with all-null
-        // SeriesOrder still surface (HighestOwnedOrder=0) so the user
-        // can mark the first 10 sought from scratch.
-        var openSeries = await db.Series
-            .Include(s => s.Works)
-            .Where(s => s.Type == SeriesType.Series && s.ExpectedCount == null && s.Works.Any())
-            .ToListAsync();
-
-        OpenSeriesList = openSeries
-            .OrderBy(s => s.Name)
-            .Select(s =>
-            {
-                var orders = s.Works
-                    .Where(w => w.SeriesOrder.HasValue)
-                    .Select(w => w.SeriesOrder!.Value)
-                    .OrderBy(n => n)
-                    .ToList();
-                return new OpenSeries(
-                    s.Id,
-                    s.Name,
-                    s.Author,
-                    s.Works.Count,
-                    orders.Count == 0 ? 0 : orders.Max(),
-                    orders);
-            })
-            .ToList();
-
+        var result = await dispatcher.Query(new GetSeriesGaps());
+        SeriesGaps = result.Gaps.ToList();
+        OpenSeriesList = result.OpenSeries.ToList();
         GapsLoaded = true;
     }
 
@@ -386,17 +284,7 @@ public class WishlistViewModel(
 
     public async Task LoadWishlistAsync()
     {
-        await using var db = await dbFactory.CreateDbContextAsync();
-        Wishlist = await db.WishlistItems
-            .Include(w => w.Series)
-            .OrderByDescending(w => w.Priority)
-            .ThenBy(w => w.Title)
-            .Select(w => new WishlistRow(
-                w.Id, w.Title, w.Author, w.Priority, w.Isbn,
-                w.CoverUrl,
-                w.Series != null ? w.Series.Name : null,
-                w.SeriesOrder))
-            .ToListAsync();
+        Wishlist = (await dispatcher.Query(new GetWishlist())).ToList();
         WishlistLoaded = true;
     }
 
@@ -466,10 +354,6 @@ public class WishlistViewModel(
         public WishlistPriority Priority { get; set; } = WishlistPriority.Medium;
     }
 
-    public record WishlistRow(
-        int Id, string Title, string Author, WishlistPriority Priority,
-        string? Isbn, string? CoverUrl, string? SeriesName, int? SeriesOrder);
-
     /// <summary>Unified shape for search candidates from both the ISBN
     /// lookup (BookLookupResult) and the title/author search
     /// (BookSearchCandidate). Carries enough metadata to populate a
@@ -488,25 +372,4 @@ public class WishlistViewModel(
         string Source,
         int? AlreadyOwnedBookId = null,
         int? AlreadyWishlistedItemId = null);
-
-    public record SeriesGap(
-        int SeriesId, string SeriesName, string? Author,
-        int OwnedCount, int ExpectedCount,
-        List<int> MissingPositions,
-        List<OwnedSeriesBook> OwnedBooks);
-
-    public record OwnedSeriesBook(int Id, string Title, string? SeriesOrderLabel);
-
-    /// <summary>Series with no ExpectedCount where the user owns at least
-    /// one Work. HighestOwnedOrder seeds the "Add next N missing" flow
-    /// (0 when no Works carry a SeriesOrder yet — UI suggests starting
-    /// from #1). OwnedOrders is the full set so the suggestion can skip
-    /// slots the user already owns when computing the next-N range.</summary>
-    public record OpenSeries(
-        int SeriesId,
-        string SeriesName,
-        string? Author,
-        int OwnedCount,
-        int HighestOwnedOrder,
-        IReadOnlyList<int> OwnedOrders);
 }


### PR DESCRIPTION
Final sub-PR of the 6b read-model arc. WishlistViewModel's three direct
DbContext reads move into BookTracker.Application query handlers; the VM
now takes only IBookLookupService + IDispatcher + ILogger (IDbContextFactory
dropped).

New handlers (verbatim relocations — logic preserved exactly, scale
optimisations deferred to TD-17 at arc close):
- GetWishlist        <- LoadWishlistAsync (priority-desc, title list)
- GetWishlistDuplicate <- FindDuplicateMatchesAsync (owned/wishlisted badge)
- GetSeriesGaps      <- LoadSeriesGapsAsync (slot-occupancy math + open series)

DTOs WishlistRow / SeriesGap / OwnedSeriesBook / OpenSeries move to
BookTracker.Application.Wishlist; WishlistCandidate + QuickAddInput stay on
the VM (search-only, never relocated). Index.razor gains the @using and
references the moved types unqualified.

The gnarly series-gaps math keeps its existing regression coverage: the
three LoadSeriesGapsAsync_* VM tests (incl. the floored-interquel guard)
now exercise GetSeriesGapsHandler end-to-end via TestDispatcher.For(factory),
so no duplicate handler-level test is added.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
