### PR TITLE
refactor/backend arc close 2b library scale

### DIFF
--- a/BookTracker.Application/Authors/AuthorRollups.cs
+++ b/BookTracker.Application/Authors/AuthorRollups.cs
@@ -13,10 +13,11 @@ namespace BookTracker.Application.Authors;
 //
 // All counts use Author-role authorship only — Editor/Translator/Illustrator are
 // excluded from "books by X" so reference-work contributors don't pollute the
-// list. The per-author dedup — the expensive part — is pushed to SQL (a
-// `SELECT DISTINCT` over the authorship join); the distinct pairs come back and
-// the final group-count is a trivial in-memory tally bounded by the catalogue
-// size (EF can't translate `Distinct().GroupBy()` to a single SQL statement).
+// list. Each count is a correlated `COUNT(DISTINCT ...)` subquery over the
+// author's Author-role links, computed in SQL — one row per author comes back,
+// no per-link payload (EF can't fold `Distinct().GroupBy()` / `GROUP BY
+// COUNT(DISTINCT)` over the join into one statement, but it DOES translate the
+// per-author correlated subquery — the shape the old snapshot directCounts used).
 //
 // Canonical rollup is a plain in-memory SUM of the member authors' counts (own +
 // aliases) — see RollUpToCanonical. A title credited to BOTH a canonical author
