### PR TITLE
fix(add): show series picker for collections too

### DIFF
--- a/BookTracker.Tests/ViewModels/BookAddViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/BookAddViewModelTests.cs
@@ -279,6 +279,41 @@ public class BookAddViewModelTests
     }
 
     [Fact]
+    public async Task SaveAsync_Collection_AttachesBookLevelSeries()
+    {
+        // Series membership is a per-Book concept (the book is installment N
+        // of a publication series), so a collection can belong to a series
+        // just like a single-work book. The Add page now renders the series
+        // picker in both modes; this guards that the collection save path
+        // actually persists the chosen series onto the Book.
+        var vm = CreateVm();
+        vm.BookInput.Title = "The Sandman: Season of Mists";
+        vm.EditionInput.Format = BookFormat.TradePaperback;
+        vm.IsCollection = true;
+        vm.SingleAuthor = true;
+        vm.SharedAuthors = new List<string> { "Neil Gaiman" };
+        vm.CollectionWorks =
+        [
+            new() { Title = "Chapter 1" },
+            new() { Title = "Chapter 2" },
+        ];
+        await vm.OnSeriesChosenAsync("The Sandman");
+        vm.AcceptedSeriesOrderLabel = "4";
+
+        var bookId = await vm.SaveAsync(selectedGenreIds: []);
+
+        Assert.NotNull(bookId);
+        await using var db = _factory.CreateDbContext();
+        var saved = await db.Books
+            .Include(b => b.Series)
+            .FirstAsync(b => b.Id == bookId);
+
+        Assert.NotNull(saved.Series);
+        Assert.Equal("The Sandman", saved.Series!.Name);
+        Assert.Equal(4, saved.SeriesOrder);
+    }
+
+    [Fact]
     public async Task SaveAsync_SingleAuthorMode_NoSharedAuthors_Throws()
     {
         // Save in Single-Author mode with no shared authors set should

--- a/BookTracker.Web/Components/Pages/Books/Add.razor
+++ b/BookTracker.Web/Components/Pages/Books/Add.razor
@@ -252,45 +252,6 @@
                     </MudCardContent>
                 </MudCard>
             </MudItem>
-
-            <MudItem xs="12">
-                <MudCard Elevation="0" Outlined="true">
-                    <MudCardHeader>
-                        <CardHeaderContent>
-                            <MudText Typo="Typo.h6">Series / collection</MudText>
-                        </CardHeaderContent>
-                    </MudCardHeader>
-                    <MudCardContent>
-                        @* Optional manual series entry — pick an existing series,
-                           or choose the "Add …" row to create a new one. Creation
-                           is an explicit selection (no commit-on-blur guessing).
-                           The ISBN-lookup suggestion above fills this same field. *@
-                        <MudText Typo="Typo.caption" Color="Color.Secondary" Class="d-block mb-2">Optional — applies to this book. Pick an existing series, or choose the “Add …” row to create a new one.</MudText>
-                        <MudGrid Spacing="3">
-                            <MudItem xs="12" md="8">
-                                <CreatableAutocomplete Value="@VM.AcceptedSeriesName"
-                                                       ValueChanged="VM.OnSeriesChosenAsync"
-                                                       SearchExisting="VM.SearchSeriesAsync"
-                                                       Label="Series"
-                                                       Placeholder="e.g. The Stormlight Archive"
-                                                       HelperText="Pick an existing series, or choose the “Add …” row to create a new one." />
-                            </MudItem>
-                            @if (!string.IsNullOrWhiteSpace(VM.AcceptedSeriesName))
-                            {
-                                <MudItem xs="12" md="4">
-                                    <MudTextField T="string"
-                                                  @bind-Value="VM.AcceptedSeriesOrderLabel"
-                                                  Label="Order / position"
-                                                  Placeholder="3"
-                                                  HelperText="Whole number, or '4.5' for an interquel."
-                                                  Variant="Variant.Outlined"
-                                                  Margin="Margin.Dense" />
-                                </MudItem>
-                            }
-                        </MudGrid>
-                    </MudCardContent>
-                </MudCard>
-            </MudItem>
         }
         else
         {
@@ -364,6 +325,48 @@
                 </MudCard>
             </MudItem>
         }
