### PR TITLE
chore(deps): batch dependency update (safe, no code changes)

### DIFF
--- a/BookTracker.Application/BookTracker.Application.csproj
+++ b/BookTracker.Application/BookTracker.Application.csproj
@@ -28,7 +28,7 @@
   <ItemGroup>
     <!-- DI extension surface so the host calls one AddApplicationLayer()
          and every handler self-registers from inside this project. -->
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/BookTracker.Data/BookTracker.Data.csproj
+++ b/BookTracker.Data/BookTracker.Data.csproj
@@ -7,16 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.10">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.9">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.10">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
   </ItemGroup>
 
 </Project>

--- a/BookTracker.Mobile.Cache.Tests/BookTracker.Mobile.Cache.Tests.csproj
+++ b/BookTracker.Mobile.Cache.Tests/BookTracker.Mobile.Cache.Tests.csproj
@@ -16,14 +16,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     <!-- Same NU1903 native-SQLite override as the Cache project, pinned
          directly here because the Cache project's copy is PrivateAssets="all"
          and so doesn't flow across the ProjectReference (sqlite-net-pcl's
          transitive 2.1.2 still would). See BookTracker.Mobile.Cache.csproj. -->
-    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.50.3" />
+    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.53.3" />
   </ItemGroup>
 
   <ItemGroup>
@@ -34,9 +34,9 @@
          explicitly — Linux for CI ubuntu runners, Win32 for local
          Windows dev, macOS for completeness. The runtime picks the
          one matching its RID and ignores the others. -->
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="4.148.0" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Win32" Version="4.148.0" />
-    <PackageReference Include="SkiaSharp.NativeAssets.macOS" Version="4.148.0" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="4.150.1" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Win32" Version="4.150.1" />
+    <PackageReference Include="SkiaSharp.NativeAssets.macOS" Version="4.150.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/BookTracker.Mobile.Cache/BookTracker.Mobile.Cache.csproj
+++ b/BookTracker.Mobile.Cache/BookTracker.Mobile.Cache.csproj
@@ -28,11 +28,11 @@
          diagnostics). Abstractions-only — concrete provider is wired
          up on the Bookshelf side (MauiProgram.AddDebug + platform
          logcat sink); tests use NullLogger. -->
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
     <!-- sqlite-net-pcl: ORM-lite over SQLite. Bundles a managed +
          native SQLite via SQLitePCLRaw; works on Android, iOS, and
          desktop with no manual native-library hookup. -->
