### PR TITLE
chore(deps): update deferred dependency pins

### DIFF
--- a/BookTracker.Mobile/BookTracker.Mobile.csproj
+++ b/BookTracker.Mobile/BookTracker.Mobile.csproj
@@ -57,23 +57,12 @@
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.10" />
 		<!-- MSAL.NET — AAD interactive sign-in via Chrome Custom Tabs, token
 		     cached in SecureStorage (Keystore-backed). -->
-		<PackageReference Include="Microsoft.Identity.Client" Version="4.66.2" />
+		<PackageReference Include="Microsoft.Identity.Client" Version="4.86.1" />
 		<!-- Barcode scanner control + camera plumbing. ZXing.Net.MAUI
 		     wraps the platform camera APIs and exposes a
 		     CameraBarcodeReaderView control with a BarcodesDetected
 		     event. Configured for EAN-13/EAN-8 only (book barcodes). -->
-		<PackageReference Include="ZXing.Net.MAUI.Controls" Version="0.4.0" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<!-- CVE-2025-6965 / NU1903 in SQLitePCLRaw.lib.e_sqlite3.android 2.1.2 (the
-		     Android SQLite native). No patched .android (3.50.x) has shipped yet;
-		     the desktop/CI build is already on the fixed 3.50.3. Suppress THIS
-		     advisory specifically (by URL) rather than exempting the whole NU1903
-		     High-severity class — a future High advisory on any other package still
-		     fails the build under TreatWarningsAsErrors. Remove when a 3.50.x
-		     .android native ships (TD-10/TD-11). -->
-		<NuGetAuditSuppress Include="https://github.com/advisories/GHSA-2m69-gcr7-jv3q" />
+		<PackageReference Include="ZXing.Net.MAUI.Controls" Version="0.10.3" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/BookTracker.Tests/BookTracker.Tests.csproj
+++ b/BookTracker.Tests/BookTracker.Tests.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />
     <PackageReference Include="Microsoft.Playwright" Version="1.61.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
-    <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="NSubstitute" Version="6.0.0" />
     <PackageReference Include="Respawn" Version="7.0.0" />
     <PackageReference Include="Testcontainers.MsSql" Version="4.13.0" />
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/BookTracker.Tests/Components/EditionCopyFormTests.cs
+++ b/BookTracker.Tests/Components/EditionCopyFormTests.cs
@@ -59,7 +59,7 @@ public class EditionCopyFormTests : ComponentTestBase
 
         Assert.Equal("Gollancz", edition.Publisher); // stored for the save
         await _dispatcher.Received(1).Send(
-            Arg.Is<CreatePublisher>(c => c.Name == "Gollancz"), Arg.Any<CancellationToken>());
+            Arg.Is<CreatePublisher>(c => c!.Name == "Gollancz"), Arg.Any<CancellationToken>());
         // Appended to the cache so a re-pick is a no-op and it shows in search.
         var vm = Services.GetRequiredService<EditionFormViewModel>();
         Assert.Contains(vm.ExistingPublishers, p => p.Name == "Gollancz");

--- a/BookTracker.Tests/Components/MudAuthorPickerTests.cs
+++ b/BookTracker.Tests/Components/MudAuthorPickerTests.cs
@@ -96,7 +96,7 @@ public class MudAuthorPickerTests : ComponentTestBase
         await cut.InvokeAsync(() => cut.Instance.OnCommitKey("Preston"));
 
         await _dispatcher.Received(1).Send(
-            Arg.Is<CreateAuthor>(c => c.Name == "Preston"), Arg.Any<CancellationToken>());
+            Arg.Is<CreateAuthor>(c => c!.Name == "Preston"), Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/BookTracker.Tests/Components/PublisherEagerCreateTests.cs
+++ b/BookTracker.Tests/Components/PublisherEagerCreateTests.cs
@@ -32,7 +32,7 @@ public class PublisherEagerCreateTests
         Assert.Equal(42, result.Value.Id);
         Assert.Equal("Gollancz", result.Value.Name);
         await _dispatcher.Received(1).Send(
-            Arg.Is<CreatePublisher>(c => c.Name == "Gollancz"), Arg.Any<CancellationToken>());
+            Arg.Is<CreatePublisher>(c => c!.Name == "Gollancz"), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -45,7 +45,7 @@ public class PublisherEagerCreateTests
         Assert.NotNull(result);
         Assert.Equal("Gollancz", result.Value.Name);
         await _dispatcher.Received(1).Send(
-            Arg.Is<CreatePublisher>(c => c.Name == "Gollancz"), Arg.Any<CancellationToken>());
+            Arg.Is<CreatePublisher>(c => c!.Name == "Gollancz"), Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/BookTracker.Tests/Components/SeriesEagerCreateTests.cs
+++ b/BookTracker.Tests/Components/SeriesEagerCreateTests.cs
@@ -25,7 +25,7 @@ public class SeriesEagerCreateTests
 
         Assert.Equal(42, id);
         await _dispatcher.Received(1).Send(
-            Arg.Is<EnsureSeries>(c => c.Name == "Mistborn"), Arg.Any<CancellationToken>());
+            Arg.Is<EnsureSeries>(c => c!.Name == "Mistborn"), Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/BookTracker.Tests/ViewModels/AuthorDetailViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/AuthorDetailViewModelTests.cs
@@ -18,7 +18,7 @@ public class AuthorDetailViewModelTests
         new(new AuthorHeader(id, name, canonicalId, canonicalName), AuthorDetail.Empty, []);
 
     private void StubDetail(int id, AuthorDetailResult? result) =>
