### PR TITLE
chore: gitignore TestResults/ + *.trx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@ bin/
 obj/
 [Dd]ebug/
 [Rr]elease/
+
+# Test run output (dotnet test --logger trx writes TestResults/*.trx)
+TestResults/
+*.trx
 x64/
 x86/
 [Bb]uild/


### PR DESCRIPTION
A stray BookTracker.Tests/TestResults/resauth.trx from a `dotnet test
--logger trx` run was lurking untracked (deleted). The build-output section
ignored bin/obj but not the test-run output dir, so trx files sat unignored.
Add TestResults/ and *.trx so they can't be accidentally staged.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