+
+        @* Series membership is a per-Book concept (the book is installment N),
+           so the picker renders for single-work books and collections alike —
+           the VM attaches it to the Book at save regardless of work count. *@
+        <MudItem xs="12">
+            <MudCard Elevation="0" Outlined="true">
+                <MudCardHeader>
+                    <CardHeaderContent>
+                        <MudText Typo="Typo.h6">Series / collection</MudText>
+                    </CardHeaderContent>
+                </MudCardHeader>
+                <MudCardContent>
+                    @* Optional manual series entry — pick an existing series,
+                       or choose the "Add …" row to create a new one. Creation
+                       is an explicit selection (no commit-on-blur guessing).
+                       The ISBN-lookup suggestion above fills this same field. *@
+                    <MudText Typo="Typo.caption" Color="Color.Secondary" Class="d-block mb-2">Optional — applies to this book. Pick an existing series, or choose the “Add …” row to create a new one.</MudText>
+                    <MudGrid Spacing="3">
+                        <MudItem xs="12" md="8">
+                            <CreatableAutocomplete Value="@VM.AcceptedSeriesName"
+                                                   ValueChanged="VM.OnSeriesChosenAsync"
+                                                   SearchExisting="VM.SearchSeriesAsync"
+                                                   Label="Series"
+                                                   Placeholder="e.g. The Stormlight Archive"
+                                                   HelperText="Pick an existing series, or choose the “Add …” row to create a new one." />
+                        </MudItem>
+                        @if (!string.IsNullOrWhiteSpace(VM.AcceptedSeriesName))
+                        {
+                            <MudItem xs="12" md="4">
+                                <MudTextField T="string"
+                                              @bind-Value="VM.AcceptedSeriesOrderLabel"
+                                              Label="Order / position"
+                                              Placeholder="3"
+                                              HelperText="Whole number, or '4.5' for an interquel."
+                                              Variant="Variant.Outlined"
+                                              Margin="Margin.Dense" />
+                            </MudItem>
+                        }
+                    </MudGrid>
+                </MudCardContent>
+            </MudCard>
+        </MudItem>
 
         <MudItem xs="12">
             <EditionCopyForm EditionInput="VM.EditionInput" CopyInput="VM.CopyInput" Title="First edition & copy" />

--- a/BookTracker.Web/ViewModels/BookAddViewModel.cs
+++ b/BookTracker.Web/ViewModels/BookAddViewModel.cs
@@ -567,12 +567,14 @@ public class BookAddViewModel(
                 //     from the row fields (title, authors, subtitle,
                 //     first-published, per-row or shared genres).
                 //
-                // Series suggestions stay deferred to per-work editing on
-                // /books/{id} (the lookup flow can't pick per-work, and
-                // applying to all would be wrong). Author source depends on
-                // SingleAuthor mode; genre source on SingleGenre — both
-                // apply only to new-work rows (existing Works bring their
-                // own).
+                // Book-level series (AcceptedSeries*) is attached below via
+                // AttachToBookAsync just as in single-work mode — a collection
+                // is still installment N of a publication series. What stays
+                // deferred to per-work editing on /books/{id} is any *per-Work*
+                // series notion (the lookup flow can't pick per-work, and
+                // applying one to all would be wrong). Author source depends on
+                // SingleAuthor mode; genre source on SingleGenre — both apply
+                // only to new-work rows (existing Works bring their own).
                 List<string> AuthorsFor(WorkFormViewModel.WorkFormInput row) =>
                     SingleAuthor ? SharedAuthors : row.Authors;
                 List<int> GenresFor(WorkFormViewModel.WorkFormInput row) =>


### PR DESCRIPTION
The "Series / collection" card was nested inside the `!VM.IsCollection`
branch on the Add page, so a book capturing multiple works (a collection)
had nowhere to set its series. Series membership is a per-Book concept (the
book is installment N of a publication series), and the VM already attaches
it to the Book at save regardless of work count — only the UI gated it.

Move the series card below the single-work/collection branches so it renders
in both modes. Correct the now-stale save-path comment and add a regression
test asserting a collection persists its book-level series + order.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