@@ -28,36 +29,53 @@ public static class AuthorRollups
 {
     public record AuthorCounts(int WorkCount, int BookCount, int SeriesCount);
 
-    // EF projection target — named (not anonymous) so the grouped-count helper
-    // can take it as IQueryable<KeyVal>. EF translates `new KeyVal(a, b)` to a
-    // two-column projection and `.Distinct()` to SQL DISTINCT over those columns.
-    public sealed record KeyVal(int Key, int Val);
-
     // Distinct work/book/series counts keyed by individual author id (Author-role
-    // only). The single SQL touch-point; canonical totals are summed from this.
+    // only). Canonical totals are summed from this.
     public static async Task<Dictionary<int, AuthorCounts>> PerAuthorAsync(
         BookTrackerDbContext db, CancellationToken ct)
     {
-        var baseQ = db.WorkAuthors.AsNoTracking().Where(wa => wa.Role == AuthorRole.Author);
-        var works = await CountByKeyAsync(
-            baseQ.Select(wa => new KeyVal(wa.AuthorId, wa.WorkId)), ct);
-        var books = await CountByKeyAsync(
-            baseQ.SelectMany(wa => wa.Work.Books.Select(b => new KeyVal(wa.AuthorId, b.Id))), ct);
-        var series = await CountByKeyAsync(
-            baseQ.Where(wa => wa.Work.SeriesId != null)
-                 .Select(wa => new KeyVal(wa.AuthorId, wa.Work.SeriesId!.Value)), ct);
-        return Merge(works, books, series);
+        var rows = await db.Authors
+            .AsNoTracking()
+            .Select(a => new
+            {
+                a.Id,
+                Works = a.WorkAuthors.Where(wa => wa.Role == AuthorRole.Author)
+                    .Select(wa => wa.WorkId).Distinct().Count(),
+                Books = a.WorkAuthors.Where(wa => wa.Role == AuthorRole.Author)
+                    .SelectMany(wa => wa.Work.Books).Select(b => b.Id).Distinct().Count(),
+                Series = a.WorkAuthors.Where(wa => wa.Role == AuthorRole.Author && wa.Work.SeriesId != null)
+                    .Select(wa => wa.Work.SeriesId!.Value).Distinct().Count(),
+            })
+            .ToListAsync(ct);
+
+        // Authors with no Author-role works are dropped (no entry → callers
+        // default to 0), matching the old grouping which produced no key for them.
+        return rows
+            .Where(x => x.Works > 0)
+            .ToDictionary(x => x.Id, x => new AuthorCounts(x.Works, x.Books, x.Series));
     }
 
     // Just the distinct book count per author (Author-role) — for consumers that
     // need only BookCount (Home top-authors, the catalog snapshot) and shouldn't
-    // pay for the works + series distinct scans PerAuthorAsync also runs (F3).
-    public static Task<Dictionary<int, int>> PerAuthorBookCountAsync(
+    // pay for the works + series counts (F3). The "Author-role distinct books"
+    // definition is kept identical to PerAuthorAsync's Books above so /authors and
+    // the snapshot can't drift (TD-17 b: their BookCounts are documented to match).
+    public static async Task<Dictionary<int, int>> PerAuthorBookCountAsync(
         BookTrackerDbContext db, CancellationToken ct)
     {
-        var baseQ = db.WorkAuthors.AsNoTracking().Where(wa => wa.Role == AuthorRole.Author);
-        return CountByKeyAsync(
-            baseQ.SelectMany(wa => wa.Work.Books.Select(b => new KeyVal(wa.AuthorId, b.Id))), ct);
+        var rows = await db.Authors
+            .AsNoTracking()
+            .Select(a => new
+            {
+                a.Id,
+                Books = a.WorkAuthors.Where(wa => wa.Role == AuthorRole.Author)
+                    .SelectMany(wa => wa.Work.Books).Select(b => b.Id).Distinct().Count(),
+            })
+            .ToListAsync(ct);
+
+        return rows
+            .Where(x => x.Books > 0)
+            .ToDictionary(x => x.Id, x => x.Books);
     }
 
     // Roll per-author counts up onto canonical authors by summing each canonical's
@@ -97,32 +115,18 @@ public static class AuthorRollups
         return result;
     }
 
-    // DISTINCT the (key, value) pairs server-side, then group-count in memory.
-    // EF can't translate `Distinct().GroupBy(...)` to SQL (it walls on the
-    // grouped subquery — the same limitation the old in-app rollups dodged), but
-    // it DOES translate `Select(pair).Distinct()` to a `SELECT DISTINCT` over the
-    // join (GetCatalogSnapshot's proven shape). So the dedup — the heavy part —
-    // runs in SQL; only the distinct pairs cross the wire and the final count is
-    // a trivial in-memory tally bounded by the catalogue size.
-    static async Task<Dictionary<int, int>> CountByKeyAsync(IQueryable<KeyVal> pairs, CancellationToken ct)
-    {
-        var distinct = await pairs.Distinct().ToListAsync(ct);
-        return distinct
-            .GroupBy(x => x.Key)
-            .ToDictionary(g => g.Key, g => g.Count());
-    }
-
-    static Dictionary<int, AuthorCounts> Merge(
-        Dictionary<int, int> works, Dictionary<int, int> books, Dictionary<int, int> series)
-    {
-        // Work-count keys are the superset (an author with no Author-role works
-        // produces no rows in any grouping and correctly has no entry → callers
-        // default to 0).
-        return works.Keys.ToDictionary(
-            id => id,
-            id => new AuthorCounts(
-                works.GetValueOrDefault(id),
-                books.GetValueOrDefault(id),
-                series.GetValueOrDefault(id)));
-    }
+    // The single canonical-vs-alias display rule shared by /authors and the
+    // snapshot: a canonical row (authorId == its own canonical id) shows the
+    // rolled-up total (own + aliases) from `byCanonical`; an alias row shows just
+    // its own per-author value from `perAuthor`. Missing keys default (0 / null)
+    // so works-less authors read as zero. Generic over the value type — int for
+    // the snapshot's BookCount, AuthorCounts for the /authors triple.
+    public static TVal? SelectForDisplay<TVal>(
+        int authorId,
+        int canonicalId,
+        IReadOnlyDictionary<int, TVal> byCanonical,
+        IReadOnlyDictionary<int, TVal> perAuthor)
+        => authorId == canonicalId
+            ? byCanonical.GetValueOrDefault(authorId)
+            : perAuthor.GetValueOrDefault(authorId);
 }

--- a/BookTracker.Application/Authors/AuthorRollups.cs
+++ b/BookTracker.Application/Authors/AuthorRollups.cs
@@ -49,6 +49,17 @@ public static class AuthorRollups
         return Merge(works, books, series);
     }
 
