### PR TITLE
feat/td15a publisher eager create

### DIFF
--- a/BookTracker.Application/Books/CreatePublisher.cs
+++ b/BookTracker.Application/Books/CreatePublisher.cs
@@ -1,0 +1,33 @@
+using BookTracker.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookTracker.Application.Books;
+
+/// <summary>
+/// Eagerly find-or-create a <c>Publisher</c> by name and return its id.
+/// Dispatched by the publisher autocompletes the moment the user commits a
+/// name (TD-15a) — picking a suggestion or leaving free text in the field —
+/// so the row exists immediately rather than being created during the Edition
+/// save. Idempotent: an existing name returns its id, a blank name is a no-op
+/// returning null.
+///
+/// Plain find-or-create via <see cref="PublisherResolver"/> (so name handling
+/// lives in one place). The check-then-insert race is the accepted single-user
+/// residual tracked as TD-15 — moving creation here just localises it to a tiny
+/// dedicated command instead of the contended aggregate save. Mirrors
+/// <c>CreateAuthor</c>.
+/// </summary>
+public sealed record CreatePublisher(string? Name) : ICommand<int?>;
+
+public sealed class CreatePublisherHandler(IDbContextFactory<BookTrackerDbContext> dbFactory)
+    : ICommandHandler<CreatePublisher, int?>
+{
+    public async Task<int?> HandleAsync(CreatePublisher command, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var publisher = await PublisherResolver.ResolveAsync(db, command.Name, ct);
+        if (publisher is null) return null;
+        await db.SaveChangesAsync(ct);
+        return publisher.Id;
+    }
+}

