### PR TITLE
chore(config): commit .claude/settings.json denying push + PR operations

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "deny": [
+      "Bash(git push:*)",
+      "Bash(gh pr create:*)",
+      "Bash(gh pr merge:*)"
+    ]
+  }
+}


### PR DESCRIPTION
The "never push, never open PRs" rule lived only as prose in memory, so it
depended on Claude choosing to honour it each session. Commit a shared
.claude/settings.json that denies the operations at the permission layer:

  Bash(git push:*)      -- blocks push (incl. --force and any args)
  Bash(gh pr create:*)  -- blocks opening PRs
  Bash(gh pr merge:*)   -- blocks merging PRs

deny always wins over allow, so this composes with the local allow-list in
.claude/settings.local.json (which stays gitignored). .gitignore already
scoped the ignore to settings.local.json only, anticipating this tracked file.

No .claude/commands or agents exist locally, so none were considered for
sharing.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