+    // Just the distinct book count per author (Author-role) — for consumers that
+    // need only BookCount (Home top-authors, the catalog snapshot) and shouldn't
+    // pay for the works + series distinct scans PerAuthorAsync also runs (F3).
+    public static Task<Dictionary<int, int>> PerAuthorBookCountAsync(
+        BookTrackerDbContext db, CancellationToken ct)
+    {
+        var baseQ = db.WorkAuthors.AsNoTracking().Where(wa => wa.Role == AuthorRole.Author);
+        return CountByKeyAsync(
+            baseQ.SelectMany(wa => wa.Work.Books.Select(b => new KeyVal(wa.AuthorId, b.Id))), ct);
+    }
+
     // Roll per-author counts up onto canonical authors by summing each canonical's
     // members. `membership` maps every author id to its canonical id (own id when
     // not an alias) — callers build it from data they already load. Result is
@@ -67,6 +78,21 @@ public static class AuthorRollups
                 cur.WorkCount + c.WorkCount,
                 cur.BookCount + c.BookCount,
                 cur.SeriesCount + c.SeriesCount);
+        }
+        return result;
+    }
+
+    // Int overload — sum a single per-author scalar (e.g. BookCount) up onto
+    // canonicals. Same membership + accepted cross-member double-count as above.
+    public static Dictionary<int, int> RollUpToCanonical(
+        IReadOnlyDictionary<int, int> perAuthor,
+        IEnumerable<(int AuthorId, int CanonicalId)> membership)
+    {
+        var result = new Dictionary<int, int>();
+        foreach (var (authorId, canonicalId) in membership)
+        {
+            if (!perAuthor.TryGetValue(authorId, out var v)) continue;
+            result[canonicalId] = result.GetValueOrDefault(canonicalId) + v;
         }
         return result;
     }