-        _dispatcher.Query(Arg.Is<GetAuthorDetail>(q => q.AuthorId == id), Arg.Any<CancellationToken>())
+        _dispatcher.Query(Arg.Is<GetAuthorDetail>(q => q!.AuthorId == id), Arg.Any<CancellationToken>())
             .Returns(result);
 
     [Fact]
@@ -58,7 +58,7 @@ public class AuthorDetailViewModelTests
 
         Assert.Equal("Renamed to \"New\".", vm.SuccessMessage);
         // Reload = a second GetAuthorDetail dispatch for the same id.
-        await _dispatcher.Received(2).Query(Arg.Is<GetAuthorDetail>(q => q.AuthorId == 1), Arg.Any<CancellationToken>());
+        await _dispatcher.Received(2).Query(Arg.Is<GetAuthorDetail>(q => q!.AuthorId == 1), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -74,7 +74,7 @@ public class AuthorDetailViewModelTests
 
         Assert.NotNull(vm.ErrorMessage);
         // No reload — still only the initial load dispatch.
-        await _dispatcher.Received(1).Query(Arg.Is<GetAuthorDetail>(q => q.AuthorId == 1), Arg.Any<CancellationToken>());
+        await _dispatcher.Received(1).Query(Arg.Is<GetAuthorDetail>(q => q!.AuthorId == 1), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -134,7 +134,7 @@ public class AuthorDetailViewModelTests
         await vm.MarkAsAliasOfAsync(1);
 
         await _dispatcher.Received(1).Send(
-            Arg.Is<MarkAuthorAsAliasOf>(c => c.AliasId == 2 && c.CanonicalId == 1),
+            Arg.Is<MarkAuthorAsAliasOf>(c => c!.AliasId == 2 && c.CanonicalId == 1),
             Arg.Any<CancellationToken>());
     }
 
@@ -162,7 +162,7 @@ public class AuthorDetailViewModelTests
         await vm.PromoteToCanonicalAsync();
 
         await _dispatcher.Received(1).Send(
-            Arg.Is<PromoteAuthorToCanonical>(c => c.AuthorId == 2),
+            Arg.Is<PromoteAuthorToCanonical>(c => c!.AuthorId == 2),
             Arg.Any<CancellationToken>());
     }
 }

--- a/BookTracker.Tests/ViewModels/AuthorMergeViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/AuthorMergeViewModelTests.cs
@@ -102,7 +102,7 @@ public class AuthorMergeViewModelTests
         Assert.NotNull(result);
         Assert.True(result!.Success);
         await _dispatcher.Received(1).Send(
-            Arg.Is<MergeAuthors>(c => c.WinnerId == 1 && c.LoserId == 2),
+            Arg.Is<MergeAuthors>(c => c!.WinnerId == 1 && c.LoserId == 2),
             Arg.Any<CancellationToken>());
     }
 

--- a/BookTracker.Tests/ViewModels/BookMergeViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/BookMergeViewModelTests.cs
@@ -98,7 +98,7 @@ public class BookMergeViewModelTests
         Assert.NotNull(result);
         Assert.True(result!.Success);
         await _dispatcher.Received(1).Send(
-            Arg.Is<MergeBooks>(c => c.WinnerId == 1 && c.LoserId == 2),
+            Arg.Is<MergeBooks>(c => c!.WinnerId == 1 && c.LoserId == 2),
             Arg.Any<CancellationToken>());
     }
 }

