### PR TITLE
build: TreatWarningsAsErrors on the clean managed projects + fix CS0618 (TD-11)

### DIFF
--- a/BookTracker.Mobile.Cache.Tests/BookTracker.Mobile.Cache.Tests.csproj
+++ b/BookTracker.Mobile.Cache.Tests/BookTracker.Mobile.Cache.Tests.csproj
@@ -13,6 +13,9 @@
     <IsPackable>false</IsPackable>
     <!-- Same SQLitePCLRaw alpine-RID noise as the Cache project. -->
     <NoWarn>$(NoWarn);NETSDK1206</NoWarn>
+    <!-- TD-11: opted out until the Mobile PR bumps SQLitePCLRaw off the
+         NU1903-flagged 2.1.2 (inherited transitively from the Cache project). -->
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/BookTracker.Mobile.Cache/BookTracker.Mobile.Cache.csproj
+++ b/BookTracker.Mobile.Cache/BookTracker.Mobile.Cache.csproj
@@ -21,6 +21,10 @@
          runners, never alpine. Suppressing rather than carrying the
          noise on every build. -->
     <NoWarn>$(NoWarn);NETSDK1206</NoWarn>
+    <!-- TD-11: opted out of the repo-wide TreatWarningsAsErrors until the
+         Mobile PR bumps SQLitePCLRaw off the NU1903-flagged 2.1.2 (high-severity
+         vuln, transitive via sqlite-net-pcl). Delete this line once clean. -->
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/BookTracker.Mobile/BookTracker.Mobile.csproj
+++ b/BookTracker.Mobile/BookTracker.Mobile.csproj
@@ -17,6 +17,11 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 
+		<!-- TD-11: opted out of the repo-wide TreatWarningsAsErrors until the
+		     Mobile PR handles XA0141 (16KB-page alignment of ZXing camera-core +
+		     SQLitePCLRaw native libs) — partly NoWarn, partly upstream bumps. -->
+		<TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+
 		<MauiXamlInflator>SourceGen</MauiXamlInflator>
 
 		<ApplicationTitle>Bookshelf</ApplicationTitle>

--- a/BookTracker.Tests/SqlServerContainer.cs
+++ b/BookTracker.Tests/SqlServerContainer.cs
@@ -26,7 +26,11 @@ internal static class SqlServerContainer
 
     private static MsSqlContainer StartAndMigrate()
     {
-        var c = new MsSqlBuilder()
+        // Pin the image explicitly — Testcontainers 4.x deprecated the implicit
+        // default (and the MsSqlImage const) so an engine change can't slip in on
+        // a package bump. This literal is the 4.12.0 default, so behaviour is
+        // unchanged; bump it deliberately when we want a newer SQL Server CU.
+        var c = new MsSqlBuilder("mcr.microsoft.com/mssql/server:2022-CU14-ubuntu-22.04")
             .WithCleanUp(true)
             .Build();
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,23 @@
+<Project>
+
+  <!--
+    Repo-wide build policy (TD-11). Promotes compiler + restore warnings to
+    errors so deprecations, nullable holes, analyzer hits, and NuGet audit
+    advisories gate a PR instead of slipping through an incremental build
+    (which only recompiles changed assemblies, so warnings in untouched code
+    silently vanish — see .claude-memory/feedback_verify_warnings_clean_build.md).
+
+    This only PROMOTES existing warnings — it adds no new analyzers and no
+    stricter nullable/analysis settings.
+
+    Projects not yet warning-clean opt out with their own
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>. Current opt-outs
+    (cleared in the TD-11/TD-10 Mobile PR): BookTracker.Mobile.Cache,
+    BookTracker.Mobile.Cache.Tests, BookTracker.Mobile — all blocked on the
+    SQLitePCLRaw bump (NU1903 + XA0141).
+  -->
+  <PropertyGroup>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
Second TD-11 step — flip the switch where the build is already clean.

- Add a root Directory.Build.props setting TreatWarningsAsErrors=true. It only
  PROMOTES existing warnings (no new analyzers / nullable strictness). CI builds
  the whole slnx in Release, so this now gates every PR on a warning-clean build.
- Fix the last managed warning: BookTracker.Tests SqlServerContainer used the
  obsolete parameterless MsSqlBuilder() (CS0618). Pin the image explicitly via
  new MsSqlBuilder("mcr.microsoft.com/mssql/server:2022-CU14-ubuntu-22.04") —
  the 4.12.0 default, so the test container engine is unchanged; the const
  MsSqlImage is itself obsolete so it's inlined.
- Opt the not-yet-clean projects out (TreatWarningsAsErrors=false) until the
  Mobile PR clears them: BookTracker.Mobile.Cache + .Cache.Tests (NU1903 on the
  transitive SQLitePCLRaw.lib.e_sqlite3 2.1.2) and BookTracker.Mobile (XA0141).

Now live on Application / Data / Shared / Web / Tests. Full Release slnx build:
0 errors (4 NU1903 warnings remain, confined to the opted-out Mobile.Cache
projects). Unit/Component/Integration suite green (91 + 663).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
