### PR TITLE
fix(security): add Permissions-Policy header (SEC-004) + refresh audit doc

### DIFF
--- a/BookTracker.Web/ProgramSetup.cs
+++ b/BookTracker.Web/ProgramSetup.cs
@@ -210,13 +210,16 @@ public static class ProgramSetup
         app.UseHttpsRedirection();
 
         // Baseline security response headers. CSP lives in App.razor as a <meta>
-        // tag; the three below need to be HTTP-header-only (meta-tag equivalents
+        // tag; the four below need to be HTTP-header-only (meta-tag equivalents
         // are either deprecated or ignored by modern browsers).
         app.Use(async (context, next) =>
         {
             context.Response.Headers["X-Frame-Options"] = "DENY";                     // clickjacking
             context.Response.Headers["X-Content-Type-Options"] = "nosniff";           // MIME sniffing
             context.Response.Headers["Referrer-Policy"] = "strict-origin-when-cross-origin";
+            // Deny powerful browser features by default; allow the camera to the
+            // same origin only — the /bookshop barcode scanner uses getUserMedia.
+            context.Response.Headers["Permissions-Policy"] = "camera=(self), microphone=(), geolocation=(), payment=()";
             await next();
         });
 

--- a/SECURITY-AUDIT.md
+++ b/SECURITY-AUDIT.md
@@ -2,7 +2,7 @@
 
 Living security posture review. Per-area verdicts: **Pass** / **Concern** / **Action required**. Fixes applied in the same PR are listed at the bottom; deferred items link to `TODO.md`. Monthly scan + review is automated via `.github/workflows/security-scan.yml`.
 
-**Last reviewed:** 2026-05-05 (monthly cycle; per-run report in `audits/security-2026-05-05.md`).
+**Last reviewed:** 2026-07-24 via the `security-audit` skill (per-run report in `audits/security-2026-07-24.md`) — 0 critical / 0 high / 0 medium; 1 low (SEC-004 `Permissions-Policy` absent, **fixed this cycle**), rest info/clean, no drift from this doc. Prior review: 2026-05-05.
 
 ---
 
@@ -68,6 +68,7 @@ Living security posture review. Per-area verdicts: **Pass** / **Concern** / **Ac
   - `X-Frame-Options: DENY` (middleware in `Program.cs`) — clickjacking protection.
   - `X-Content-Type-Options: nosniff` — MIME sniffing protection.
   - `Referrer-Policy: strict-origin-when-cross-origin` — limit referrer leakage.
+  - `Permissions-Policy: camera=(self), microphone=(), geolocation=(), payment=()` (middleware in `ProgramSetup.cs`, added 2026-07-24) — deny powerful browser features by default; camera allowed same-origin only for the `/bookshop` barcode scanner (`getUserMedia`). Closes **SEC-004** from the 2026-07-24 audit run.
 - **Follow-up:** the `unsafe-inline` + `unsafe-eval` directives leave a real XSS surface. Moving to a nonce-based CSP with a script-nonce middleware is tracked as a new TODO row.
 
 ---


### PR DESCRIPTION
The 2026-07-24 security-audit skill run flagged SEC-004 (Low): the
Permissions-Policy response header was absent (the other four security headers
present and correct). Add it in the existing security-headers middleware —
deny powerful browser features by default, allow camera to the same origin
only (the /bookshop barcode scanner uses getUserMedia).

Also refresh SECURITY-AUDIT.md: bump "Last reviewed" to 2026-07-24 with the
run's result (0 critical/high/medium; SEC-004 fixed this cycle; rest info/clean,
no drift from the doc) and record the new header in section 4.

Per-run audit report lives (gitignored) at audits/security-2026-07-24.md.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