--- a/BookTracker.Tests/ViewModels/EditionMergeViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/EditionMergeViewModelTests.cs
@@ -93,7 +93,7 @@ public class EditionMergeViewModelTests
         Assert.NotNull(result);
         Assert.True(result!.Success);
         await _dispatcher.Received(1).Send(
-            Arg.Is<MergeEditions>(c => c.WinnerId == 1 && c.LoserId == 2),
+            Arg.Is<MergeEditions>(c => c!.WinnerId == 1 && c.LoserId == 2),
             Arg.Any<CancellationToken>());
     }
 }

--- a/BookTracker.Tests/ViewModels/PublisherListViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/PublisherListViewModelTests.cs
@@ -103,7 +103,7 @@ public class PublisherListViewModelTests
         Assert.False(vm.DetailByPublisherId.ContainsKey(1));
         Assert.False(vm.DetailByPublisherId.ContainsKey(2));
         await _dispatcher.Received(1).Send(
-            Arg.Is<MergePublishers>(c => c.SourceId == 1 && c.TargetId == 2),
+            Arg.Is<MergePublishers>(c => c!.SourceId == 1 && c.TargetId == 2),
             Arg.Any<CancellationToken>());
     }
 }

--- a/BookTracker.Tests/ViewModels/SeriesListViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/SeriesListViewModelTests.cs
@@ -51,7 +51,7 @@ public class SeriesListViewModelTests
         Assert.False(vm.Loading);
         Assert.Single(vm.AllSeries);
         await _dispatcher.Received().Query(
-            Arg.Is<GetSeriesList>(q => q.Search == "foo" && q.Type == SeriesType.Collection),
+            Arg.Is<GetSeriesList>(q => q!.Search == "foo" && q.Type == SeriesType.Collection),
             Arg.Any<CancellationToken>());
     }
 
@@ -65,7 +65,7 @@ public class SeriesListViewModelTests
         await vm.InitializeAsync();
 
         await _dispatcher.Received().Query(
-            Arg.Is<GetSeriesList>(q => q.Type == null),
+            Arg.Is<GetSeriesList>(q => q!.Type == null),
             Arg.Any<CancellationToken>());
     }
 }

--- a/BookTracker.Tests/ViewModels/WorkMergeViewModelTests.cs
+++ b/BookTracker.Tests/ViewModels/WorkMergeViewModelTests.cs
@@ -59,7 +59,7 @@ public class WorkMergeViewModelTests
         Assert.NotNull(result);
         Assert.True(result!.Success);
         await _dispatcher.Received(1).Send(
-            Arg.Is<MergeWorks>(c => c.WinnerId == 1 && c.LoserId == 2),
+            Arg.Is<MergeWorks>(c => c!.WinnerId == 1 && c.LoserId == 2),
             Arg.Any<CancellationToken>());
     }
 


### PR DESCRIPTION
Clears the deps held back in the 2026-07-24 batch, now verified:

- NSubstitute 5.3.0 -> 6.0.0: 6.0 annotates Arg.Is<T> matcher lambdas as
  nullable, so 17 `Arg.Is<T>(x => x.Prop)` sites tripped CS8602 under TWAE.
  Fixed each with a null-forgiving `!` on the lambda param's first deref
  (flow analysis covers the rest of each lambda). 756 tests pass.
- Microsoft.Identity.Client (MSAL) 4.66.2 -> 4.86.1 (Mobile) — builds clean.
- ZXing.Net.MAUI.Controls 0.4.0 -> 0.10.3 (Mobile) — builds clean, and cleared
  2 obsolete-API warnings the old version emitted. NEEDS AN ON-DEVICE SCANNER
  TEST before merge — camera behaviour can't be verified in CI.
- Removed the GHSA-2m69-gcr7-jv3q NuGetAuditSuppress + its comment: a patched
  .android SQLite native has since shipped (the condition its own comment set
  for removal). Verified the Mobile build stays green under
  TreatWarningsAsErrors with the suppression gone.

Held deliberately: Microsoft.ApplicationInsights.AspNetCore stays 2.23.0 — 3.x
is the OpenTelemetry migration (TODO #42), not a version bump.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
