### PR TITLE
chore(ci): fast-path doc/config-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,46 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      # `build` is a REQUIRED status check on main, so this job must run and
+      # report on every PR — a skipped required check blocks the merge. But a
+      # doc/config-only PR (markdown, docs/, blog/, .claude-memory/, .claude/)
+      # doesn't need a build or test. paths-filter sets `code`; the dotnet
+      # steps below are gated on it, so a doc-only PR reports green in seconds
+      # without building. Anything that isn't clearly a doc — any .cs / .csproj
+      # / .razor / .json, workflow or infra files — leaves code=true and the
+      # full build runs. Fail-safe: the steps run unless code is *explicitly*
+      # 'false', so a paths-filter hiccup errs toward building, not skipping.
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - '**'
+              - '!**/*.md'
+              - '!docs/**'
+              - '!blog/**'
+              - '!.claude-memory/**'
+              - '!.claude/**'
+              - '!LICENSE'
+
+      - name: Doc-only change — skip build + test
+        if: steps.filter.outputs.code == 'false'
+        run: echo "Docs/config-only change — no build or test needed; reporting green for the required check."
+
       - uses: actions/setup-dotnet@v4
+        if: steps.filter.outputs.code != 'false'
         with:
           dotnet-version: '10.0.x'
       - run: dotnet restore BookTracker.slnx
+        if: steps.filter.outputs.code != 'false'
       - run: dotnet build BookTracker.slnx --configuration Release --no-restore
+        if: steps.filter.outputs.code != 'false'
       # Whitelist of test categories the PR job runs. E2E (Playwright) is
       # deliberately excluded — it'll get its own job once the Playwright
       # POC lands. Adding a new category is opt-in: append it here when
       # CI should run it. See BookTracker.Tests/README.md for the
       # category contract.
-      - run: dotnet test BookTracker.slnx --configuration Release --no-build --verbosity normal --filter "Category=Unit|Category=Component|Category=Integration"
+      - name: Test (Unit | Component | Integration)
+        if: steps.filter.outputs.code != 'false'
+        run: dotnet test BookTracker.slnx --configuration Release --no-build --verbosity normal --filter "Category=Unit|Category=Component|Category=Integration"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,18 @@ name: Deploy to staging slot
 on:
   push:
     branches: [main]
+    # Doc/config-only merges don't change the deployed bits, so skip the
+    # staging push. GitHub skips the run only when EVERY changed path matches,
+    # so a mixed doc+code merge still deploys. Keep this list in sync with the
+    # paths-filter in ci.yml. (Deploy isn't a required status check, so a
+    # skipped run can't block anything.)
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'blog/**'
+      - '.claude-memory/**'
+      - '.claude/**'
+      - 'LICENSE'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Doc-only changes (markdown, docs/, blog/, .claude-memory/, .claude/) don't
need a build, test, or staging deploy — but the tidy-up/docs PRs still ran the
full CI. Skip the expensive work while keeping the required checks honest.

- ci.yml: the `build` job (a REQUIRED status check on main) still runs on every
  PR so it always reports — a skipped required check would block the merge.
  A dorny/paths-filter step sets `code`; the dotnet restore/build/test steps are
  gated on it, so a doc-only PR reports green in seconds without building.
  Fail-safe: steps run unless the change is *explicitly* doc-only, so a filter
  hiccup errs toward building.
- deploy.yml: added paths-ignore (same globs) to the push:[main] trigger, so a
  doc-only merge skips the staging push. Deploy isn't a required check, so a
  skipped run can't block anything; a mixed doc+code merge still deploys
  (GitHub skips only when every changed path matches).

Left as-is on purpose: gitleaks (the other required check) still runs on every
PR incl. doc-only, per intent; CodeQL stays on GitHub default-setup (not
path-filterable without converting to advanced setup — Drew's call to leave it).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
