### PR TITLE
fix(web): clear MudBlazor 9 Razor warnings + repair dead cover-upload button (TD-11)

### DIFF
--- a/BookTracker.Web/Components/Shared/EditionCoverUploadDialog.razor
+++ b/BookTracker.Web/Components/Shared/EditionCoverUploadDialog.razor
@@ -21,22 +21,28 @@
                for accept="image/*" alone — they fall back to the file picker.
                iOS Safari respects the hint by pre-selecting "Take Photo or
                Video" in the action sheet but still allows gallery via the
-               same sheet. Forwarded through MudFileUpload's InputAttributes
-               which propagate to the underlying <input type="file">. *@
+               same sheet. Passed via @attributes → MudFileUpload's captured
+               UserAttributes, which it spreads onto the underlying
+               <input type="file"> (MudBlazor 9 dropped the old InputAttributes
+               parameter). *@
             <MudFileUpload T="IBrowserFile"
                            FilesChanged="OnFileChanged"
                            Accept="image/*"
                            MaximumFileCount="1"
-                           InputAttributes="@(new Dictionary<string, object?> { ["capture"] = "environment" })">
-                <ActivatorContent>
+                           @attributes="@(new Dictionary<string, object> { ["capture"] = "environment" })">
+                @* MudBlazor 9 replaced ActivatorContent with CustomContent,
+                   which no longer auto-wires a label to the hidden input —
+                   the activator must call OpenFilePickerAsync() itself. *@
+                <CustomContent>
                     <MudButton Variant="Variant.Outlined"
                                StartIcon="@Icons.Material.Filled.CameraAlt"
                                Color="Color.Primary"
                                FullWidth="true"
-                               Disabled="@uploading">
+                               Disabled="@uploading"
+                               OnClick="@(() => context.OpenFilePickerAsync())">
                         @(picked is null ? "Choose photo" : "Choose different photo")
                     </MudButton>
-                </ActivatorContent>
+                </CustomContent>
             </MudFileUpload>
 
             @if (picked is not null)

--- a/BookTracker.Web/Components/Shared/MarkReadDialog.razor
+++ b/BookTracker.Web/Components/Shared/MarkReadDialog.razor
@@ -22,7 +22,7 @@
                           Label="Notes (optional)"
                           Variant="Variant.Outlined"
                           Lines="3"
-                          AutoGrow="true" />
+                          Sizing="InputSizing.Auto" />
         </MudStack>
     </DialogContent>
     <DialogActions>


### PR DESCRIPTION
First of the TD-11 backlog clears (warnings-as-errors prep). All four Web
warnings were stale MudBlazor 8->9 API drift:

- EditionCoverUploadDialog: MudFileUpload dropped `InputAttributes` and
  `ActivatorContent` in MudBlazor 9. Migrated to `@attributes` (capture=
  environment still spreads onto the hidden <input> via UserAttributes) and
  `CustomContent`. CustomContent no longer auto-wires a label to the input, so
  the activator button now calls `OpenFilePickerAsync()` explicitly — the old
  `ActivatorContent` was unrecognised (RZ10012), so the "Choose photo" button
  was almost certainly inert in production. Behavioural repair, not just a
  warning fix — worth a manual verify.
- MarkReadDialog: MudTextField `AutoGrow="true"` -> `Sizing="InputSizing.Auto"`
  (the auto-grow mechanism was renamed in MudBlazor 9).

Verified against the MudBlazor v9.5.0 component source. Clean --no-incremental
Web build: 0 warnings, 0 errors.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