--- a/BookTracker.Tests/Application/Books/CreatePublisherHandlerTests.cs
+++ b/BookTracker.Tests/Application/Books/CreatePublisherHandlerTests.cs
@@ -1,0 +1,51 @@
+using BookTracker.Application.Books;
+using Xunit;
+
+namespace BookTracker.Tests;
+
+// Integration tests for the eager-create Publisher command (TD-15a). The
+// publisher autocompletes dispatch this on commit so the row exists
+// immediately; it's an idempotent find-or-create returning the id (or null
+// for a blank name, mirroring PublisherResolver).
+[Trait("Category", TestCategories.Integration)]
+public class CreatePublisherHandlerTests
+{
+    private readonly TestDbContextFactory _factory = new();
+
+    [Fact]
+    public async Task CreatePublisher_newName_insertsTrimmedAndReturnsId()
+    {
+        var id = await new CreatePublisherHandler(_factory).HandleAsync(new CreatePublisher("  Gollancz  "));
+
+        Assert.NotNull(id);
+        await using var db = _factory.CreateDbContext();
+        var saved = await db.Publishers.FindAsync(id);
+        Assert.NotNull(saved);
+        Assert.Equal("Gollancz", saved!.Name); // trimmed
+        Assert.Equal(1, db.Publishers.Count(p => p.Name == "Gollancz"));
+    }
+
+    [Fact]
+    public async Task CreatePublisher_existingName_returnsExistingIdNoDuplicate()
+    {
+        var first = await new CreatePublisherHandler(_factory).HandleAsync(new CreatePublisher("Penguin Books"));
+        var second = await new CreatePublisherHandler(_factory).HandleAsync(new CreatePublisher("penguin books")); // CI clash
+
+        Assert.Equal(first, second); // idempotent — resolves to the same row
+        await using var db = _factory.CreateDbContext();
+        Assert.Equal(1, db.Publishers.Count(p => p.Name == "Penguin Books")); // not duplicated
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task CreatePublisher_blankName_returnsNullAndInsertsNothing(string? name)
+    {
+        var id = await new CreatePublisherHandler(_factory).HandleAsync(new CreatePublisher(name));
+
+        Assert.Null(id);
+        await using var db = _factory.CreateDbContext();
+        Assert.Equal(0, db.Publishers.Count());
+    }
+}

--- a/BookTracker.Tests/Components/EditionCopyFormTests.cs
+++ b/BookTracker.Tests/Components/EditionCopyFormTests.cs
@@ -1,0 +1,88 @@
+using BookTracker.Application;
+using BookTracker.Application.Books;
+using BookTracker.Web.Components.Shared;
+using BookTracker.Web.ViewModels;
+using Bunit;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Xunit;
+
+namespace BookTracker.Tests.Components;
+
+/// <summary>
+/// bUnit tests for EditionCopyForm's publisher eager-create wiring (TD-15a).
+/// The publisher MudAutocomplete commits via ValueChanged (pick or coerced
+/// free text), which stores the value and dispatches <see cref="CreatePublisher"/>
+/// best-effort so the row exists immediately. Mirrors the author-picker
+/// pattern in <see cref="MudAuthorPickerTests"/>.
+///
+/// Integration-flavoured: EditionCopyForm.OnInitializedAsync loads existing
+/// publishers from the DB, so it needs a real <see cref="TestDbContextFactory"/>
+/// (wiped empty) behind its EditionFormViewModel rather than the DB-free stub
+/// the chip-only author picker gets.
+/// </summary>
+[Trait("Category", TestCategories.Integration)]
+public class EditionCopyFormTests : ComponentTestBase
+{
+    private readonly IDispatcher _dispatcher = Substitute.For<IDispatcher>();
+
+    public EditionCopyFormTests()
+    {
+        Services.AddSingleton(_dispatcher);
+        Services.AddLogging();
+        // Real (wiped-empty) DB behind the VM so InitializeAsync's publisher
+        // load succeeds; the eager-create path under test goes through the
+        // substituted dispatcher, not this factory.
+        Services.AddScoped(_ => new EditionFormViewModel(new TestDbContextFactory()));
+    }
+
+    private (EditionFormViewModel.EditionFormInput Edition, CopyFormViewModel.CopyFormInput Copy) Inputs()
+        => (new EditionFormViewModel.EditionFormInput(), new CopyFormViewModel.CopyFormInput());
+
+    [Fact]
+    public async Task PublisherCommit_NewName_StoresValueAndEagerCreates()
+    {
+        var (edition, copy) = Inputs();
+        var cut = Render<EditionCopyForm>(p => p
+            .Add(c => c.EditionInput, edition)
+            .Add(c => c.CopyInput, copy));
+
+        await cut.InvokeAsync(() => cut.Instance.OnPublisherCommittedAsync("Gollancz"));
+
+        Assert.Equal("Gollancz", edition.Publisher);
+        await _dispatcher.Received(1).Send(
+            Arg.Is<CreatePublisher>(c => c.Name == "Gollancz"), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PublisherCommit_Blank_StoresValueButDoesNotEagerCreate()
+    {
+        var (edition, copy) = Inputs();
+        var cut = Render<EditionCopyForm>(p => p
+            .Add(c => c.EditionInput, edition)
+            .Add(c => c.CopyInput, copy));
+
+        await cut.InvokeAsync(() => cut.Instance.OnPublisherCommittedAsync("   "));
+
+        Assert.Equal("   ", edition.Publisher);
+        await _dispatcher.DidNotReceive().Send(
+            Arg.Any<CreatePublisher>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PublisherCommit_EagerCreateThrows_StillStoresValue()
+    {
+        // Best-effort: a faulting dispatch must not abort the field edit — the
+        // save's PublisherResolver net guarantees the row.
+        _dispatcher.Send(Arg.Any<CreatePublisher>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<int?>(new InvalidOperationException("transient")));
+        var (edition, copy) = Inputs();
+        var cut = Render<EditionCopyForm>(p => p
+            .Add(c => c.EditionInput, edition)
+            .Add(c => c.CopyInput, copy));
+
+        await cut.InvokeAsync(() => cut.Instance.OnPublisherCommittedAsync("Gollancz"));
+
+        Assert.Equal("Gollancz", edition.Publisher);
+    }
+}

--- a/BookTracker.Tests/Components/EditionCopyFormTests.cs
+++ b/BookTracker.Tests/Components/EditionCopyFormTests.cs
@@ -11,12 +11,13 @@ using Xunit;
 namespace BookTracker.Tests.Components;
 
 /// <summary>
-/// bUnit tests for EditionCopyForm's publisher eager-create wiring (TD-15a).
-/// The publisher MudAutocomplete commits via ValueChanged (pick or coerced
-/// free text), which stores the value and — only for a name not already in the
-/// cached publisher list — dispatches <see cref="CreatePublisher"/> best-effort
-/// so the row exists immediately. An existing pick is a no-op (no wire call).
-/// Mirrors the author-picker pattern in <see cref="MudAuthorPickerTests"/>.
+/// bUnit tests for EditionCopyForm's publisher eager-create (TD-15a). The
+/// commit gesture is the field losing focus (OnBlur) — NOT per-keystroke
+/// ValueChanged, which fired on every character and created a publisher row
+/// for each partial string. On blur, a name not already in the cached list is
+/// eager-created via <see cref="CreatePublisher"/> (best-effort); an existing
+/// name or blank is a no-op (no wire call). @bind-Value handles the field value
+/// itself, so these tests drive the eager-create method directly.
 ///
 /// Integration-flavoured: EditionCopyForm.OnInitializedAsync loads existing
 /// publishers from the DB, so it needs a real <see cref="TestDbContextFactory"/>
@@ -47,20 +48,19 @@ public class EditionCopyFormTests : ComponentTestBase
             .Add(c => c.CopyInput, copy));
 
     [Fact]
-    public async Task PublisherCommit_NewName_StoresValueAndEagerCreates()
+    public async Task PublisherBlur_NewName_EagerCreates()
     {
         var (edition, copy) = Inputs();
         var cut = RenderForm(edition, copy);
 
-        await cut.InvokeAsync(() => cut.Instance.OnPublisherCommittedAsync("Gollancz"));
+        await cut.InvokeAsync(() => cut.Instance.EagerCreatePublisherIfNewAsync("Gollancz"));
 
-        Assert.Equal("Gollancz", edition.Publisher);
         await _dispatcher.Received(1).Send(
             Arg.Is<CreatePublisher>(c => c.Name == "Gollancz"), Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public async Task PublisherCommit_ExistingName_StoresValueButDoesNotEagerCreate()
+    public async Task PublisherBlur_ExistingName_DoesNotEagerCreate()
     {
         // Seed an existing publisher; OnInitializedAsync caches it. Committing it
         // (even with a case clash) is a pure pick — no CreatePublisher round-trip.
@@ -72,38 +72,38 @@ public class EditionCopyFormTests : ComponentTestBase
         var (edition, copy) = Inputs();
         var cut = RenderForm(edition, copy);
 
-        await cut.InvokeAsync(() => cut.Instance.OnPublisherCommittedAsync("penguin books"));
+        await cut.InvokeAsync(() => cut.Instance.EagerCreatePublisherIfNewAsync("penguin books"));
 
-        Assert.Equal("penguin books", edition.Publisher);
         await _dispatcher.DidNotReceive().Send(
             Arg.Any<CreatePublisher>(), Arg.Any<CancellationToken>());
     }
 
-    [Fact]
-    public async Task PublisherCommit_Blank_StoresValueButDoesNotEagerCreate()
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task PublisherBlur_Blank_DoesNotEagerCreate(string? value)
     {
         var (edition, copy) = Inputs();
         var cut = RenderForm(edition, copy);
 
-        await cut.InvokeAsync(() => cut.Instance.OnPublisherCommittedAsync("   "));
+        await cut.InvokeAsync(() => cut.Instance.EagerCreatePublisherIfNewAsync(value));
 
-        Assert.Equal("   ", edition.Publisher);
         await _dispatcher.DidNotReceive().Send(
             Arg.Any<CreatePublisher>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public async Task PublisherCommit_EagerCreateThrows_StillStoresValue()
+    public async Task PublisherBlur_EagerCreateThrows_DoesNotSurface()
     {
-        // Best-effort: a faulting dispatch must not abort the field edit — the
-        // save's PublisherResolver net guarantees the row.
+        // Best-effort: a faulting dispatch must not throw out of the blur handler
+        // — the save's PublisherResolver net guarantees the row.
         _dispatcher.Send(Arg.Any<CreatePublisher>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromException<int?>(new InvalidOperationException("transient")));
         var (edition, copy) = Inputs();
         var cut = RenderForm(edition, copy);
 
-        await cut.InvokeAsync(() => cut.Instance.OnPublisherCommittedAsync("Gollancz"));
-
-        Assert.Equal("Gollancz", edition.Publisher);
+        // Should complete without throwing.
+        await cut.InvokeAsync(() => cut.Instance.EagerCreatePublisherIfNewAsync("Gollancz"));
     }
 }

--- a/BookTracker.Tests/Components/EditionCopyFormTests.cs
+++ b/BookTracker.Tests/Components/EditionCopyFormTests.cs
@@ -1,5 +1,6 @@
 using BookTracker.Application;
 using BookTracker.Application.Books;
+using BookTracker.Data.Models;
 using BookTracker.Web.Components.Shared;
 using BookTracker.Web.ViewModels;
 using Bunit;
@@ -12,40 +13,44 @@ namespace BookTracker.Tests.Components;
 /// <summary>
 /// bUnit tests for EditionCopyForm's publisher eager-create wiring (TD-15a).
 /// The publisher MudAutocomplete commits via ValueChanged (pick or coerced
-/// free text), which stores the value and dispatches <see cref="CreatePublisher"/>
-/// best-effort so the row exists immediately. Mirrors the author-picker
-/// pattern in <see cref="MudAuthorPickerTests"/>.
+/// free text), which stores the value and — only for a name not already in the
+/// cached publisher list — dispatches <see cref="CreatePublisher"/> best-effort
+/// so the row exists immediately. An existing pick is a no-op (no wire call).
+/// Mirrors the author-picker pattern in <see cref="MudAuthorPickerTests"/>.
 ///
 /// Integration-flavoured: EditionCopyForm.OnInitializedAsync loads existing
 /// publishers from the DB, so it needs a real <see cref="TestDbContextFactory"/>
-/// (wiped empty) behind its EditionFormViewModel rather than the DB-free stub
-/// the chip-only author picker gets.
+/// (wiped empty, then optionally seeded per test) behind its EditionFormViewModel.
 /// </summary>
 [Trait("Category", TestCategories.Integration)]
 public class EditionCopyFormTests : ComponentTestBase
 {
     private readonly IDispatcher _dispatcher = Substitute.For<IDispatcher>();
+    private readonly TestDbContextFactory _factory = new();
 
     public EditionCopyFormTests()
     {
         Services.AddSingleton(_dispatcher);
         Services.AddLogging();
-        // Real (wiped-empty) DB behind the VM so InitializeAsync's publisher
-        // load succeeds; the eager-create path under test goes through the
-        // substituted dispatcher, not this factory.
-        Services.AddScoped(_ => new EditionFormViewModel(new TestDbContextFactory()));
+        // Reuse the one (already-wiped) factory so per-test seeding survives —
+        // a fresh TestDbContextFactory would wipe again on construction. The
+        // eager-create path under test goes through the substituted dispatcher.
+        Services.AddScoped(_ => new EditionFormViewModel(_factory));
     }
 
     private (EditionFormViewModel.EditionFormInput Edition, CopyFormViewModel.CopyFormInput Copy) Inputs()
         => (new EditionFormViewModel.EditionFormInput(), new CopyFormViewModel.CopyFormInput());
 
+    private IRenderedComponent<EditionCopyForm> RenderForm(EditionFormViewModel.EditionFormInput edition, CopyFormViewModel.CopyFormInput copy)
+        => Render<EditionCopyForm>(p => p
+            .Add(c => c.EditionInput, edition)
+            .Add(c => c.CopyInput, copy));
+
     [Fact]
     public async Task PublisherCommit_NewName_StoresValueAndEagerCreates()
     {
         var (edition, copy) = Inputs();
-        var cut = Render<EditionCopyForm>(p => p
-            .Add(c => c.EditionInput, edition)
-            .Add(c => c.CopyInput, copy));
+        var cut = RenderForm(edition, copy);
 
         await cut.InvokeAsync(() => cut.Instance.OnPublisherCommittedAsync("Gollancz"));
 
@@ -55,12 +60,30 @@ public class EditionCopyFormTests : ComponentTestBase
     }
 
     [Fact]
+    public async Task PublisherCommit_ExistingName_StoresValueButDoesNotEagerCreate()
+    {
+        // Seed an existing publisher; OnInitializedAsync caches it. Committing it
+        // (even with a case clash) is a pure pick — no CreatePublisher round-trip.
+        await using (var db = _factory.CreateDbContext())
+        {
+            db.Publishers.Add(new Publisher { Name = "Penguin Books" });
+            await db.SaveChangesAsync();
+        }
+        var (edition, copy) = Inputs();
+        var cut = RenderForm(edition, copy);
+
+        await cut.InvokeAsync(() => cut.Instance.OnPublisherCommittedAsync("penguin books"));
+
+        Assert.Equal("penguin books", edition.Publisher);
+        await _dispatcher.DidNotReceive().Send(
+            Arg.Any<CreatePublisher>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task PublisherCommit_Blank_StoresValueButDoesNotEagerCreate()
     {
         var (edition, copy) = Inputs();
-        var cut = Render<EditionCopyForm>(p => p
-            .Add(c => c.EditionInput, edition)
-            .Add(c => c.CopyInput, copy));
+        var cut = RenderForm(edition, copy);
 
         await cut.InvokeAsync(() => cut.Instance.OnPublisherCommittedAsync("   "));
 
@@ -77,9 +100,7 @@ public class EditionCopyFormTests : ComponentTestBase
         _dispatcher.Send(Arg.Any<CreatePublisher>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromException<int?>(new InvalidOperationException("transient")));
         var (edition, copy) = Inputs();
-        var cut = Render<EditionCopyForm>(p => p
-            .Add(c => c.EditionInput, edition)
-            .Add(c => c.CopyInput, copy));
+        var cut = RenderForm(edition, copy);
 
         await cut.InvokeAsync(() => cut.Instance.OnPublisherCommittedAsync("Gollancz"));
 

--- a/BookTracker.Tests/ViewModels/EditionFormDialogViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/EditionFormDialogViewModelTests.cs
@@ -210,6 +210,27 @@ public class EditionFormDialogViewModelTests
     }
 
     [Fact]
+    public async Task InitializeForAdd_CachesExistingPublishersOrderedByName()
+    {
+        // The publisher autocomplete + eager-create commit (TD-15a) work off this
+        // client-side cache: filtered locally for suggestions, and consulted to
+        // tell an existing pick from a genuinely new name.
+        var factory = new TestDbContextFactory();
+        using (var db = factory.CreateDbContext())
+        {
+            db.Publishers.AddRange(
+                new Publisher { Name = "Orbit" },
+                new Publisher { Name = "Corgi" });
+            await db.SaveChangesAsync();
+        }
+
+        var vm = new EditionFormDialogViewModel(factory, _lookup, TestDispatcher.For(factory));
+        await vm.InitializeForAddAsync(1);
+
+        Assert.Equal(["Corgi", "Orbit"], vm.ExistingPublishers.Select(p => p.Name));
+    }
+
+    [Fact]
     public async Task SearchPublishersAsync_MatchesSubstring()
     {
         var factory = new TestDbContextFactory();

--- a/BookTracker.Web/Components/Shared/EditionCopyForm.razor
+++ b/BookTracker.Web/Components/Shared/EditionCopyForm.razor
@@ -127,23 +127,30 @@
     {
         // Fires when the user picks a suggestion or leaves free text in the field
         // (CoerceValue="true"). Store the value, then eagerly find-or-create the
-        // Publisher row (TD-15a) so it exists the moment it's chosen, not at the
-        // Edition save. Idempotent — committing an existing name is a harmless
-        // no-op, a blank name is skipped.
+        // Publisher row (TD-15a) so it exists the moment it's chosen.
+        //
+        // Existing pick (already in the cached list) → no create round-trip; only
+        // a genuinely new name dispatches CreatePublisher. Blank is skipped.
         //
         // Best-effort: a transient DB fault or the accepted check-then-insert
         // race (TD-15) must not abort the field edit — the save's
         // PublisherResolver net (Option B) still guarantees the row, so on
         // failure we log and keep the typed value.
         EditionInput.Publisher = value;
-        if (string.IsNullOrWhiteSpace(value)) return;
+        var trimmed = value?.Trim();
+        if (string.IsNullOrEmpty(trimmed)) return;
+        if (EditionVM.ExistingPublishers.Any(p => p.Name.Equals(trimmed, StringComparison.OrdinalIgnoreCase))) return;
         try
         {
-            await Dispatcher.Send(new CreatePublisher(value));
+            var id = await Dispatcher.Send(new CreatePublisher(trimmed));
+            if (id is int newId)
+            {
+                EditionVM.ExistingPublishers.Add(new EditionFormViewModel.PublisherOption(newId, trimmed));
+            }
         }
         catch (Exception ex)
         {
-            Logger.LogWarning(ex, "Eager publisher create failed for {Name}; the save will create it", value);
+            Logger.LogWarning(ex, "Eager publisher create failed for {Name}; the save will create it", trimmed);
         }
     }
 

--- a/BookTracker.Web/Components/Shared/EditionCopyForm.razor
+++ b/BookTracker.Web/Components/Shared/EditionCopyForm.razor
@@ -1,4 +1,9 @@
+@using BookTracker.Application
+@using BookTracker.Application.Books
+@using Microsoft.Extensions.Logging
 @inject EditionFormViewModel EditionVM
+@inject IDispatcher Dispatcher
+@inject ILogger<EditionCopyForm> Logger
 
 @* Edition + Copy fields for a new book being captured on /books/add.
    Publisher input is an autocomplete over existing Publisher rows
@@ -76,7 +81,8 @@
                    time find-or-create works the same as the previous datalist
                    shape (user can either pick or type-new). *@
                 <MudAutocomplete T="string"
-                                 @bind-Value="EditionInput.Publisher"
+                                 Value="EditionInput.Publisher"
+                                 ValueChanged="OnPublisherCommittedAsync"
                                  SearchFunc="@SearchPublishers"
                                  Label="Publisher"
                                  Placeholder="Penguin Books"
@@ -113,6 +119,32 @@
     protected override async Task OnInitializedAsync()
     {
         await EditionVM.InitializeAsync();
+    }
+
+    // internal (not private) so the bUnit wiring test can invoke it directly —
+    // BookTracker.Web exposes internals to BookTracker.Tests.
+    internal async Task OnPublisherCommittedAsync(string? value)
+    {
+        // Fires when the user picks a suggestion or leaves free text in the field
+        // (CoerceValue="true"). Store the value, then eagerly find-or-create the
+        // Publisher row (TD-15a) so it exists the moment it's chosen, not at the
+        // Edition save. Idempotent — committing an existing name is a harmless
+        // no-op, a blank name is skipped.
+        //
+        // Best-effort: a transient DB fault or the accepted check-then-insert
+        // race (TD-15) must not abort the field edit — the save's
+        // PublisherResolver net (Option B) still guarantees the row, so on
+        // failure we log and keep the typed value.
+        EditionInput.Publisher = value;
+        if (string.IsNullOrWhiteSpace(value)) return;
+        try
+        {
+            await Dispatcher.Send(new CreatePublisher(value));
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Eager publisher create failed for {Name}; the save will create it", value);
+        }
     }
 
     private Task<IEnumerable<string>> SearchPublishers(string? query, CancellationToken ct)

--- a/BookTracker.Web/Components/Shared/EditionCopyForm.razor
+++ b/BookTracker.Web/Components/Shared/EditionCopyForm.razor
@@ -81,8 +81,8 @@
                    time find-or-create works the same as the previous datalist
                    shape (user can either pick or type-new). *@
                 <MudAutocomplete T="string"
-                                 Value="EditionInput.Publisher"
-                                 ValueChanged="OnPublisherCommittedAsync"
+                                 @bind-Value="EditionInput.Publisher"
+                                 OnBlur="OnPublisherBlurAsync"
                                  SearchFunc="@SearchPublishers"
                                  Label="Publisher"
                                  Placeholder="Penguin Books"
@@ -121,22 +121,25 @@
         await EditionVM.InitializeAsync();
     }
 
-    // internal (not private) so the bUnit wiring test can invoke it directly —
+    // Commit gesture = the field losing focus. @bind-Value keeps the value
+    // updated as the user types (no side effect — a pause to think or fix a
+    // typo is NOT a save point); only on blur do we eagerly find-or-create a
+    // genuinely new publisher (TD-15a). Reading the now-settled bound value.
+    private Task OnPublisherBlurAsync() => EagerCreatePublisherIfNewAsync(EditionInput.Publisher);
+
+    // internal (not private) so the bUnit test can invoke it directly —
     // BookTracker.Web exposes internals to BookTracker.Tests.
-    internal async Task OnPublisherCommittedAsync(string? value)
+    internal async Task EagerCreatePublisherIfNewAsync(string? value)
     {
-        // Fires when the user picks a suggestion or leaves free text in the field
-        // (CoerceValue="true"). Store the value, then eagerly find-or-create the
-        // Publisher row (TD-15a) so it exists the moment it's chosen.
-        //
-        // Existing pick (already in the cached list) → no create round-trip; only
-        // a genuinely new name dispatches CreatePublisher. Blank is skipped.
+        // Existing (cached) name → no create round-trip; blank → skip. Only a
+        // genuinely new name dispatches CreatePublisher, and the created row is
+        // appended to the cache so it's known to later commits + shows in
+        // suggestions.
         //
         // Best-effort: a transient DB fault or the accepted check-then-insert
-        // race (TD-15) must not abort the field edit — the save's
+        // race (TD-15) must not surface as an error — the save's
         // PublisherResolver net (Option B) still guarantees the row, so on
-        // failure we log and keep the typed value.
-        EditionInput.Publisher = value;
+        // failure we just log.
         var trimmed = value?.Trim();
         if (string.IsNullOrEmpty(trimmed)) return;
         if (EditionVM.ExistingPublishers.Any(p => p.Name.Equals(trimmed, StringComparison.OrdinalIgnoreCase))) return;

--- a/BookTracker.Web/Components/Shared/EditionFormDialog.razor
+++ b/BookTracker.Web/Components/Shared/EditionFormDialog.razor
@@ -141,27 +141,34 @@
 
     private async Task LookupAsync() => await VM.LookupAsync();
 
-    private async Task OnPublisherCommittedAsync(string? value)
+    internal async Task OnPublisherCommittedAsync(string? value)
     {
         // Fires when the user picks a suggestion or leaves free text in the field
         // (CoerceValue="true"). Store the value, then eagerly find-or-create the
-        // Publisher row (TD-15a) so it exists the moment it's chosen, not at the
-        // Edition save. Idempotent — committing an existing name is a harmless
-        // no-op, a blank name is skipped.
+        // Publisher row (TD-15a) so it exists the moment it's chosen.
+        //
+        // Existing pick (already in the cached list) → no create round-trip; only
+        // a genuinely new name dispatches CreatePublisher. Blank is skipped.
         //
         // Best-effort: a transient DB fault or the accepted check-then-insert
         // race (TD-15) must not abort the field edit — the save's
         // PublisherResolver net (Option B) still guarantees the row, so on
         // failure we log and keep the typed value.
         VM.Publisher = value;
-        if (string.IsNullOrWhiteSpace(value)) return;
+        var trimmed = value?.Trim();
+        if (string.IsNullOrEmpty(trimmed)) return;
+        if (VM.ExistingPublishers.Any(p => p.Name.Equals(trimmed, StringComparison.OrdinalIgnoreCase))) return;
         try
         {
-            await Dispatcher.Send(new CreatePublisher(value));
+            var id = await Dispatcher.Send(new CreatePublisher(trimmed));
+            if (id is int newId)
+            {
+                VM.ExistingPublishers.Add(new EditionFormDialogViewModel.PublisherOption(newId, trimmed));
+            }
         }
         catch (Exception ex)
         {
-            Logger.LogWarning(ex, "Eager publisher create failed for {Name}; the save will create it", value);
+            Logger.LogWarning(ex, "Eager publisher create failed for {Name}; the save will create it", trimmed);
         }
     }
 

--- a/BookTracker.Web/Components/Shared/EditionFormDialog.razor
+++ b/BookTracker.Web/Components/Shared/EditionFormDialog.razor
@@ -65,8 +65,8 @@
                 </MudSelect>
 
                 <MudAutocomplete T="string"
-                                 Value="VM.Publisher"
-                                 ValueChanged="OnPublisherCommittedAsync"
+                                 @bind-Value="VM.Publisher"
+                                 OnBlur="OnPublisherBlurAsync"
                                  SearchFunc="VM.SearchPublishersAsync"
                                  Label="Publisher"
                                  Variant="Variant.Outlined"
@@ -141,20 +141,18 @@
 
     private async Task LookupAsync() => await VM.LookupAsync();
 
-    internal async Task OnPublisherCommittedAsync(string? value)
+    // Commit gesture = the field losing focus. @bind-Value keeps the value
+    // updated as the user types (no side effect — a pause to think or fix a
+    // typo is NOT a save point); only on blur do we eagerly find-or-create a
+    // genuinely new publisher (TD-15a).
+    private Task OnPublisherBlurAsync() => EagerCreatePublisherIfNewAsync(VM.Publisher);
+
+    internal async Task EagerCreatePublisherIfNewAsync(string? value)
     {
-        // Fires when the user picks a suggestion or leaves free text in the field
-        // (CoerceValue="true"). Store the value, then eagerly find-or-create the
-        // Publisher row (TD-15a) so it exists the moment it's chosen.
-        //
-        // Existing pick (already in the cached list) → no create round-trip; only
-        // a genuinely new name dispatches CreatePublisher. Blank is skipped.
-        //
-        // Best-effort: a transient DB fault or the accepted check-then-insert
-        // race (TD-15) must not abort the field edit — the save's
-        // PublisherResolver net (Option B) still guarantees the row, so on
-        // failure we log and keep the typed value.
-        VM.Publisher = value;
+        // Existing (cached) name → no create round-trip; blank → skip. Only a
+        // genuinely new name dispatches CreatePublisher, appended to the cache.
+        // Best-effort — the save's PublisherResolver net (Option B) guarantees
+        // the row, so a fault here just logs.
         var trimmed = value?.Trim();
         if (string.IsNullOrEmpty(trimmed)) return;
         if (VM.ExistingPublishers.Any(p => p.Name.Equals(trimmed, StringComparison.OrdinalIgnoreCase))) return;

--- a/BookTracker.Web/Components/Shared/EditionFormDialog.razor
+++ b/BookTracker.Web/Components/Shared/EditionFormDialog.razor
@@ -2,8 +2,13 @@
    picks between the two flows — Add shows the ISBN-lookup button and a
    first-copy condition field; Edit is field-only. *@
 
+@using BookTracker.Application
+@using BookTracker.Application.Books
+@using Microsoft.Extensions.Logging
 @inject EditionFormDialogViewModel VM
 @inject ISnackbar Snackbar
+@inject IDispatcher Dispatcher
+@inject ILogger<EditionFormDialog> Logger
 
 <MudDialog>
     <DialogContent>
@@ -60,7 +65,8 @@
                 </MudSelect>
 
                 <MudAutocomplete T="string"
-                                 @bind-Value="VM.Publisher"
+                                 Value="VM.Publisher"
+                                 ValueChanged="OnPublisherCommittedAsync"
                                  SearchFunc="VM.SearchPublishersAsync"
                                  Label="Publisher"
                                  Variant="Variant.Outlined"
@@ -134,6 +140,30 @@
     }
 
     private async Task LookupAsync() => await VM.LookupAsync();
+
+    private async Task OnPublisherCommittedAsync(string? value)
+    {
+        // Fires when the user picks a suggestion or leaves free text in the field
+        // (CoerceValue="true"). Store the value, then eagerly find-or-create the
+        // Publisher row (TD-15a) so it exists the moment it's chosen, not at the
+        // Edition save. Idempotent — committing an existing name is a harmless
+        // no-op, a blank name is skipped.
+        //
+        // Best-effort: a transient DB fault or the accepted check-then-insert
+        // race (TD-15) must not abort the field edit — the save's
+        // PublisherResolver net (Option B) still guarantees the row, so on
+        // failure we log and keep the typed value.
+        VM.Publisher = value;
+        if (string.IsNullOrWhiteSpace(value)) return;
+        try
+        {
+            await Dispatcher.Send(new CreatePublisher(value));
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Eager publisher create failed for {Name}; the save will create it", value);
+        }
+    }
 
     private async Task SaveAsync()
     {

--- a/BookTracker.Web/ViewModels/EditionFormDialogViewModel.cs
+++ b/BookTracker.Web/ViewModels/EditionFormDialogViewModel.cs
@@ -40,6 +40,17 @@ public class EditionFormDialogViewModel(
     // Edition needs at least one Copy, so the Add flow captures it here.
     public BookCondition FirstCopyCondition { get; set; } = BookCondition.Good;
 
+    // Publisher lookup cached client-side (loaded once on init). Publishers
+    // are a small lookup table, so the autocomplete filters this in-memory
+    // rather than round-tripping the DB per keystroke. It also lets the
+    // commit handler tell an existing pick (already in this list → no create
+    // call) from a genuinely new name (TD-15a eager create). A newly-created
+    // publisher is appended here so it's known to subsequent commits + shows
+    // in suggestions.
+    public List<PublisherOption> ExistingPublishers { get; private set; } = [];
+
+    public record PublisherOption(int Id, string Name);
+
     public string? LookupMessage { get; private set; }
     public bool LookingUp { get; private set; }
 
@@ -48,6 +59,9 @@ public class EditionFormDialogViewModel(
         IsNew = true;
         BookId = bookId;
         EditionId = null;
+
+        await using var db = await dbFactory.CreateDbContextAsync();
+        ExistingPublishers = await LoadPublishersAsync(db);
     }
 
     public async Task InitializeForEditAsync(int editionId)
@@ -65,27 +79,27 @@ public class EditionFormDialogViewModel(
         Publisher = edition.Publisher?.Name;
         FirstPublishedOrPrintedDate = PartialDateParser.Format(edition.DatePrinted, edition.DatePrintedPrecision);
         CoverUrl = edition.CoverUrl;
+        ExistingPublishers = await LoadPublishersAsync(db);
     }
 
-    public async Task<IEnumerable<string>> SearchPublishersAsync(string query, CancellationToken ct)
-    {
-        // .ToLower() inside the Where keeps behaviour consistent across
-        // providers. SQL Server defaults to case-insensitive collation so
-        // raw Contains would match either way in prod, but the EF InMemory
-        // provider used in tests is case-sensitive — explicit lowering
-        // prevents tests and prod from disagreeing.
-        var q = (query ?? "").Trim().ToLower();
-        await using var db = await dbFactory.CreateDbContextAsync();
-        var matches = db.Publishers.AsQueryable();
-        if (!string.IsNullOrEmpty(q))
-        {
-            matches = matches.Where(p => p.Name.ToLower().Contains(q));
-        }
-        return await matches
+    private static Task<List<PublisherOption>> LoadPublishersAsync(BookTrackerDbContext db) =>
+        db.Publishers
             .OrderBy(p => p.Name)
-            .Select(p => p.Name)
-            .Take(20)
-            .ToListAsync(ct);
+            .Select(p => new PublisherOption(p.Id, p.Name))
+            .ToListAsync();
+
+    public Task<IEnumerable<string>> SearchPublishersAsync(string query, CancellationToken ct)
+    {
+        // Filters the cached ExistingPublishers in-memory (loaded once on
+        // init) rather than hitting the DB per keystroke. Case-insensitive
+        // Contains; the cache is already name-ordered.
+        var q = (query ?? "").Trim();
+        IEnumerable<string> matches = string.IsNullOrEmpty(q)
+            ? ExistingPublishers.Select(p => p.Name)
+            : ExistingPublishers
+                .Where(p => p.Name.Contains(q, StringComparison.OrdinalIgnoreCase))
+                .Select(p => p.Name);
+        return Task.FromResult(matches.Take(20));
     }
 
     public async Task LookupAsync()


### PR DESCRIPTION
- **feat(covers): eager-create Publisher at the picker (TD-15a PR2)**
- **refactor(covers): only eager-create new publishers, not existing picks**
- **fix(covers): eager-create publisher on blur, not per-keystroke**