--- a/BookTracker.Application/Authors/GetAuthorList.cs
+++ b/BookTracker.Application/Authors/GetAuthorList.cs
@@ -48,9 +48,8 @@ public sealed class GetAuthorListHandler(IDbContextFactory<BookTrackerDbContext>
         var rows = new List<AuthorRow>(authorsRaw.Count);
         foreach (var a in authorsRaw)
         {
-            var counts = a.CanonicalAuthorId is null
-                ? byCanonical.GetValueOrDefault(a.Id)
-                : perAuthor.GetValueOrDefault(a.Id);
+            var counts = AuthorRollups.SelectForDisplay(
+                a.Id, a.CanonicalAuthorId ?? a.Id, byCanonical, perAuthor);
 
             rows.Add(new AuthorRow(
                 a.Id,

--- a/BookTracker.Application/Authors/GetAuthorMergePreview.cs
+++ b/BookTracker.Application/Authors/GetAuthorMergePreview.cs
@@ -67,19 +67,10 @@ public sealed class GetAuthorMergePreviewHandler(IDbContextFactory<BookTrackerDb
             .Select(w => w.Title)
             .ToListAsync(ct);
 
-        // Cover pick: prefer a Book that contains a single Work credited to
-        // this author (its cover faithfully represents one of the author's
-        // Works); fall back to any Book by the author.
-        var singleWorkBookCover = await db.Books
-            .Where(b => b.Works.Any(w => w.Authors.Any(a => a.Id == id)) && b.Works.Count == 1)
-            .Select(b => b.DefaultCoverArtUrl)
-            .FirstOrDefaultAsync(ct);
-        var cover = singleWorkBookCover is null
-            ? await db.Books
-                .Where(b => b.Works.Any(w => w.Authors.Any(a => a.Id == id)))
-                .Select(b => b.DefaultCoverArtUrl)
-                .FirstOrDefaultAsync(ct)
-            : singleWorkBookCover;
+        // Cover pick: prefer a Book that contains a single Work credited to this
+        // author, fall back to any Book by the author (shared rule — BookCovers).
+        var cover = await Books.BookCovers.PickAsync(
+            db.Books.Where(b => b.Works.Any(w => w.Authors.Any(a => a.Id == id))), ct);
 
         return new AuthorMergeDetail(
             author.Id, author.Name,

--- a/BookTracker.Application/Books/BookCovers.cs
+++ b/BookTracker.Application/Books/BookCovers.cs
@@ -1,0 +1,30 @@
+using BookTracker.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookTracker.Application.Books;
+
+// Shared "best-effort cover" pick for the merge-preview cards. Both the Author-
+// and Work-merge previews want the DefaultCoverArtUrl of a candidate Book,
+// preferring one that contains a single Work (its cover represents that Work
+// faithfully) over a compendium, and falling back to any candidate. Callers pass
+// their own candidate set (books credited to an author / books containing a
+// work); this owns the single-Work-else-any rule that was copied between the two
+// previews (TD-16).
+public static class BookCovers
+{
+    public static async Task<string?> PickAsync(IQueryable<Book> candidates, CancellationToken ct)
+    {
+        // Prefer a single-Work book's cover. Faithful to the original: this takes
+        // the first single-Work book's cover even if it's null, and only then
+        // falls back to any candidate — so a single-Work book with no cover still
+        // defers to a covered compendium.
+        var singleWorkCover = await candidates
+            .Where(b => b.Works.Count == 1)
+            .Select(b => b.DefaultCoverArtUrl)
+            .FirstOrDefaultAsync(ct);
+
+        return singleWorkCover ?? await candidates
+            .Select(b => b.DefaultCoverArtUrl)
+            .FirstOrDefaultAsync(ct);
+    }
+}

--- a/BookTracker.Application/Books/GetLibraryBooks.cs
+++ b/BookTracker.Application/Books/GetLibraryBooks.cs
@@ -41,28 +41,54 @@ public sealed class GetLibraryBooksHandler(IDbContextFactory<BookTrackerDbContex
                 .ThenBy(b => b.Title)
             : filtered.OrderByDescending(b => b.DateAdded);
 
+        // Project the page in SQL — pull only the scalars + the small per-Work
+        // author/genre name lists and the tag names, instead of hydrating the
+        // Book→Works→{WorkAuthors,Genres}+Tags graph (the old TD-2 cartesian).
+        // The display computations (single-Work subtitle, distinct author join,
+        // distinct genres) run over the materialised projection below, identical
+        // to the old in-memory map.
         var raw = await ordered
             .Skip((page - 1) * GetLibraryBooks.PageSize)
             .Take(GetLibraryBooks.PageSize)
+            .Select(b => new
+            {
+                b.Id,
+                b.Title,
+                b.DefaultCoverArtUrl,
+                b.Status,
+                b.Rating,
+                WorksCount = b.Works.Count,
+                Works = b.Works.Select(w => new
+                {
+                    w.Subtitle,
+                    Authors = w.WorkAuthors
+                        .Where(wa => wa.Role == AuthorRole.Author)
+                        .OrderBy(wa => wa.Order)
+                        .Select(wa => wa.Author.Name)
+                        .ToList(),
+                    Genres = w.Genres.Select(g => g.Name).ToList(),
+                }).ToList(),
+                Tags = b.Tags.Select(t => t.Name).ToList(),
+            })
             .ToListAsync(ct);
 
-        return new LibraryBooksResult(
-            raw.Select(ToBookListItem).ToList(), totalCount, totalPages, page);
-    }
+        var items = raw.Select(b => new BookListItem(
+            b.Id,
+            b.Title,
+            // Subtitle only renders for single-Work books — for collections the
+            // inner-Work subtitle would be an arbitrary story's, which reads as noise.
+            b.WorksCount == 1 ? b.Works[0].Subtitle : null,
+            // Comma-join unique author names across all Works (each Work's authors
+            // already ordered by Order in SQL). List views stay uniform; the " & "
+            // formatter is reserved for single-Work surfaces.
+            string.Join(", ", b.Works.SelectMany(w => w.Authors).Distinct()),
+            b.DefaultCoverArtUrl,
+            b.Status,
+            b.Rating,
+            b.WorksCount,
+            b.Works.SelectMany(w => w.Genres).Distinct().ToList(),
+            b.Tags)).ToList();
 
-    private static BookListItem ToBookListItem(Book b) => new(
-        b.Id,
-        b.Title,
-        // Subtitle only renders for single-Work books — for collections the
-        // inner-Work subtitle would be an arbitrary story's, which reads as noise.
-        b.Works.Count == 1 ? b.Works.First().Subtitle : null,
-        // Comma-join unique author names across all Works. List views stay
-        // uniform; the " & " formatter is reserved for single-Work surfaces.
-        string.Join(", ", b.Works.SelectMany(w => w.WorkAuthors.Where(wa => wa.Role == AuthorRole.Author).OrderBy(wa => wa.Order).Select(wa => wa.Author.Name)).Distinct()),
-        b.DefaultCoverArtUrl,
-        b.Status,
-        b.Rating,
-        b.Works.Count,
-        b.Works.SelectMany(w => w.Genres).Select(g => g.Name).Distinct().ToList(),
-        b.Tags.Select(t => t.Name).ToList());
+        return new LibraryBooksResult(items, totalCount, totalPages, page);
+    }
 }

--- a/BookTracker.Application/Books/LibraryBookQuery.cs
+++ b/BookTracker.Application/Books/LibraryBookQuery.cs
@@ -4,20 +4,17 @@ using Microsoft.EntityFrameworkCore;
 
 namespace BookTracker.Application.Books;
 
-// Shared filtered Book query for the Library read models — the include graph +
-// the filter predicate, lifted verbatim from BookListViewModel so the flat-list
-// (GetLibraryBooks) and grouped (GetLibraryGroups) reads filter identically.
-// NOTE: the load-then-project shape with a 4-collection Include (the TD-2
-// cartesian) is preserved as-is; pushing the projection to SQL is deferred to
-// the TD-17 close-out consolidation.
+// Shared filtered Book query for the Library read models — just the filter
+// predicate, so the flat-list (GetLibraryBooks) and grouped (GetLibraryGroups)
+// reads filter identically. The filters are all `.Any()` → SQL `EXISTS`, so no
+// Includes are needed: GetLibraryGroups projects via SelectMany/GroupBy and
+// GetLibraryBooks projects its page (both close-2b), so the old 4-collection
+// Include cartesian (TD-2) is gone.
 internal static class LibraryBookQuery
 {
     public static IQueryable<Book> Filtered(BookTrackerDbContext db, LibraryFilter f)
     {
-        IQueryable<Book> query = db.Books
-            .Include(b => b.Tags)
-            .Include(b => b.Works).ThenInclude(w => w.Genres)
-            .Include(b => b.Works).ThenInclude(w => w.WorkAuthors).ThenInclude(wa => wa.Author);
+        IQueryable<Book> query = db.Books;
 
         if (!string.IsNullOrWhiteSpace(f.SearchTerm))
         {

--- a/BookTracker.Application/Catalog/GetCatalogSnapshot.cs
+++ b/BookTracker.Application/Catalog/GetCatalogSnapshot.cs
@@ -198,9 +198,9 @@ public sealed class GetCatalogSnapshotHandler(IDbContextFactory<BookTrackerDbCon
             .Select(a => new { a.Id, a.Name, CanonicalId = a.CanonicalAuthorId ?? a.Id })
             .ToListAsync(ct);
 
-        var perAuthor = await AuthorRollups.PerAuthorAsync(db, ct);
+        var perAuthorBooks = await AuthorRollups.PerAuthorBookCountAsync(db, ct);
         var byCanonical = AuthorRollups.RollUpToCanonical(
-            perAuthor, authorRows.Select(a => (a.Id, a.CanonicalId)));
+            perAuthorBooks, authorRows.Select(a => (a.Id, a.CanonicalId)));
 
         var authors = authorRows
             .Select(a => new AuthorSnapshot(
@@ -208,8 +208,8 @@ public sealed class GetCatalogSnapshotHandler(IDbContextFactory<BookTrackerDbCon
                 a.Name,
                 a.CanonicalId,
                 BookCount: a.Id == a.CanonicalId
-                    ? byCanonical.GetValueOrDefault(a.CanonicalId)?.BookCount ?? 0
-                    : perAuthor.GetValueOrDefault(a.Id)?.BookCount ?? 0))
+                    ? byCanonical.GetValueOrDefault(a.CanonicalId)
+                    : perAuthorBooks.GetValueOrDefault(a.Id)))
             .OrderBy(a => a.Name)
             .ToList();
 

--- a/BookTracker.Application/Catalog/GetCatalogSnapshot.cs
+++ b/BookTracker.Application/Catalog/GetCatalogSnapshot.cs
@@ -189,10 +189,11 @@ public sealed class GetCatalogSnapshotHandler(IDbContextFactory<BookTrackerDbCon
 
         // Authors — BookCount per row via the shared SQL-side rollup (Author-role
         // distinct books), so /authors, Home, and this snapshot read one
-        // definition. Canonical rows take the rolled-up count (own + aliases,
-        // de-duped at the canonical key so a book credited to both counts once);
-        // alias rows take their own (tapping "Richard Bachman" shows just
-        // Bachman's titles, "Stephen King" the rolled-up total).
+        // definition. Canonical rows take the rolled-up count (own + aliases
+        // summed — a title credited to both a canonical and one of its aliases
+        // counts once per crediting member; see AuthorRollups); alias rows take
+        // their own (tapping "Richard Bachman" shows just Bachman's titles,
+        // "Stephen King" the rolled-up total).
         var authorRows = await db.Authors
             .AsNoTracking()
             .Select(a => new { a.Id, a.Name, CanonicalId = a.CanonicalAuthorId ?? a.Id })
@@ -207,9 +208,8 @@ public sealed class GetCatalogSnapshotHandler(IDbContextFactory<BookTrackerDbCon
                 a.Id,
                 a.Name,
                 a.CanonicalId,
-                BookCount: a.Id == a.CanonicalId
-                    ? byCanonical.GetValueOrDefault(a.CanonicalId)
-                    : perAuthorBooks.GetValueOrDefault(a.Id)))
+                BookCount: AuthorRollups.SelectForDisplay(
+                    a.Id, a.CanonicalId, byCanonical, perAuthorBooks)))
             .OrderBy(a => a.Name)
             .ToList();
 

--- a/BookTracker.Application/Home/GetHomeDashboard.cs
+++ b/BookTracker.Application/Home/GetHomeDashboard.cs
@@ -42,16 +42,16 @@ public sealed class GetHomeDashboardHandler(IDbContextFactory<BookTrackerDbConte
         // no surviving books so a works-but-all-tombstoned author can't land a
         // "0 books" row in the headline, order by count then id for a
         // deterministic boundary, then sort for display (count desc, name asc).
-        var perAuthor = await AuthorRollups.PerAuthorAsync(db, ct);
+        var perAuthorBooks = await AuthorRollups.PerAuthorBookCountAsync(db, ct);
         var membership = await db.Authors
             .AsNoTracking()
             .Select(a => new { a.Id, Canonical = a.CanonicalAuthorId ?? a.Id })
             .ToListAsync(ct);
         var rollup = AuthorRollups.RollUpToCanonical(
-            perAuthor, membership.Select(m => (m.Id, m.Canonical)));
+            perAuthorBooks, membership.Select(m => (m.Id, m.Canonical)));
         var top = rollup
-            .Where(kv => kv.Value.BookCount > 0)
-            .OrderByDescending(kv => kv.Value.BookCount)
+            .Where(kv => kv.Value > 0)
+            .OrderByDescending(kv => kv.Value)
             .ThenBy(kv => kv.Key)
             .Take(10)
             .ToList();
@@ -63,7 +63,7 @@ public sealed class GetHomeDashboardHandler(IDbContextFactory<BookTrackerDbConte
             .ToDictionaryAsync(x => x.Id, x => x.Name, ct);
 
         var topAuthors = top
-            .Select(t => new AuthorCount(t.Key, nameLookup.GetValueOrDefault(t.Key) ?? "(unknown)", t.Value.BookCount))
+            .Select(t => new AuthorCount(t.Key, nameLookup.GetValueOrDefault(t.Key) ?? "(unknown)", t.Value))
             .OrderByDescending(a => a.Count)
             .ThenBy(a => a.Author)
             .ToList();

--- a/BookTracker.Application/Home/GetHomeDashboard.cs
+++ b/BookTracker.Application/Home/GetHomeDashboard.cs
@@ -43,12 +43,15 @@ public sealed class GetHomeDashboardHandler(IDbContextFactory<BookTrackerDbConte
         // "0 books" row in the headline, order by count then id for a
         // deterministic boundary, then sort for display (count desc, name asc).
         var perAuthorBooks = await AuthorRollups.PerAuthorBookCountAsync(db, ct);
-        var membership = await db.Authors
+        // One pass over Authors carries both the canonical membership (for the
+        // rollup) and the names (for the display lookup) — no second round-trip
+        // just to resolve the top-10 canonical names.
+        var authors = await db.Authors
             .AsNoTracking()
-            .Select(a => new { a.Id, Canonical = a.CanonicalAuthorId ?? a.Id })
+            .Select(a => new { a.Id, a.Name, Canonical = a.CanonicalAuthorId ?? a.Id })
             .ToListAsync(ct);
         var rollup = AuthorRollups.RollUpToCanonical(
-            perAuthorBooks, membership.Select(m => (m.Id, m.Canonical)));
+            perAuthorBooks, authors.Select(m => (m.Id, m.Canonical)));
         var top = rollup
             .Where(kv => kv.Value > 0)
             .OrderByDescending(kv => kv.Value)
@@ -56,14 +59,10 @@ public sealed class GetHomeDashboardHandler(IDbContextFactory<BookTrackerDbConte
             .Take(10)
             .ToList();
 
-        var canonicalIds = top.Select(t => t.Key).ToList();
-        var nameLookup = await db.Authors
-            .Where(a => canonicalIds.Contains(a.Id))
-            .Select(a => new { a.Id, a.Name })
-            .ToDictionaryAsync(x => x.Id, x => x.Name, ct);
+        var nameById = authors.ToDictionary(a => a.Id, a => a.Name);
 
         var topAuthors = top
-            .Select(t => new AuthorCount(t.Key, nameLookup.GetValueOrDefault(t.Key) ?? "(unknown)", t.Value))
+            .Select(t => new AuthorCount(t.Key, nameById.GetValueOrDefault(t.Key) ?? "(unknown)", t.Value))
             .OrderByDescending(a => a.Count)
             .ThenBy(a => a.Author)
             .ToList();

--- a/BookTracker.Application/Works/GetWorkMergePreview.cs
+++ b/BookTracker.Application/Works/GetWorkMergePreview.cs
@@ -110,18 +110,10 @@ public sealed class GetWorkMergePreviewHandler(IDbContextFactory<BookTrackerDbCo
             .Select(b => b.Title)
             .ToListAsync(ct);
 
-        // Cover pick: prefer a single-Work Book (its cover represents this
-        // Work faithfully); fall back to any Book.
-        var singleWorkBookCover = await db.Books
-            .Where(b => b.Works.Any(w => w.Id == id) && b.Works.Count == 1)
-            .Select(b => b.DefaultCoverArtUrl)
-            .FirstOrDefaultAsync(ct);
-        var fallbackCover = singleWorkBookCover is null
-            ? await db.Books
-                .Where(b => b.Works.Any(w => w.Id == id))
-                .Select(b => b.DefaultCoverArtUrl)
-                .FirstOrDefaultAsync(ct)
-            : singleWorkBookCover;
+        // Cover pick: prefer a single-Work Book, fall back to any Book
+        // containing this Work (shared rule — BookCovers).
+        var fallbackCover = await Books.BookCovers.PickAsync(
+            db.Books.Where(b => b.Works.Any(w => w.Id == id)), ct);
 
         return new WorkMergeDetail(
             work.Id, work.Title, work.Subtitle,


### PR DESCRIPTION
- **refactor(read-models): project Library list, share cover-pick, BookCount-only rollup (close-2b)**
- **refactor(read-models): whole-arc review fixes — light per-author rollups (close-2b)**