-    <PackageReference Include="sqlite-net-pcl" Version="1.9.172" />
+    <PackageReference Include="sqlite-net-pcl" Version="1.11.285" />
     <!-- Pin the native SQLite binary ahead of what sqlite-net-pcl drags in
          transitively (SQLitePCLRaw.lib.e_sqlite3 2.1.2). 2.1.2 is flagged by
          NU1903 / CVE-2025-6965 (SQLite < 3.50.2 aggregate-terms memory
@@ -45,7 +45,7 @@
          an Android .so, which would collide with the .android AAR (XA4301 dup).
          Android keeps its own native (.android 2.1.2) until upstream ships a
          3.50.x .android — see BookTracker.Mobile's targeted NoWarn. -->
-    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.50.3" PrivateAssets="all" />
+    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.53.3" PrivateAssets="all" />
     <!-- SkiaSharp: cross-platform image decode + resize. Pulls native
          assets for Android (via transitive SkiaSharp.NativeAssets.*)
          and for the test runner OS automatically. Used by
@@ -57,7 +57,7 @@
          with 16KB pages enabled (the XA0141 build warning). 4.x keeps
          the SKSamplingOptions Resize API (replacing 2.x's SKFilterQuality)
          and stays 16KB-aligned; verify on-device after this bump (TD-10). -->
-    <PackageReference Include="SkiaSharp" Version="4.148.0" />
+    <PackageReference Include="SkiaSharp" Version="4.150.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/BookTracker.Mobile/BookTracker.Mobile.csproj
+++ b/BookTracker.Mobile/BookTracker.Mobile.csproj
@@ -53,8 +53,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
-		<PackageReference Include="Microsoft.Extensions.Http" Version="10.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Http" Version="10.0.10" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.10" />
 		<!-- MSAL.NET — AAD interactive sign-in via Chrome Custom Tabs, token
 		     cached in SecureStorage (Keystore-backed). -->
 		<PackageReference Include="Microsoft.Identity.Client" Version="4.66.2" />

--- a/BookTracker.Tests/BookTracker.Tests.csproj
+++ b/BookTracker.Tests/BookTracker.Tests.csproj
@@ -9,22 +9,30 @@
 
   <ItemGroup>
     <PackageReference Include="bunit" Version="2.7.2" />
+    <!-- Security pin: bUnit 2.7.2 pulls AngleSharp 1.4.0 transitively, which has
+         a moderate mXSS sanitizer-bypass advisory (GHSA-pgww-w46g-26qg,
+         CVE-2026-54570, patched in 1.5.0). We only use AngleSharp via bUnit to
+         parse rendered component markup in tests — never as a production
+         sanitizer — but TWAE promotes the NU1902 audit warning to an error.
+         Pin the patched version directly; PrivateAssets so it stays test-local.
+         Remove once bUnit's own AngleSharp floor reaches >= 1.5.0. -->
+    <PackageReference Include="AngleSharp" Version="1.5.2" PrivateAssets="all" />
     <!-- SkiaSharp for the CoverImageProcessor tests (make/decode sample images).
          Native assets explicit so the test host decodes on Windows (local) +
          Linux (CI). Linux.NoDependencies (not the full .Linux) because these
          tests only decode/resize/encode — no text rendering, so fontconfig
          isn't needed; mirrors the headless asset choice in BookTracker.Web.
          (BookTracker.Mobile.Cache.Tests uses the full .Linux + macOS set.) -->
-    <PackageReference Include="SkiaSharp" Version="4.148.0" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Win32" Version="4.148.0" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="4.148.0" />
+    <PackageReference Include="SkiaSharp" Version="4.150.1" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Win32" Version="4.150.1" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="4.150.1" />
     <PackageReference Include="coverlet.collector" Version="10.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />
     <PackageReference Include="Microsoft.Playwright" Version="1.61.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="Respawn" Version="7.0.0" />
-    <PackageReference Include="Testcontainers.MsSql" Version="4.12.0" />
+    <PackageReference Include="Testcontainers.MsSql" Version="4.13.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>

--- a/BookTracker.Web/BookTracker.Web.csproj
+++ b/BookTracker.Web/BookTracker.Web.csproj
@@ -19,16 +19,16 @@
          which moved to a build-time licence key in v4). NoDependencies on Linux
          because the cover pipeline is headless decode/resize/encode — no fonts, so
          we don't need fontconfig in the App Service container. Win32 asset covers
-         local Windows dev + the BookTracker.Tests run. Same 4.148.0 as Mobile. -->
-    <PackageReference Include="SkiaSharp" Version="4.148.0" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="4.148.0" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Win32" Version="4.148.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9">
+         local Windows dev + the BookTracker.Tests run. Same 4.150.1 as Mobile. -->
+    <PackageReference Include="SkiaSharp" Version="4.150.1" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="4.150.1" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Win32" Version="4.150.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.10">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.9" />
-    <PackageReference Include="MudBlazor" Version="9.6.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.10" />
+    <PackageReference Include="MudBlazor" Version="9.7.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Security fix + routine batch bump on the weekly dependabot branch.

AngleSharp reached us transitively via bUnit at 1.4.0, which carries a
moderate mXSS advisory (GHSA-pgww-w46g-26qg / CVE-2026-54570, patched in
1.5.0). Pin AngleSharp 1.5.2 directly in the test project (PrivateAssets)
so TWAE stops failing the NU1902 audit. We never use AngleSharp as a
production sanitizer -- only bUnit markup parsing in tests.

Batch-bump everything else that updates with no code changes:
- EF Core + Microsoft.Extensions.* 10.0.9 -> 10.0.10
- SkiaSharp family 4.148.0 -> 4.150.1 (lockstep across Web/Tests/Cache)
- sqlite-net-pcl 1.9.172 -> 1.11.285, SQLitePCLRaw 3.50.3 -> 3.53.3
- MudBlazor 9.6.0 -> 9.7.0
- Testcontainers.MsSql 4.12.0 -> 4.13.0, Test.Sdk -> 18.8.1, Mvc.Testing 10.0.10
- Mobile BCL patches: Extensions.Http + Logging.Debug 10.0.0 -> 10.0.10

Held (would require code changes / review -- not this branch):
- Microsoft.ApplicationInsights.AspNetCore stays 2.23.0: 3.x is the
  OpenTelemetry rewrite that removes ITelemetryInitializer (dependabot
  ignore rule; TODO #42). Reverted an accidental 3.1.2 bump in the tree.
- NSubstitute stays 5.3.0: 6.0 annotates Arg.Is<T> matcher lambdas as
  nullable, tripping CS8602 across ~17 test sites under TWAE.
- Mobile MSAL 4.66->4.86, ZXing.Net.MAUI 0.4->0.10 (big 0.x jump), and
  workload-driven Maui.Controls left alone.

Verified: restore clean, 0 vulnerable packages; every project builds clean
under TWAE; 756 main tests + 93 cache tests green; MAUI Android builds.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
